### PR TITLE
Extensions `||.jpg` in default photo_path expression

### DIFF
--- a/qfieldsync/core/layer.py
+++ b/qfieldsync/core/layer.py
@@ -93,7 +93,7 @@ class LayerSource(object):
         self._action = action
 
     def photo_naming(self, field_name: str) -> str:
-        return self._photo_naming.get(field_name, "'DCIM/{}_'||now()".format(slugify(self.layer.name())))
+        return self._photo_naming.get(field_name, "'DCIM/{}_'||now()||'.jpg'".format(slugify(self.layer.name())))
 
     def set_photo_naming(self, field_name: str, expression: str):
         self._photo_naming[field_name] = expression

--- a/qfieldsync/gui/project_configuration_dialog.py
+++ b/qfieldsync/gui/project_configuration_dialog.py
@@ -111,7 +111,7 @@ class ProjectConfigurationDialog(QDialog, DialogUi):
 
         self.photoResourceTable.setColumnCount(3)
         self.photoResourceTable.setHorizontalHeaderLabels([self.tr('Layer'), self.tr('Field'), self.tr('Naming Expression')])
-        self.photoResourceTable.horizontalHeaderItem(2).setToolTip(self.tr('Enter expression for a file path without extension'))
+        self.photoResourceTable.horizontalHeaderItem(2).setToolTip(self.tr('Enter expression for a file path with the extension .jpg'))
         self.photoResourceTable.horizontalHeader().setStretchLastSection(True)
         self.photoResourceTable.setRowCount(0)
         row = 0
@@ -139,7 +139,7 @@ class ProjectConfigurationDialog(QDialog, DialogUi):
         self.photoResourceTable.resizeColumnsToContents()
 
         # Remove this part to remove the tab when the functionality will be available on QField
-        self.tabWidget.removeTab(self.tabWidget.count()-1)
+        self.tabWidget.removeTab(self.tabWidget.count() - 1)
 
         # Load Map Themes
         for theme in self.project.mapThemeCollection().mapThemes():

--- a/qfieldsync/gui/project_configuration_dialog.py
+++ b/qfieldsync/gui/project_configuration_dialog.py
@@ -111,6 +111,7 @@ class ProjectConfigurationDialog(QDialog, DialogUi):
 
         self.photoResourceTable.setColumnCount(3)
         self.photoResourceTable.setHorizontalHeaderLabels([self.tr('Layer'), self.tr('Field'), self.tr('Naming Expression')])
+        self.photoResourceTable.horizontalHeaderItem(2).setToolTip(self.tr('Enter expression for a file path without extension'))
         self.photoResourceTable.horizontalHeader().setStretchLastSection(True)
         self.photoResourceTable.setRowCount(0)
         row = 0


### PR DESCRIPTION
The user should configure the extension and can be able to set other extensions than jpg.

See what QField does:
https://github.com/opengisch/QField/pull/790#issue-368538835