### PR TITLE
Further project properties improvements

### DIFF
--- a/qfieldsync/core/layer.py
+++ b/qfieldsync/core/layer.py
@@ -166,11 +166,8 @@ class LayerSource(object):
 
     @property
     def is_supported(self):
-        # jpeg 2000
-        if self.layer.source().endswith(('jp2', 'jpx')):
-            return False
         # ecw raster
-        elif self.layer.source().endswith('ecw'):
+        if self.layer.source().endswith('ecw'):
             return False
         else:
             return True
@@ -189,13 +186,9 @@ class LayerSource(object):
 
     @property
     def warning(self):
-        if self.layer.source().endswith(('jp2', 'jpx')):
-            return QCoreApplication.translate('DataSourceWarning',
-                                              'JPEG2000 layers are not supported by QField.'
-                                              )
         if self.layer.source().endswith('ecw'):
             return QCoreApplication.translate('DataSourceWarning',
-                                              'ECW layers are not supported by QField.<br>')
+                                              'ECW layers are not supported by QField.')
         return None
 
     @property

--- a/qfieldsync/core/layer.py
+++ b/qfieldsync/core/layer.py
@@ -191,13 +191,11 @@ class LayerSource(object):
     def warning(self):
         if self.layer.source().endswith(('jp2', 'jpx')):
             return QCoreApplication.translate('DataSourceWarning',
-                                              'JPEG2000 layers are not supported by QField.<br>You can rasterize '
-                                              'them as basemap.'
+                                              'JPEG2000 layers are not supported by QField.'
                                               )
         if self.layer.source().endswith('ecw'):
             return QCoreApplication.translate('DataSourceWarning',
-                                              'ECW layers are not supported by QField.<br>You can rasterize them '
-                                              'as basemap.')
+                                              'ECW layers are not supported by QField.<br>')
         return None
 
     @property

--- a/qfieldsync/core/offline_converter.py
+++ b/qfieldsync/core/offline_converter.py
@@ -131,6 +131,11 @@ class OfflineConverter(QObject):
                 self.total_progress_updated.emit(current_layer_index - len(self.__offline_layers), len(self.__layers),
                                                  self.trUtf8('Copying layers…'))
 
+                layer_source = LayerSource(layer)
+                if not layer_source.is_supported:
+                     project.removeMapLayer(layer)
+                     continue
+
                 if layer.dataProvider() is not None:
                     md = QgsProviderRegistry.instance().providerMetadata(layer.dataProvider().name())
                     if md is not None:
@@ -140,8 +145,6 @@ class OfflineConverter(QObject):
                             if path.startswith("localized:"):
                                 # Layer stored in localized data path, skip
                                 continue
-
-                layer_source = LayerSource(layer)
 
                 if layer_source.action == SyncAction.OFFLINE:
                     if self.project_configuration.offline_copy_only_aoi:

--- a/qfieldsync/gui/project_configuration_widget.py
+++ b/qfieldsync/gui/project_configuration_widget.py
@@ -94,8 +94,6 @@ class ProjectConfigurationWidget(WidgetUi, QgsOptionsPageWidget):
         self.layersTable.setSortingEnabled(False)
         for layer in self.project.mapLayers().values():
             layer_source = LayerSource(layer)
-            if not layer_source.is_supported:
-                self.unsupportedLayersList.append(layer_source)
             count = self.layersTable.rowCount()
             self.layersTable.insertRow(count)
             item = QTableWidgetItem(layer.name())
@@ -121,6 +119,13 @@ class ProjectConfigurationWidget(WidgetUi, QgsOptionsPageWidget):
 
             self.layersTable.setCellWidget(count, 1, cbx_widget)
             self.layersTable.setCellWidget(count, 2, cmb)
+
+            if not layer_source.is_supported:
+                self.unsupportedLayersList.append(layer_source)
+                self.layersTable.item(count,0).setFlags(Qt.NoItemFlags)
+                self.layersTable.cellWidget(count,1).setEnabled(False)
+                self.layersTable.cellWidget(count,2).setEnabled(False)
+                cmb.setCurrentIndex(cmb.findData(SyncAction.REMOVE))
 
             # make sure layer_source is the same instance everywhere
             self.photoNamingTable.addLayerFields(layer_source)
@@ -156,17 +161,12 @@ class ProjectConfigurationWidget(WidgetUi, QgsOptionsPageWidget):
         self.onlyOfflineCopyFeaturesInAoi.setChecked(self.__project_configuration.offline_copy_only_aoi)
 
         if self.unsupportedLayersList:
-            self.unsupportedLayers.setVisible(True)
+            self.unsupportedLayersLabel.setVisible(True)
 
-            unsupported_layers_text = '<b>{}</b><br>'.format(self.tr('Warning'))
-            unsupported_layers_text += self.tr("There are unsupported layers in your project. They will not be available on QField.")
-
-            unsupported_layers_text += '<ul>'
-            for layer in self.unsupportedLayersList:
-                unsupported_layers_text += '<li>' + '<b>' + layer.name + ':</b> ' + layer.warning
-            unsupported_layers_text += '<ul>'
-
-            self.unsupportedLayers.setText(unsupported_layers_text)
+            unsupported_layers_text = '<b>{}: </b>'.format(self.tr('Warning'))
+            unsupported_layers_text += self.tr("There are unsupported layers in your project which will not be available in QField.")
+            unsupported_layers_text += self.tr(" If needed, you can create a Base Map to include those layers in your packaged project.")
+            self.unsupportedLayersLabel.setText(unsupported_layers_text)
 
     def apply(self):
         """

--- a/qfieldsync/ui/project_configuration_widget.ui
+++ b/qfieldsync/ui/project_configuration_widget.ui
@@ -267,20 +267,23 @@
         </column>
        </widget>
       </item>
+      <item row="3" column="0" colspan="2">
+       <widget class="QLabel" name="unsupportedLayersLabel">
+        <property name="text">
+         <string></string>
+        </property>
+        <property name="visible">
+         <bool>false</bool>
+        </property>
+        <property name="textFormat">
+         <enum>Qt::RichText</enum>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
      </layout>
-    </widget>
-   </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="unsupportedLayers">
-     <property name="text">
-      <string>Unsupported layers</string>
-     </property>
-     <property name="textFormat">
-      <enum>Qt::RichText</enum>
-     </property>
-     <property name="wordWrap">
-      <bool>true</bool>
-     </property>
     </widget>
    </item>
   </layout>


### PR DESCRIPTION
Improvements around unsupported layers handling:
- QField has been supporting JP2K rasters for a while now, thanks to @m-kuhn , let's not report those as unsupported
- Never package unsupported datasets (as of now only one format: ECW), it's a waste of bandwidth and let's to errors in QField
- Don't show an "invalid/unsupported layers" label if none are detected

Fixes #78 