### PR TITLE
Disable EvaluateDefaultValues and AutoTransaction options

### DIFF
--- a/qfieldsync/core/offline_converter.py
+++ b/qfieldsync/core/offline_converter.py
@@ -155,6 +155,11 @@ class OfflineConverter(QObject):
                                                                         self.project_configuration.offline_copy_only_aoi):
                         raise Exception(self.tr("Error trying to convert layers to offline layers"))
 
+            # Disable project options that could create problems on a portable
+            # project
+            QgsProject.instance().setEvaluateDefaultValues(False)
+            QgsProject.instance().setAutoTransaction(False)
+
             # Now we have a project state which can be saved as offline project
             QgsProject.instance().write(project_path)
         finally:

--- a/qfieldsync/core/offline_converter.py
+++ b/qfieldsync/core/offline_converter.py
@@ -156,9 +156,10 @@ class OfflineConverter(QObject):
                         raise Exception(self.tr("Error trying to convert layers to offline layers"))
 
             # Disable project options that could create problems on a portable
-            # project
-            QgsProject.instance().setEvaluateDefaultValues(False)
-            QgsProject.instance().setAutoTransaction(False)
+            # project with offline layers
+            if self.__offline_layers:
+                QgsProject.instance().setEvaluateDefaultValues(False)
+                QgsProject.instance().setAutoTransaction(False)
 
             # Now we have a project state which can be saved as offline project
             QgsProject.instance().write(project_path)


### PR DESCRIPTION
Disable EvaluateDefaultValues and AutoTransaction options on exported projects to avoid possible synchronization problems with geopackages.