### PR TITLE
"copy" option (instead of "no action") for GPKG layer

### DIFF
--- a/qfieldsync/core/layer.py
+++ b/qfieldsync/core/layer.py
@@ -95,7 +95,8 @@ class LayerSource(object):
 
     @property
     def is_file(self):
-        if os.path.isfile(self.layer.source()):
+        # reading the part before | so it's valid when gpkg
+        if os.path.isfile(self.layer.source().split('|')[0]):
             return True
         elif os.path.isfile(QgsDataSourceUri(self.layer.dataProvider().dataSourceUri()).database()):
             return True
@@ -153,8 +154,8 @@ class LayerSource(object):
             # Copy will also be called on non-file layers like WMS. In this case, just do nothing.
             return
 
-        # Shapefiles... have the path in the source
-        file_path = self.layer.source()
+        # Shapefiles and GeoPackages have the path in the source
+        file_path = self.layer.source().split('|')[0]
         # Spatialite have the path in the table part of the uri
         uri = QgsDataSourceUri(self.layer.dataProvider().dataSourceUri())
 

--- a/qfieldsync/core/layer.py
+++ b/qfieldsync/core/layer.py
@@ -163,7 +163,7 @@ class LayerSource(object):
             source_path, file_name = os.path.split(file_path)
             basename, extensions = get_file_extension_group(file_name)
             for ext in extensions:
-                if os.path.exists(os.path.join(source_path, basename + ext)):
+                if os.path.exists(os.path.join(source_path, basename + ext)) and not os.path.exists(os.path.join(target_path, basename + ext)):
                     shutil.copy(os.path.join(source_path, basename + ext), os.path.join(target_path, basename + ext))
             self._change_data_source(os.path.join(target_path, file_name))
         # Spatialite files have a uri

--- a/qfieldsync/core/layer.py
+++ b/qfieldsync/core/layer.py
@@ -143,7 +143,7 @@ class LayerSource(object):
                                               'as basemap.')
         return None
 
-    def copy(self, target_path):
+    def copy(self, target_path, copied_files):
         """
         Copy a layer to a new path and adjust its datasource.
 
@@ -163,8 +163,9 @@ class LayerSource(object):
             source_path, file_name = os.path.split(file_path)
             basename, extensions = get_file_extension_group(file_name)
             for ext in extensions:
-                if os.path.exists(os.path.join(source_path, basename + ext)) and not os.path.exists(os.path.join(target_path, basename + ext)):
+                if os.path.exists(os.path.join(source_path, basename + ext)) and os.path.join(target_path, basename + ext) not in copied_files:
                     shutil.copy(os.path.join(source_path, basename + ext), os.path.join(target_path, basename + ext))
+                    copied_files.append(os.path.join(target_path, basename + ext))
             self._change_data_source(os.path.join(target_path, file_name))
         # Spatialite files have a uri
         else:
@@ -178,6 +179,7 @@ class LayerSource(object):
                                     os.path.join(target_path, basename + ext))
                 uri.setDatabase(os.path.join(target_path, file_name))
                 self._change_data_source(uri.uri())
+        return copied_files
 
     def _change_data_source(self, new_data_source):
         """

--- a/qfieldsync/core/offline_converter.py
+++ b/qfieldsync/core/offline_converter.py
@@ -112,6 +112,7 @@ class OfflineConverter(QObject):
                                             self.project_configuration.base_map_mupp)
 
             # Loop through all layers and copy/remove/offline them
+            copied_files = list()
             for current_layer_index, layer in enumerate(self.__layers):
                 self.total_progress_updated.emit(current_layer_index - len(self.__offline_layers), len(self.__layers),
                                                  self.tr('Copying layers'))
@@ -122,7 +123,8 @@ class OfflineConverter(QObject):
                         layer.selectByRect(self.extent)
                     self.__offline_layers.append(layer)
                 elif layer_source.action == SyncAction.NO_ACTION:
-                    layer_source.copy(self.export_folder)
+                    copied_files = layer_source.copy(self.export_folder, copied_files)
+                    print(copied_files)
                 elif layer_source.action == SyncAction.REMOVE:
                     project.removeMapLayer(layer)
 

--- a/qfieldsync/core/offline_converter.py
+++ b/qfieldsync/core/offline_converter.py
@@ -124,7 +124,6 @@ class OfflineConverter(QObject):
                     self.__offline_layers.append(layer)
                 elif layer_source.action == SyncAction.NO_ACTION:
                     copied_files = layer_source.copy(self.export_folder, copied_files)
-                    print(copied_files)
                 elif layer_source.action == SyncAction.REMOVE:
                     project.removeMapLayer(layer)
 


### PR DESCRIPTION
So the GPKG file is copied if a layer has this option.
In case there are several layer in this file, they are all copied. But only the ones with "copy" option are used from there. In case a GPKG layer has the option "offline editing" it has as the source the usual "data.gpkg" and if the GPKG layer has the option "remove" it's not in the project at all.

This fixes https://github.com/opengisch/Vogelwarte_QField_2019/issues/7