### PR TITLE
Open original project after synchronization

### DIFF
--- a/qfieldsync/core/offline_converter.py
+++ b/qfieldsync/core/offline_converter.py
@@ -128,6 +128,9 @@ class OfflineConverter(QObject):
 
             project_path = os.path.join(self.export_folder, project_filename + "_qfield.qgs")
 
+            # save the original project path
+            ProjectConfiguration(project).original_project_path = original_project_path
+
             # save the offline project twice so that the offline plugin can "know" that it's a relative path
             QgsProject.instance().write(project_path)
             try:

--- a/qfieldsync/core/project.py
+++ b/qfieldsync/core/project.py
@@ -104,7 +104,7 @@ class ProjectConfiguration(object):
 
     @property
     def original_project_path(self):
-        original_project_path, _ = self.project.readBoolEntry('qfieldsync', ProjectProperties.ORIGINAL_PROJECT_PATH)
+        original_project_path, _ = self.project.readEntry('qfieldsync', ProjectProperties.ORIGINAL_PROJECT_PATH)
         return original_project_path
 
     @original_project_path.setter

--- a/qfieldsync/core/project.py
+++ b/qfieldsync/core/project.py
@@ -13,6 +13,7 @@ class ProjectProperties(object):
     BASE_MAP_TILE_SIZE = '/baseMapTileSize'
     BASE_MAP_MUPP = '/baseMapMupp'
     OFFLINE_COPY_ONLY_AOI = '/offlineCopyOnlyAoi'
+    ORIGINAL_PROJECT_PATH = '/originalProjectPath'
 
     class BaseMapType(object):
 
@@ -100,3 +101,12 @@ class ProjectConfiguration(object):
     @offline_copy_only_aoi.setter
     def offline_copy_only_aoi(self, value):
         self.project.writeEntry('qfieldsync', ProjectProperties.OFFLINE_COPY_ONLY_AOI, value)
+
+    @property
+    def original_project_path(self):
+        original_project_path, _ = self.project.readBoolEntry('qfieldsync', ProjectProperties.ORIGINAL_PROJECT_PATH)
+        return original_project_path
+
+    @original_project_path.setter
+    def original_project_path(self, value):
+        self.project.writeEntry('qfieldsync', ProjectProperties.ORIGINAL_PROJECT_PATH, value)

--- a/qfieldsync/dialogs/synchronize_dialog.py
+++ b/qfieldsync/dialogs/synchronize_dialog.py
@@ -73,7 +73,7 @@ class SynchronizeDialog(QDialog, FORM_CLASS):
                 original_project_path = ProjectConfiguration(QgsProject.instance()).original_project_path
                 if original_project_path:
                     if open_project(original_project_path):
-                        self.iface.messageBar().pushInfo('Sync dialog', self.tr(u"Opened original project {}".format(original_project_path)))
+                        self.iface.messageBar().pushInfo('QFieldSync', self.tr(u"Opened original project {}".format(original_project_path)))
                     else:
                         self.iface.messageBar().pushInfo('QFieldSync', self.tr(u"The data has been synchronized successfully but the original project ({}) could not be opened. ".format(original_project_path)))
                 self.close()

--- a/qfieldsync/dialogs/synchronize_dialog.py
+++ b/qfieldsync/dialogs/synchronize_dialog.py
@@ -75,7 +75,7 @@ class SynchronizeDialog(QDialog, FORM_CLASS):
                     if open_project(original_project_path):
                         self.iface.messageBar().pushInfo('Sync dialog', self.tr(u"Opened original project {}".format(original_project_path)))
                     else:
-                        self.iface.messageBar().pushInfo('Sync dialog', self.tr(u"Did not open original project {}. Maybe it's not existing.".format(original_project_path)))
+                        self.iface.messageBar().pushInfo('QFieldSync', self.tr(u"The data has been synchronized successfully but the original project ({}) could not be opened. ".format(original_project_path)))
                 self.close()
             else:
                 message = self.tr("The project you imported does not seem to be "

--- a/qfieldsync/dialogs/synchronize_dialog.py
+++ b/qfieldsync/dialogs/synchronize_dialog.py
@@ -63,21 +63,17 @@ class SynchronizeDialog(QDialog, FORM_CLASS):
         try:
             self.progress_group.setEnabled(True)
             qgs_file = get_project_in_folder(qfield_folder)
-            project = QgsProject.instance()
-            project.clear()
-            project.read(qgs_file)
-            project.setFileName(qgs_file)
+            open_project(qgs_file)
             self.offline_editing.progressStopped.connect(self.update_done)
             self.offline_editing.layerProgressUpdated.connect(self.update_total)
             self.offline_editing.progressModeSet.connect(self.update_mode)
             self.offline_editing.progressUpdated.connect(self.update_value)
             self.offline_editing.synchronize()
             if self.offline_editing_done:
-                original_project_path = ProjectConfiguration(project).original_project_path
+                original_project_path = ProjectConfiguration(QgsProject.instance()).original_project_path
                 if original_project_path:
-                    project.clear()
-                    project.read(original_project_path)
-                    project.setFileName(original_project_path)
+                    open_project(original_project_path)
+                    self.iface.messageBar().pushInfo('Sync dialog', 'Opened original project')
                 self.close()
             else:
                 message = self.tr("The project you imported does not seem to be "

--- a/qfieldsync/dialogs/synchronize_dialog.py
+++ b/qfieldsync/dialogs/synchronize_dialog.py
@@ -82,7 +82,7 @@ class SynchronizeDialog(QDialog, FORM_CLASS):
                                   "an offline project")
                 raise NoProjectFoundError(message)
         except NoProjectFoundError as e:
-            self.iface.messageBar().pushWarning('Sync dialog', str(e))
+            self.iface.messageBar().pushWarning('QFieldSync', str(e))
         finally:
             self.progress_group.setEnabled(False)
 

--- a/qfieldsync/dialogs/synchronize_dialog.py
+++ b/qfieldsync/dialogs/synchronize_dialog.py
@@ -72,8 +72,10 @@ class SynchronizeDialog(QDialog, FORM_CLASS):
             if self.offline_editing_done:
                 original_project_path = ProjectConfiguration(QgsProject.instance()).original_project_path
                 if original_project_path:
-                    open_project(original_project_path)
-                    self.iface.messageBar().pushInfo('Sync dialog', 'Opened original project')
+                    if open_project(original_project_path):
+                        self.iface.messageBar().pushInfo('Sync dialog', self.tr(u"Opened original project {}".format(original_project_path)))
+                    else:
+                        self.iface.messageBar().pushInfo('Sync dialog', self.tr(u"Did not open original project {}. Maybe it's not existing.".format(original_project_path)))
                 self.close()
             else:
                 message = self.tr("The project you imported does not seem to be "

--- a/qfieldsync/utils/qgis_utils.py
+++ b/qfieldsync/utils/qgis_utils.py
@@ -36,4 +36,4 @@ def get_project_title(proj):
 def open_project(fn):
     QgsProject.instance().clear()
     QgsProject.instance().setFileName(fn)
-    QgsProject.instance().read()
+    return QgsProject.instance().read()


### PR DESCRIPTION
On the very last moment on creating an offline project, the absolute path of the original project is written to the offline-project. On synchronization after done, this project is tried to be opened again.