### PR TITLE
Drop qgis2compat dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ install:
 - sudo apt-get update
 - sudo apt-get install -y python-qgis python-nose pyqt4-dev-tools qgis
 - pip install -r requirements.txt
-- "./scripts/ci/install_qgis2compat.sh"
 before_script:
 - export QGIS_PREFIX_PATH=/usr
 - export PYTHONPATH=${QGIS_PREFIX_PATH}/share/qgis/python/:${QGIS_PREFIX_PATH}/share/qgis/python/plugins:`pwd`/qfieldsync:${PYTHONPATH}

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
 install:
 - printf "deb http://qgis.org/debian trusty main\ndeb-src http://qgis.org/debian trusty
   main" | sudo tee /etc/apt/sources.list.d/qgis.list
-- sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-key 073D307A618E5811
+- sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-key CAEB3DC3BDF7FB45
 - sudo apt-get update
 - sudo apt-get install -y python-qgis python-nose pyqt4-dev-tools qgis
 - pip install -r requirements.txt

--- a/qfieldsync/__init__.py
+++ b/qfieldsync/__init__.py
@@ -27,9 +27,6 @@ from __future__ import absolute_import
 import os
 import qgis.utils
 
-qgis2compat_min_version = '0.4.3'
-
-
 # noinspection PyPep8Naming
 def classFactory(iface):  # pylint: disable=invalid-name
     """Load QFieldSync class from file QFieldSync.
@@ -37,35 +34,6 @@ def classFactory(iface):  # pylint: disable=invalid-name
     :param iface: A QGIS interface instance.
     :type iface: QgsInterface
     """
-
-    plugin_name = os.path.dirname(__file__).split(os.path.sep)[-1]
-    plugin_name = qgis.utils.pluginMetadata(plugin_name, 'name')
-
-    def qgis2compat_version_check():
-        if not qgis.utils.pluginMetadata('qgis2compat', 'version') >= qgis2compat_min_version:
-            raise RuntimeError('The plugin {plugin_name} requires at least version {qgis2compat_min_version} of the '
-                               '`qgis2compat` plugin. Please update it with the plugin manager.'
-                               .format(plugin_name=plugin_name, qgis2compat_min_version=qgis2compat_min_version))
-
-    try:
-        # qgis.PyQt is available in QGIS >=2.14
-        from qgis.PyQt.QtCore import qVersion  # NOQA
-        # qgis.utils.QGis is available in QGIS < 3
-        if hasattr(qgis.utils, 'QGis'):
-            import qgis2compat.apicompat
-            qgis2compat_version_check()
-            qgis2compat.log('apicompat used in {}'.format(plugin_name))
-    except ImportError:
-        try:
-            # we are in QGIS < 2.14
-            import qgis2compat.apicompat
-            qgis2compat_version_check()
-            qgis2compat.log('PyQt and apicompat used in {}'.format(plugin_name))
-        except ImportError:
-            import traceback
-            traceback.print_exc()
-            raise ImportError('The Plugin {} requires the `qgis2compat` plugin. Please install it with the plugin '
-                              'manager. For more information visit http://opengis.ch/qgis2compat'.format(plugin_name))
 
     from qfieldsync.qfield_sync import QFieldSync
     return QFieldSync(iface)

--- a/qfieldsync/__init__.py
+++ b/qfieldsync/__init__.py
@@ -22,10 +22,6 @@
  This script initializes the plugin, making it known to QGIS.
 """
 
-from __future__ import absolute_import
-
-import os
-import qgis.utils
 
 # noinspection PyPep8Naming
 def classFactory(iface):  # pylint: disable=invalid-name

--- a/qfieldsync/core/layer.py
+++ b/qfieldsync/core/layer.py
@@ -4,7 +4,7 @@ import shutil
 from qgis.PyQt.QtXml import QDomDocument
 from qgis.PyQt.QtCore import QCoreApplication
 from qgis.core import (
-    QgsDataSourceUri,
+    QgsDataSourceURI,
     QgsMapLayer
 )
 
@@ -94,7 +94,7 @@ class LayerSource(object):
     def is_file(self):
         if os.path.isfile(self.layer.source()):
             return True
-        elif os.path.isfile(QgsDataSourceUri(self.layer.dataProvider().dataSourceUri()).database()):
+        elif os.path.isfile(QgsDataSourceURI(self.layer.dataProvider().dataSourceUri()).database()):
             return True
         else:
             return False
@@ -153,7 +153,7 @@ class LayerSource(object):
         # Shapefiles... have the path in the source
         file_path = self.layer.source()
         # Spatialite have the path in the table part of the uri
-        uri = QgsDataSourceUri(self.layer.dataProvider().dataSourceUri())
+        uri = QgsDataSourceURI(self.layer.dataProvider().dataSourceUri())
 
         if os.path.isfile(file_path):
             source_path, file_name = os.path.split(file_path)
@@ -182,7 +182,7 @@ class LayerSource(object):
         document = QDomDocument("style")
         map_layers_element = document.createElement("maplayers")
         map_layer_element = document.createElement("maplayer")
-        self.layer.writeLayerXml(map_layer_element, document)
+        self.layer.writeLayerXML(map_layer_element, document)
 
         # modify DOM element with new layer reference
         map_layer_element.firstChildElement("datasource").firstChild().setNodeValue(new_data_source)
@@ -190,5 +190,5 @@ class LayerSource(object):
         document.appendChild(map_layers_element)
 
         # reload layer definition
-        self.layer.readLayerXml(map_layer_element)
+        self.layer.readLayerXML(map_layer_element)
         self.layer.reload()

--- a/qfieldsync/dialogs/package_dialog.py
+++ b/qfieldsync/dialogs/package_dialog.py
@@ -41,7 +41,8 @@ from qgis.PyQt.QtWidgets import (
 )
 from qgis.core import (
     QgsProject,
-    QgsApplication
+    QgsApplication,
+    QgsMapLayerRegistry
 )
 from qgis.gui import (
     QgsMessageBar
@@ -138,7 +139,7 @@ class PackageDialog(QDialog, FORM_CLASS):
         Show the info label if there are unconfigured layers
         """
         self.infoGroupBox.hide()
-        for layer in self.project.mapLayers().values():
+        for layer in QgsMapLayerRegistry.instance().mapLayers().values():
             if not LayerSource(layer).is_configured:
                 self.infoGroupBox.show()
 

--- a/qfieldsync/dialogs/project_configuration_dialog.py
+++ b/qfieldsync/dialogs/project_configuration_dialog.py
@@ -28,6 +28,9 @@ from qgis.PyQt.QtWidgets import (
 )
 from qgis.core import (
     QgsProject,
+    QgsMapLayerRegistry
+)
+from qgis.gui import (
     QgsMapLayerProxyModel
 )
 from ..utils.qt_utils import get_ui_class
@@ -61,7 +64,7 @@ class ProjectConfigurationDialog(QDialog, FORM_CLASS):
         """
         self.layersTable.setRowCount(0)
         self.layersTable.setSortingEnabled(False)
-        for layer in self.project.mapLayers().values():
+        for layer in QgsMapLayerRegistry.instance().mapLayers().values():
             layer_source = LayerSource(layer)
             count = self.layersTable.rowCount()
             self.layersTable.insertRow(count)
@@ -83,7 +86,7 @@ class ProjectConfigurationDialog(QDialog, FORM_CLASS):
         self.layersTable.setSortingEnabled(True)
 
         # Load Map Themes
-        for theme in self.project.mapThemeCollection().mapThemes():
+        for theme in self.project.visibilityPresetCollection().presets():
             self.mapThemeComboBox.addItem(theme)
 
         self.layerComboBox.setFilters(QgsMapLayerProxyModel.RasterLayer)
@@ -98,7 +101,7 @@ class ProjectConfigurationDialog(QDialog, FORM_CLASS):
 
         self.mapThemeComboBox.setCurrentIndex(
             self.mapThemeComboBox.findText(self.__project_configuration.base_map_theme))
-        layer = self.project.mapLayer(self.__project_configuration.base_map_layer)
+        layer = QgsMapLayerRegistry.instance().mapLayer(self.__project_configuration.base_map_layer)
         self.layerComboBox.setLayer(layer)
         self.mapUnitsPerPixel.setText(str(self.__project_configuration.base_map_mupp))
         self.tileSize.setText(str(self.__project_configuration.base_map_tile_size))

--- a/qfieldsync/processing/basemap.py
+++ b/qfieldsync/processing/basemap.py
@@ -163,10 +163,10 @@ class TileSet():
         self.settings.setFlag(QgsMapSettings.Antialiasing, True)
         self.settings.setFlag(QgsMapSettings.RenderMapTile, True)
 
-        if QgsProject.instance().mapThemeCollection().hasMapTheme(map_theme):
-            self.settings.setLayers(QgsProject.instance().mapThemeCollection().mapThemeVisibleLayers(map_theme))
+        if QgsProject.instance().visibilityPresetCollection().hasPreset(map_theme):
+            self.settings.setLayers(QgsProject.instance().visibilityPresetCollection().presetVisibleLayers(map_theme))
             self.settings.setLayerStyleOverrides(
-                QgsProject.instance().mapThemeCollection().mapThemeStyleOverrides(map_theme))
+                QgsProject.instance().visibilityPresetCollection().presetStyleOverrides(map_theme))
         elif layer:
             self.settings.setLayers([layer])
         else:

--- a/qfieldsync/tests/__init__.py
+++ b/qfieldsync/tests/__init__.py
@@ -24,9 +24,3 @@ import pkgutil
 
 import qgis  # pylint: disable=W0611  # NOQA
 import qfieldsync
-
-# On travis, the qgis2compat module is copied into the sourcetree, if it's present, just laod it
-try:
-    import qgis2compat.apicompat  # NOQA
-except ImportError:
-    pass

--- a/scripts/ci/install_qgis2compat.sh
+++ b/scripts/ci/install_qgis2compat.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-qgis2compat_version=$(grep -oP "qgis2compat_min_version = '\K[0-9\.]+" qfieldsync/__init__.py)
-mkdir qgis2compat
-echo "Downloading qgis2compat version from https://github.com/opengisch/qgis2compat/archive/v${qgis2compat_version}.tar.gz"
-curl -L "https://github.com/opengisch/qgis2compat/archive/v${qgis2compat_version}.tar.gz" | tar -xzC qgis2compat --strip-components=1
-rm -rf qgis2compat/test

--- a/tox.ini
+++ b/tox.ini
@@ -6,4 +6,3 @@ exclude=
   qfieldsync/ui,
   qfieldsync/resources_*,
   qfieldsync/test*,
-  qgis2compat


### PR DESCRIPTION
It was causing too much troubles and with the current state of API breaks is no longer considered a feasible migration path.