### PR TITLE
Disconnect from offline editing when tasks done

### DIFF
--- a/qfieldsync/core/offline_converter.py
+++ b/qfieldsync/core/offline_converter.py
@@ -214,6 +214,10 @@ class OfflineConverter(QObject):
             QgsProject.instance().setFileName(original_project_path)
             QApplication.restoreOverrideCursor()
 
+        self.offline_editing.layerProgressUpdated.disconnect(self.on_offline_editing_next_layer)
+        self.offline_editing.progressModeSet.disconnect(self.on_offline_editing_max_changed)
+        self.offline_editing.progressUpdated.disconnect(self.offline_editing_task_progress)
+
         self.total_progress_updated.emit(100, 100, self.tr('Finished'))
 
     def createBaseMapLayer(self, map_theme, layer, tile_size, map_units_per_pixel):

--- a/qfieldsync/gui/synchronize_dialog.py
+++ b/qfieldsync/gui/synchronize_dialog.py
@@ -118,4 +118,8 @@ class SynchronizeDialog(QDialog, DialogUi):
 
     @pyqtSlot()
     def update_done(self):
+        self.offline_editing.progressStopped.disconnect(self.update_done)
+        self.offline_editing.layerProgressUpdated.disconnect(self.update_total)
+        self.offline_editing.progressModeSet.disconnect(self.update_mode)
+        self.offline_editing.progressUpdated.disconnect(self.update_value)
         self.offline_editing_done = True


### PR DESCRIPTION
Should fix #169 . 

Because the offline editing is a single object one accross the plugin, and the plugin reloads the project, the layer objects get recreated. However, there are still references to the them in python even though they are already deleted. The error occures in signal listeners, they have reference to these deleted objects, hence the error. The problem is easy to reproduce, just export/import a project several times, the error get's hidden by the success message in the end, but it is there, if you click the X on the last message in the bar.