### PR TITLE
Update metadata changelog with generic message instead of obsolete information

### DIFF
--- a/qfieldsync/metadata.txt
+++ b/qfieldsync/metadata.txt
@@ -19,9 +19,7 @@ email=info@opengis.ch
 # Recommended items:
 
 changelog=
-    Release 3.1.10
-    --------------
-    * Support for Offline Layers with Value Relation widget
+    We've been busy improving QFieldSync, enjoy this new release.
     
     Check out the complete changelog on: https://github.com/opengisch/qfieldsync/releases
 


### PR DESCRIPTION
@m-kuhn , as suggested a while back, I think we can lower burden pushing a new qfieldsync plugin release by having a generic changelog metadata (vs. one that's not up-to-date :) ). 