### PR TITLE
Automatically add related layer from a value relation widget config

### DIFF
--- a/qfieldsync/core/configuration_checkup.py
+++ b/qfieldsync/core/configuration_checkup.py
@@ -1,3 +1,23 @@
+# -*- coding: utf-8 -*-
+
+"""
+/***************************************************************************
+ QFieldSync
+                              -------------------
+        begin                : 2020
+        copyright            : (C) 2020 by OPENGIS.ch
+        email                : info@opengis.ch
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+ """
 
 from qgis.PyQt.QtCore import QObject
 from qgis.core import QgsProject, Qgis

--- a/qfieldsync/core/configuration_checkup.py
+++ b/qfieldsync/core/configuration_checkup.py
@@ -1,0 +1,39 @@
+
+from qgis.PyQt.QtCore import QObject
+from qgis.core import QgsProject, Qgis
+from .layer import LayerSource, SyncAction
+
+
+class QfieldSyncError(object):
+    def __init__(self, layer, error_level, error_message):
+        self.layer = layer
+        self.error_level = error_level
+        self.error_message = error_message
+
+
+class ConfigurationCheckup(QObject):
+    def __init__(self, project: QgsProject):
+        """
+        Returns a list of errors in the project configuration
+        """
+        super(ConfigurationCheckup, self).__init__(parent=None)
+        self._errors = []
+        for layer in list(project.mapLayers().values()):
+            layer_source = LayerSource(layer)
+            if not layer_source.is_configured:
+                self._errors.append(QfieldSyncError(layer, Qgis.Warning, QObject.tr('Layer is not configured.')))
+
+            if layer_source.action != SyncAction.REMOVE:
+                for layer_id in layer_source.dependent_layers:
+                    dependent_layer = project.mapLayer(layer_id)
+                    dependent_layer_source = LayerSource(dependent_layer)
+                    if dependent_layer_source.action == SyncAction.REMOVE:
+                        self._errors.append(QfieldSyncError(
+                            layer,
+                            Qgis.Critical,
+                            self.tr('Layer "{}" depends on "{}" which is removed from packaged project.'
+                                    .format(layer.name(), dependent_layer.name()))
+                        ))
+
+    def errors(self) -> [QfieldSyncError]:
+        return self._errors

--- a/qfieldsync/core/configuration_checkup.py
+++ b/qfieldsync/core/configuration_checkup.py
@@ -21,7 +21,7 @@ class ConfigurationCheckup(QObject):
         for layer in list(project.mapLayers().values()):
             layer_source = LayerSource(layer)
             if not layer_source.is_configured:
-                self._errors.append(QfieldSyncError(layer, Qgis.Warning, QObject.tr('Layer is not configured.')))
+                self._errors.append(QfieldSyncError(layer, Qgis.Warning, self.tr('Layer is not configured.')))
 
             if layer_source.action != SyncAction.REMOVE:
                 for layer_id in layer_source.dependent_layers:

--- a/qfieldsync/core/layer.py
+++ b/qfieldsync/core/layer.py
@@ -1,3 +1,24 @@
+# -*- coding: utf-8 -*-
+
+"""
+/***************************************************************************
+ QFieldSync
+                              -------------------
+        begin                : 2020
+        copyright            : (C) 2020 by OPENGIS.ch
+        email                : info@opengis.ch
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+ """
+
 import os
 import shutil
 import json

--- a/qfieldsync/core/layer.py
+++ b/qfieldsync/core/layer.py
@@ -7,6 +7,7 @@ from qgis.PyQt.QtCore import QCoreApplication
 from qgis.core import (
     QgsDataSourceUri,
     QgsMapLayer,
+    QgsMapLayerType,
     QgsReadWriteContext
 )
 
@@ -67,7 +68,7 @@ class SyncAction(object):
 
 class LayerSource(object):
 
-    def __init__(self, layer):
+    def __init__(self, layer: QgsMapLayer):
         self.layer = layer
         self._action = None
         self._photo_naming = {}
@@ -167,6 +168,21 @@ class LayerSource(object):
     @property
     def name(self):
         return self.layer.name()
+
+    @property
+    def dependent_layers(self) -> [str]:
+        """
+        Returns a list of layer IDs of the layers required by the current layer
+        :return:
+        """
+        layers = []
+        # fields
+        if self.layer.type() == QgsMapLayerType.VectorLayer:
+            for field in self.layer.fields():
+                ews = field.editorWidgetSetup()
+                if ews.type() == 'ValueRelation':
+                    layers.append(ews.config()['Layer'])
+        return layers
 
     def copy(self, target_path, copied_files, keep_existent=False):
         """

--- a/qfieldsync/core/layer.py
+++ b/qfieldsync/core/layer.py
@@ -7,7 +7,6 @@ from qgis.PyQt.QtCore import QCoreApplication
 from qgis.core import (
     QgsDataSourceUri,
     QgsMapLayer,
-    QgsMapLayerType,
     QgsReadWriteContext
 )
 
@@ -177,7 +176,7 @@ class LayerSource(object):
         """
         layers = []
         # fields
-        if self.layer.type() == QgsMapLayerType.VectorLayer:
+        if self.layer.type() == QgsMapLayer.VectorLayer:
             for field in self.layer.fields():
                 ews = field.editorWidgetSetup()
                 if ews.type() == 'ValueRelation':

--- a/qfieldsync/core/preferences.py
+++ b/qfieldsync/core/preferences.py
@@ -1,3 +1,25 @@
+# -*- coding: utf-8 -*-
+
+"""
+/***************************************************************************
+ QFieldSync
+                              -------------------
+        begin                : 2020
+        copyright            : (C) 2020 by OPENGIS.ch
+        email                : info@opengis.ch
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+ """
+
+
 import os
 from qfieldsync.setting_manager import SettingManager, Scope, String
 

--- a/qfieldsync/core/project.py
+++ b/qfieldsync/core/project.py
@@ -1,4 +1,23 @@
+# -*- coding: utf-8 -*-
 
+"""
+/***************************************************************************
+ QFieldSync
+                              -------------------
+        begin                : 2020
+        copyright            : (C) 2020 by OPENGIS.ch
+        email                : info@opengis.ch
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+ """
 
 class ProjectProperties(object):
 

--- a/qfieldsync/ui/package_dialog.ui
+++ b/qfieldsync/ui/package_dialog.ui
@@ -217,7 +217,7 @@
       </sizepolicy>
      </property>
      <property name="text">
-      <string></string>
+      <string/>
      </property>
     </widget>
    </item>
@@ -240,9 +240,12 @@
       <item row="0" column="0">
        <widget class="QLabel" name="infoLabel">
         <property name="text">
-         <string>Some layers in this project have not yet been configured. &lt;a href=&quot;configuration&quot;&gt;Configure project now&lt;/a&gt;.</string>
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Some issues has been found. &lt;a href=&quot;configuration&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#419cff;&quot;&gt;Configure project now&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
         </property>
        </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QListWidget" name="infoListWidget"/>
       </item>
      </layout>
     </widget>
@@ -258,8 +261,8 @@
    <slot>accept()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>20</x>
-     <y>20</y>
+     <x>26</x>
+     <y>622</y>
     </hint>
     <hint type="destinationlabel">
      <x>20</x>
@@ -274,8 +277,8 @@
    <slot>reject()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>20</x>
-     <y>20</y>
+     <x>26</x>
+     <y>622</y>
     </hint>
     <hint type="destinationlabel">
      <x>20</x>

--- a/qfieldsync/ui/package_dialog.ui
+++ b/qfieldsync/ui/package_dialog.ui
@@ -240,7 +240,7 @@
       <item row="0" column="0">
        <widget class="QLabel" name="infoLabel">
         <property name="text">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Some issues has been found. &lt;a href=&quot;configuration&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#419cff;&quot;&gt;Configure project now&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Some issues have been found. &lt;a href=&quot;configuration&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#419cff;&quot;&gt;Configure project now&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
and report error if it missing

When setting a layer as being used, if it has dependent layers, they will be automatically used too (in the project config).
In the package layer dialog, error is reported if dependent layers are missing. 

For now, the dependent layers are checked for value relation widget config.
This can be easily extended for other use cases.

![ezgif-1-ee2fc731f4e4](https://user-images.githubusercontent.com/127259/83400878-ef028b80-a403-11ea-96ff-72f03827074d.gif)
