### PR TITLE
FEATURE add option to lock geometries

### DIFF
--- a/qfieldsync/gui/map_layer_config_widget.py
+++ b/qfieldsync/gui/map_layer_config_widget.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+"""
+/***************************************************************************
+ QFieldSyncDialog
+                                 A QGIS plugin
+ Sync your projects to QField on android
+                             -------------------
+        begin                : 2020-06-15
+        git sha              : $Format:%H$
+        copyright            : (C) 2020 by OPENGIS.ch
+        email                : info@opengis.ch
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+"""
+import os
+
+from qgis.core import Qgis, QgsProject, QgsMapLayer
+from qgis.gui import QgsMapLayerConfigWidget, QgsMapLayerConfigWidgetFactory 
+
+from qgis.PyQt.uic import loadUiType
+
+from qfieldsync.core.layer import LayerSource
+from qfieldsync.gui.photo_naming_widget import PhotoNamingTableWidget
+from qfieldsync.gui.utils import set_available_actions
+
+WidgetUi, _ = loadUiType(os.path.join(os.path.dirname(__file__), '../ui/map_layer_config_widget.ui'))
+
+
+class MapLayerConfigWidgetFactory(QgsMapLayerConfigWidgetFactory):
+    def __init__(self, title, icon):
+        super(MapLayerConfigWidgetFactory, self).__init__(title, icon)
+
+
+    def createWidget(self, layer, canvas, dock_widget, parent):
+        return MapLayerConfigWidget(layer, canvas, parent)
+
+
+    def supportsLayer(self, layer):
+        return LayerSource(layer).is_supported
+
+
+    def supportLayerPropertiesDialog(self):
+        return True
+
+
+class MapLayerConfigWidget(QgsMapLayerConfigWidget, WidgetUi):
+    def __init__(self, layer, canvas, parent):
+        super(MapLayerConfigWidget, self).__init__(layer, canvas, parent)
+        self.setupUi(self)
+        self.layer_source = LayerSource(layer)
+        self.project = QgsProject.instance()
+
+        set_available_actions(self.layerActionComboBox, self.layer_source)
+
+        self.isGeometryLockedCheckBox.setEnabled(self.layer_source.can_lock_geometry)
+        self.isGeometryLockedCheckBox.setChecked(self.layer_source.is_geometry_locked)
+        self.photoNamingTable = PhotoNamingTableWidget()
+        self.photoNamingTable.addLayerFields(self.layer_source)
+        self.photoNamingTable.setLayerColumnHidden(True)
+        
+        # insert the table as a second row only for vector layers
+        if Qgis.QGIS_VERSION_INT >= 31300 and layer.type() == QgsMapLayer.VectorLayer:
+            self.layout().insertRow(1, self.tr('Photo Naming'), self.photoNamingTable)
+            self.photoNamingTable.setEnabled(self.photoNamingTable.rowCount() > 0)
+
+
+    def apply(self):
+        old_layer_action = self.layer_source.action
+        old_is_geometry_locked = self.layer_source.is_geometry_locked
+
+        self.layer_source.action = self.layerActionComboBox.itemData(self.layerActionComboBox.currentIndex())
+        self.layer_source.is_geometry_locked = self.isGeometryLockedCheckBox.isChecked()
+        self.photoNamingTable.syncLayerSourceValues()
+
+        # apply always the photo_namings (to store default values on first apply as well)
+        if (self.layer_source.action != old_layer_action or 
+            self.layer_source.is_geometry_locked != old_is_geometry_locked or
+            self.photoNamingTable.rowCount() > 0
+            ):
+            self.layer_source.apply()
+            self.project.setDirty(True)

--- a/qfieldsync/gui/photo_naming_widget.py
+++ b/qfieldsync/gui/photo_naming_widget.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+"""
+/***************************************************************************
+ QFieldSyncDialog
+                                 A QGIS plugin
+ Sync your projects to QField on android
+                             -------------------
+        begin                : 2020-06-15
+        git sha              : $Format:%H$
+        copyright            : (C) 2020 by OPENGIS.ch
+        email                : info@opengis.ch
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+"""
+
+from qgis.core import QgsMapLayer
+from qgis.gui import QgsFieldExpressionWidget
+
+from qgis.PyQt.QtCore import Qt
+from qgis.PyQt.QtWidgets import QTableWidget, QTableWidgetItem, QAbstractScrollArea
+
+
+class PhotoNamingTableWidget(QTableWidget):
+    def __init__(self):
+        super(PhotoNamingTableWidget, self).__init__()
+
+        self.setColumnCount(3)
+        self.setHorizontalHeaderLabels([self.tr('Layer'), self.tr('Field'), self.tr('Naming Expression')])
+        self.horizontalHeaderItem(2).setToolTip(self.tr('Enter expression for a file path with the extension .jpg'))
+        self.horizontalHeader().setStretchLastSection(True)
+        self.setRowCount(0)
+        self.resizeColumnsToContents()
+        self.setMinimumHeight(100)
+        self.setSizeAdjustPolicy(QAbstractScrollArea.AdjustToContents)
+
+
+    def addLayerFields(self, layer_source):
+        layer = layer_source.layer
+
+        if layer.type() != QgsMapLayer.VectorLayer:
+            return
+
+        for i, field in enumerate(layer.fields()):
+            row = self.rowCount()
+            ews = layer.editorWidgetSetup(i)
+
+            if ews.type() == 'ExternalResource':
+                # for later: if ews.config().get('DocumentViewer', QgsExternalResourceWidget.NoContent) == QgsExternalResourceWidget.Image:
+                self.insertRow(row)
+                item = QTableWidgetItem(layer.name())
+                item.setData(Qt.UserRole, layer_source)
+                self.setItem(row, 0, item)
+                item = QTableWidgetItem(field.name())
+                self.setItem(row, 1, item)
+                ew = QgsFieldExpressionWidget()
+                ew.setLayer(layer)
+                expression = layer_source.photo_naming(field.name())
+                ew.setExpression(expression)
+                self.setCellWidget(row, 2, ew)
+
+        self.resizeColumnsToContents()
+
+
+    def setLayerColumnHidden(self, is_hidden):
+        self.setColumnHidden(0, is_hidden)
+
+
+    def syncLayerSourceValues(self, should_apply=False):
+        for i in range(self.rowCount()):
+            layer_source = self.item(i, 0).data(Qt.UserRole)
+            field_name = self.item(i, 1).text()
+            new_expression = self.cellWidget(i, 2).currentText()
+            layer_source.set_photo_naming(field_name, new_expression)
+
+            if should_apply:
+                layer_source.apply()

--- a/qfieldsync/gui/utils.py
+++ b/qfieldsync/gui/utils.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+"""
+/***************************************************************************
+ QFieldSyncDialog
+                                 A QGIS plugin
+ Sync your projects to QField on android
+                             -------------------
+        begin                : 2020-06-15
+        git sha              : $Format:%H$
+        copyright            : (C) 2020 by OPENGIS.ch
+        email                : info@opengis.ch
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+"""
+
+def set_available_actions(combobox, layer_source):
+    """Sets available actions on a checkbox and selects the current one.
+
+    Args:
+        combobox (QComboBox): target combobox
+        layer_source (LayerSource): target layer
+    """
+    for action, description in layer_source.available_actions:
+        combobox.addItem(description)
+        combobox.setItemData(combobox.count() - 1, action)
+
+        if layer_source.action == action:
+            combobox.setCurrentIndex(combobox.count() - 1)

--- a/qfieldsync/qfield_sync.py
+++ b/qfieldsync/qfield_sync.py
@@ -40,6 +40,7 @@ from qfieldsync.gui.package_dialog import PackageDialog
 from qfieldsync.gui.preferences_dialog import PreferencesDialog
 from qfieldsync.gui.synchronize_dialog import SynchronizeDialog
 from qfieldsync.gui.project_configuration_dialog import ProjectConfigurationDialog
+from qfieldsync.gui.map_layer_config_widget import MapLayerConfigWidgetFactory
 
 
 class QFieldSync(object):
@@ -79,6 +80,9 @@ class QFieldSync(object):
         # TODO: We are going to let the user set this up in a future iteration
         self.toolbar = self.iface.addToolBar(u'QFieldSync')
         self.toolbar.setObjectName(u'QFieldSync')
+
+        # instance of the map config widget factory, shown in layer properties
+        self.mapLayerConfigWidgetFactory = MapLayerConfigWidgetFactory('QField', QIcon(os.path.join(os.path.dirname(__file__), 'resources/icon.png')))
 
         # instance of the QgsOfflineEditing
         self.offline_editing = QgsOfflineEditing()
@@ -193,7 +197,7 @@ class QFieldSync(object):
             parent=self.iface.mainWindow())
 
         self.add_action(
-            './resources/icon.png',
+            os.path.join(os.path.dirname(__file__), './resources/icon.png'),
             text=self.tr(u'Project Configuration'),
             callback=self.show_project_configuration_dialog,
             parent=self.iface.mainWindow(),
@@ -201,11 +205,13 @@ class QFieldSync(object):
         )
 
         self.add_action(
-            './resources/icon.png',
+            os.path.join(os.path.dirname(__file__), './resources/icon.png' ),
             text=self.tr(u'Preferences'),
             callback=self.show_preferences_dialog,
             parent=self.iface.mainWindow(),
             add_to_toolbar=False)
+
+        self.iface.registerMapLayerConfigWidgetFactory(self.mapLayerConfigWidgetFactory)
 
         self.update_button_enabled_status()
 
@@ -218,6 +224,8 @@ class QFieldSync(object):
             self.iface.removeToolBarIcon(action)
         # remove the toolbar
         del self.toolbar
+
+        self.iface.unregisterMapLayerConfigWidgetFactory(self.mapLayerConfigWidgetFactory)
 
     def show_preferences_dialog(self):
         dlg = PreferencesDialog(self.iface.mainWindow())

--- a/qfieldsync/ui/map_layer_config_widget.ui
+++ b/qfieldsync/ui/map_layer_config_widget.ui
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>QFieldLayerSettingsPage</class>
+ <widget class="QWidget" name="QFieldLayerSettingsPage">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>500</width>
+    <height>250</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QFormLayout" name="QFieldLayerSettingsPageLayout">
+   <item row="0" column="0">
+    <widget class="QLabel" name="layerActionLabel">
+     <property name="text">
+      <string>Layer Action</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QComboBox" name="layerActionComboBox">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="QCheckBox" name="isGeometryLockedCheckBox">
+     <property name="toolTip">
+      <string>When enabled, this option disables adding and deleting features, as well as modifying the geometries of existing features.</string>
+     </property>
+     <property name="text">
+      <string>lock geometry</string>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/qfieldsync/ui/map_layer_config_widget.ui
+++ b/qfieldsync/ui/map_layer_config_widget.ui
@@ -37,7 +37,7 @@
       <string>When enabled, this option disables adding and deleting features, as well as modifying the geometries of existing features.</string>
      </property>
      <property name="text">
-      <string>lock geometry</string>
+      <string>Lock Geometries</string>
      </property>
     </widget>
    </item>

--- a/qfieldsync/ui/project_configuration_dialog.ui
+++ b/qfieldsync/ui/project_configuration_dialog.ui
@@ -77,6 +77,14 @@
         </column>
         <column>
          <property name="text">
+          <string>Lock geometry</string>
+         </property>
+         <property name="toolTip">
+          <string>When enabled, this option disables adding and deleting features, as well as modifying the geometries of existing features.</string>
+         </property>
+        </column>
+        <column>
+         <property name="text">
           <string>Action</string>
          </property>
         </column>
@@ -264,15 +272,11 @@
        </item>
       </layout>
      </widget>
-     <widget class="QWidget" name="photo_naming">
+     <widget class="QWidget" name="photoNamingTab">
       <attribute name="title">
        <string>Photo Naming</string>
       </attribute>
-      <layout class="QGridLayout" name="gridLayout_6">
-       <item row="0" column="0">
-        <widget class="QTableWidget" name="photoResourceTable"/>
-       </item>
-      </layout>
+      <layout class="QVBoxLayout" name="photoNamingLayout"/>
      </widget>
     </widget>
    </item>

--- a/qfieldsync/ui/project_configuration_dialog.ui
+++ b/qfieldsync/ui/project_configuration_dialog.ui
@@ -77,7 +77,7 @@
         </column>
         <column>
          <property name="text">
-          <string>Lock geometry</string>
+          <string>Lock Geometries</string>
          </property>
          <property name="toolTip">
           <string>When enabled, this option disables adding and deleting features, as well as modifying the geometries of existing features.</string>


### PR DESCRIPTION
Add a new layer option to "lock geometries". This new option should ideally live on a new vector layer properties panel. QField should respect this new configuration option and not allow adding, splitting, modifying etc. geometries.

![Peek 2020-06-17 12-48](https://user-images.githubusercontent.com/2820439/84883163-e57e5200-b098-11ea-9182-de58f38182cc.gif)

https://github.com/opengisch/QField/pull/1063 functionality:
![Peek 2020-06-15 11-32](https://user-images.githubusercontent.com/2820439/84695083-f15ffc00-af52-11ea-95e3-43256c97a52f.gif)
