### PR TITLE
Localized data path awareness and handling

### DIFF
--- a/qfieldsync/ui/package_dialog.ui
+++ b/qfieldsync/ui/package_dialog.ui
@@ -67,6 +67,22 @@
             </property>
            </widget>
           </item>
+          <item>
+           <spacer>
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeType">
+             <enum>QSizePolicy::Expanding</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>16</width>
+              <height>16</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
          </layout>
         </widget>
        </item>
@@ -227,7 +243,7 @@
       <enum>Qt::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::Close</set>
+      <set>QDialogButtonBox::Close|QDialogButtonBox::Reset</set>
      </property>
     </widget>
    </item>
@@ -238,9 +254,22 @@
      </property>
      <layout class="QGridLayout" name="gridLayout_8">
       <item row="0" column="0">
-       <widget class="QLabel" name="infoLabel">
+       <widget class="QLabel" name="infoConfigurationLabel">
         <property name="text">
-         <string>Some layers in this project have not yet been configured. &lt;a href=&quot;configuration&quot;&gt;Configure project now&lt;/a&gt;.</string>
+         <string>Some layers in this project have not yet been configured, configure those now.</string>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="infoLocalizedPresentLabel">
+        <property name="text">
+         <string>Some layers are stored in localized data paths, make sure those are copied into the localized data path of devices running QField. On most devices, the path is /QField/basemaps.</string>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
@m-kuhn , as discussed over whatsapp, I took the time to update the QFieldSync plugin to be aware of and handle localized data path stored layers.

What the PR does:
- when layer(s) is/are detected as stored in a localized data path, the user is informed and reminded of the need for those to be copied in devices of QField users
- layers stored in a localized data path are not copied (and the list of possible actions for those layers updated accordingly)

While at it, I've updated the plugin to make use of the decodeUri and encodeUri functions, which allows the plugin to properly copy files by non OGR/GDAL providers. For e.g., delimited text provider.