### PR TITLE
Split the configuration for cloud and traditional cable export

### DIFF
--- a/qfieldsync/gui/layers_config_widget.py
+++ b/qfieldsync/gui/layers_config_widget.py
@@ -1,0 +1,167 @@
+# -*- coding: utf-8 -*-
+"""
+/***************************************************************************
+ QFieldSyncDialog
+                                 A QGIS plugin
+ Sync your projects to QField on android
+                             -------------------
+        begin                : 2020-10-10
+        git sha              : $Format:%H$
+        copyright            : (C) 2020 by OPENGIS.ch
+        email                : info@opengis.ch
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+"""
+import os
+
+from qgis.core import QgsProject
+
+from qgis.PyQt.uic import loadUiType
+from qgis.PyQt.QtWidgets import QWidget
+
+from qgis.PyQt.QtCore import Qt, QTemporaryDir
+from qgis.PyQt.QtGui import QIcon
+from qgis.PyQt.QtWidgets import QDialog, QTableWidgetItem, QToolButton, QComboBox, QCheckBox, QMenu, QAction, QWidget, QHBoxLayout
+
+from qfieldsync.gui.utils import set_available_actions
+from qfieldsync.libqfieldsync.layer import LayerSource, SyncAction
+
+LayersConfigWidgetUi, _ = loadUiType(os.path.join(os.path.dirname(__file__), '../ui/layers_config_widget.ui'))
+
+
+class LayersConfigWidget(QWidget, LayersConfigWidgetUi):
+    
+    def __init__(self, project, parent=None):
+        """Constructor."""
+        super(LayersConfigWidget, self).__init__(parent=parent)
+        self.setupUi(self)
+
+        self.project = project
+
+        self.multipleToggleButton.setIcon(QIcon(os.path.join(os.path.dirname(__file__), '../resources/visibility.svg')))
+        self.toggleMenu = QMenu(self)
+        self.removeAllAction = QAction(self.tr("Remove All Layers"), self.toggleMenu)
+        self.toggleMenu.addAction(self.removeAllAction)
+        self.removeHiddenAction = QAction(self.tr("Remove Hidden Layers"), self.toggleMenu)
+        self.toggleMenu.addAction(self.removeHiddenAction)
+        self.addAllCopyAction = QAction(self.tr("Add All Layers"), self.toggleMenu)
+        self.toggleMenu.addAction(self.addAllCopyAction)
+        self.addVisibleCopyAction = QAction(self.tr("Add Visible Layers"), self.toggleMenu)
+        self.toggleMenu.addAction(self.addVisibleCopyAction)
+        self.addAllOfflineAction = QAction(self.tr("Add All Vector Layers as Offline"), self.toggleMenu)
+        self.toggleMenu.addAction(self.addAllOfflineAction)
+        self.addVisibleOfflineAction = QAction(self.tr("Add Visible Vector Layers as Offline"), self.toggleMenu)
+        self.toggleMenu.addAction(self.addVisibleOfflineAction)
+        self.multipleToggleButton.setMenu(self.toggleMenu)
+        self.multipleToggleButton.setAutoRaise(True)
+        self.multipleToggleButton.setPopupMode(QToolButton.InstantPopup)
+        self.toggleMenu.triggered.connect(self.toggleMenu_triggered)
+        self.unsupportedLayersList = list()
+
+        self.reloadProject()
+
+
+    def reloadProject(self):
+        """
+        Load all layers from the map layer registry into the table.
+        """
+        self.unsupportedLayersList = list()
+
+        self.layersTable.setRowCount(0)
+        self.layersTable.setSortingEnabled(False)
+        for layer in self.project.mapLayers().values():
+            layer_source = LayerSource(layer)
+            count = self.layersTable.rowCount()
+            self.layersTable.insertRow(count)
+            item = QTableWidgetItem(layer.name())
+            item.setData(Qt.UserRole, layer_source)
+            item.setData(Qt.EditRole, layer.name())
+            self.layersTable.setItem(count, 0, item)
+
+            cmb = QComboBox()
+            set_available_actions(cmb, layer_source)
+            
+            cbx = QCheckBox()
+            cbx.setEnabled(layer_source.can_lock_geometry)
+            cbx.setChecked(layer_source.is_geometry_locked)
+            # it's more UI friendly when the checkbox is centered, an ugly workaround to achieve it
+            cbx_widget = QWidget()
+            cbx_layout = QHBoxLayout()
+            cbx_layout.setAlignment(Qt.AlignCenter)
+            cbx_layout.setContentsMargins(0, 0, 0, 0)
+            cbx_layout.addWidget(cbx)
+            cbx_widget.setLayout(cbx_layout)
+            # NOTE the margin is not updated when the table column is resized, so better rely on the code above
+            # cbx.setStyleSheet("margin-left:50%; margin-right:50%;")
+
+            self.layersTable.setCellWidget(count, 1, cbx_widget)
+            self.layersTable.setCellWidget(count, 2, cmb)
+
+            if not layer_source.is_supported:
+                self.unsupportedLayersList.append(layer_source)
+                self.layersTable.item(count,0).setFlags(Qt.NoItemFlags)
+                self.layersTable.cellWidget(count,1).setEnabled(False)
+                self.layersTable.cellWidget(count,2).setEnabled(False)
+                cmb.setCurrentIndex(cmb.findData(SyncAction.REMOVE))
+
+        self.layersTable.resizeColumnsToContents()
+        self.layersTable.sortByColumn(0, Qt.AscendingOrder)
+        self.layersTable.setSortingEnabled(True)
+
+        if self.unsupportedLayersList:
+            self.unsupportedLayersLabel.setVisible(True)
+
+            unsupported_layers_text = '<b>{}: </b>'.format(self.tr('Warning'))
+            unsupported_layers_text += self.tr("There are unsupported layers in your project which will not be available in QField.")
+            unsupported_layers_text += self.tr(" If needed, you can create a Base Map to include those layers in your packaged project.")
+            self.unsupportedLayersLabel.setText(unsupported_layers_text)
+
+
+    def toggleMenu_triggered(self, action):
+        """
+        Toggles usage of layers
+        :param action: the menu action that triggered this
+        """
+        sync_action = SyncAction.NO_ACTION
+        if action in (self.removeHiddenAction, self.removeAllAction):
+            sync_action = SyncAction.REMOVE
+        elif action in (self.addAllOfflineAction, self.addVisibleOfflineAction):
+            sync_action = SyncAction.OFFLINE
+
+        # all layers
+        if action in (self.removeAllAction, self.addAllCopyAction, self.addAllOfflineAction):
+            for i in range(self.layersTable.rowCount()):
+                item = self.layersTable.item(i, 0)
+                layer_source = item.data(Qt.UserRole)
+                old_action = layer_source.action
+                available_actions, _ = zip(*layer_source.available_actions)
+                if sync_action in available_actions:
+                    layer_source.action = sync_action
+                    if layer_source.action != old_action:
+                        self.project.setDirty(True)
+                    layer_source.apply()
+        # based on visibility
+        elif action in (self.removeHiddenAction, self.addVisibleCopyAction, self.addVisibleOfflineAction):
+            visible = Qt.Unchecked if action == self.removeHiddenAction else Qt.Checked
+            root = QgsProject.instance().layerTreeRoot()
+            for layer in QgsProject.instance().mapLayers().values():
+                node = root.findLayer(layer.id())
+                if node and node.isVisible() == visible:
+                    layer_source = LayerSource(layer)
+                    old_action = layer_source.action
+                    available_actions, _ = zip(*layer_source.available_actions)
+                    if sync_action in available_actions:
+                        layer_source.action = sync_action
+                        if layer_source.action != old_action:
+                            self.project.setDirty(True)
+                        layer_source.apply()
+
+        self.reloadProject()

--- a/qfieldsync/gui/map_layer_config_widget.py
+++ b/qfieldsync/gui/map_layer_config_widget.py
@@ -58,7 +58,8 @@ class MapLayerConfigWidget(QgsMapLayerConfigWidget, WidgetUi):
         self.layer_source = LayerSource(layer)
         self.project = QgsProject.instance()
 
-        set_available_actions(self.layerActionComboBox, self.layer_source)
+        set_available_actions(self.cloudLayerActionComboBox, self.layer_source.available_cloud_actions, self.layer_source.cloud_action)
+        set_available_actions(self.cableLayerActionComboBox, self.layer_source.available_actions, self.layer_source.action)
 
         self.isGeometryLockedCheckBox.setEnabled(self.layer_source.can_lock_geometry)
         self.isGeometryLockedCheckBox.setChecked(self.layer_source.is_geometry_locked)
@@ -68,7 +69,7 @@ class MapLayerConfigWidget(QgsMapLayerConfigWidget, WidgetUi):
         
         # insert the table as a second row only for vector layers
         if Qgis.QGIS_VERSION_INT >= 31300 and layer.type() == QgsMapLayer.VectorLayer:
-            self.layout().insertRow(1, self.tr('Photo Naming'), self.photoNamingTable)
+            self.layout().insertRow(2, self.tr('Photo Naming'), self.photoNamingTable)
             self.photoNamingTable.setEnabled(self.photoNamingTable.rowCount() > 0)
 
 
@@ -76,7 +77,8 @@ class MapLayerConfigWidget(QgsMapLayerConfigWidget, WidgetUi):
         old_layer_action = self.layer_source.action
         old_is_geometry_locked = self.layer_source.is_geometry_locked
 
-        self.layer_source.action = self.layerActionComboBox.itemData(self.layerActionComboBox.currentIndex())
+        self.layer_source.cloud_action = self.cloudLayerActionComboBox.itemData(self.cloudLayerActionComboBox.currentIndex())
+        self.layer_source.action = self.cableLayerActionComboBox.itemData(self.cableLayerActionComboBox.currentIndex())
         self.layer_source.is_geometry_locked = self.isGeometryLockedCheckBox.isChecked()
         self.photoNamingTable.syncLayerSourceValues()
 

--- a/qfieldsync/gui/photo_naming_widget.py
+++ b/qfieldsync/gui/photo_naming_widget.py
@@ -40,6 +40,7 @@ class PhotoNamingTableWidget(QTableWidget):
         self.resizeColumnsToContents()
         self.setMinimumHeight(100)
         self.setSizeAdjustPolicy(QAbstractScrollArea.AdjustToContents)
+        # self.setSizeAdjustPolicy(QAbstractScrollArea.AdjustToContents)
 
 
     def addLayerFields(self, layer_source):

--- a/qfieldsync/gui/project_configuration_widget.py
+++ b/qfieldsync/gui/project_configuration_widget.py
@@ -31,7 +31,6 @@ from qgis.gui import (
     QgsOptionsPageWidget,
 )
 
-from qfieldsync.gui.photo_naming_widget import PhotoNamingTableWidget
 from qfieldsync.gui.layers_config_widget import LayersConfigWidget
 from qfieldsync.gui.utils import set_available_actions
 from qfieldsync.utils.cloud_utils import to_cloud_title
@@ -69,17 +68,10 @@ class ProjectConfigurationWidget(WidgetUi, QgsOptionsPageWidget):
         """
         self.unsupportedLayersList = list()
 
-        self.photoNamingTable = PhotoNamingTableWidget()
-        self.photoNamingGroup.layout().addWidget(self.photoNamingTable)
         self.cloudLayersConfigWidget = LayersConfigWidget(self.project)
         self.cableLayersConfigWidget = LayersConfigWidget(self.project)
         self.cloudAdvancedSettings.layout().addWidget(self.cloudLayersConfigWidget)
         self.cableExportTab.layout().addWidget(self.cableLayersConfigWidget)
-
-
-        # Remove the tab when not yet suported in QGIS
-        if Qgis.QGIS_VERSION_INT < 31300:
-            self.photoNamingGroup.setVisible(False)
 
         # Load Map Themes
         for theme in self.project.mapThemeCollection().mapThemes():
@@ -130,11 +122,6 @@ class ProjectConfigurationWidget(WidgetUi, QgsOptionsPageWidget):
             if layer_source.action != old_action or layer_source.is_geometry_locked != old_is_geometry_locked:
                 self.project.setDirty(True)
                 layer_source.apply()
-
-        # apply always the photo_namings (to store default values on first apply as well)
-        self.photoNamingTable.syncLayerSourceValues(should_apply=True)
-        if self.photoNamingTable.rowCount() > 0:
-            self.project.setDirty(True)
 
         self.__project_configuration.create_base_map = self.createBaseMapGroupBox.isChecked()
         self.__project_configuration.base_map_theme = self.mapThemeComboBox.currentText()

--- a/qfieldsync/gui/utils.py
+++ b/qfieldsync/gui/utils.py
@@ -21,16 +21,16 @@
  ***************************************************************************/
 """
 
-def set_available_actions(combobox, layer_source):
+def set_available_actions(combobox, actions, default_action):
     """Sets available actions on a checkbox and selects the current one.
 
     Args:
         combobox (QComboBox): target combobox
         layer_source (LayerSource): target layer
     """
-    for action, description in layer_source.available_actions:
+    for action, description in actions:
         combobox.addItem(description)
         combobox.setItemData(combobox.count() - 1, action)
 
-        if layer_source.action == action:
+        if action == default_action:
             combobox.setCurrentIndex(combobox.count() - 1)

--- a/qfieldsync/ui/layers_config_widget.ui
+++ b/qfieldsync/ui/layers_config_widget.ui
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>343</width>
+    <height>204</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string/>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item row="0" column="2">
+    <widget class="QToolButton" name="multipleToggleButton">
+     <property name="toolTip">
+      <string>Toggle layers</string>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+     <property name="icon">
+      <iconset>
+       <normaloff>../resources/visibility.svg</normaloff>../resources/visibility.svg</iconset>
+     </property>
+     <property name="popupMode">
+      <enum>QToolButton::InstantPopup</enum>
+     </property>
+     <property name="autoRaise">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <spacer name="horizontalSpacer">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Layers</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0" colspan="3">
+    <widget class="QTableWidget" name="layersTable">
+     <attribute name="horizontalHeaderStretchLastSection">
+      <bool>true</bool>
+     </attribute>
+     <column>
+      <property name="text">
+       <string>Layer</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Lock Geometries</string>
+      </property>
+      <property name="toolTip">
+       <string>When enabled, this option disables adding and deleting features, as well as modifying the geometries of existing features.</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Action</string>
+      </property>
+     </column>
+    </widget>
+   </item>
+   <item row="3" column="0" colspan="3">
+    <widget class="QLabel" name="unsupportedLayersLabel">
+     <property name="visible">
+      <bool>false</bool>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+     <property name="textFormat">
+      <enum>Qt::RichText</enum>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/qfieldsync/ui/map_layer_config_widget.ui
+++ b/qfieldsync/ui/map_layer_config_widget.ui
@@ -14,15 +14,8 @@
    <string>Form</string>
   </property>
   <layout class="QFormLayout" name="QFieldLayerSettingsPageLayout">
-   <item row="0" column="0">
-    <widget class="QLabel" name="layerActionLabel">
-     <property name="text">
-      <string>Layer Action</string>
-     </property>
-    </widget>
-   </item>
    <item row="0" column="1">
-    <widget class="QComboBox" name="layerActionComboBox">
+    <widget class="QComboBox" name="cloudLayerActionComboBox">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
        <horstretch>0</horstretch>
@@ -31,7 +24,21 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="1">
+   <item row="0" column="0">
+    <widget class="QLabel" name="cloudLayerActionLabel">
+     <property name="text">
+      <string>Cloud Layer Action</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="cableLayerActionLabel">
+     <property name="text">
+      <string>Cable Layer Action</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
     <widget class="QCheckBox" name="isGeometryLockedCheckBox">
      <property name="toolTip">
       <string>When enabled, this option disables adding and deleting features, as well as modifying the geometries of existing features.</string>
@@ -40,6 +47,9 @@
       <string>Lock Geometries</string>
      </property>
     </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="QComboBox" name="cableLayerActionComboBox"/>
    </item>
   </layout>
  </widget>

--- a/qfieldsync/ui/project_configuration_widget.ui
+++ b/qfieldsync/ui/project_configuration_widget.ui
@@ -30,6 +30,13 @@
        <string>QFieldCloud</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout_2">
+       <item row="0" column="1">
+        <widget class="QRadioButton" name="preferOfflineLayersRadioButton">
+         <property name="text">
+          <string>Prefer offline layers</string>
+         </property>
+        </widget>
+       </item>
        <item row="3" column="0" colspan="2">
         <widget class="QgsCollapsibleGroupBox" name="cloudAdvancedSettings">
          <property name="title">
@@ -44,22 +51,28 @@
          <layout class="QVBoxLayout" name="verticalLayout_4"/>
         </widget>
        </item>
-       <item row="0" column="1">
-        <widget class="QRadioButton" name="preferOfflineLayersRadioButton">
-         <property name="text">
-          <string>Prefer Offline Layers</string>
-         </property>
-        </widget>
-       </item>
        <item row="0" column="0">
         <widget class="QRadioButton" name="preferOnlineLayersRadioButton">
          <property name="text">
-          <string>Prefer Online Layers</string>
+          <string>Prefer online layers</string>
          </property>
          <property name="checked">
           <bool>true</bool>
          </property>
         </widget>
+       </item>
+       <item row="4" column="0" colspan="2">
+        <spacer name="verticalSpacer_2">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>0</height>
+          </size>
+         </property>
+        </spacer>
        </item>
       </layout>
      </widget>
@@ -86,7 +99,7 @@
       <item row="0" column="0">
        <widget class="QRadioButton" name="singleLayerRadioButton">
         <property name="text">
-         <string>Single Layer</string>
+         <string>Single layer</string>
         </property>
         <attribute name="buttonGroup">
          <string notr="true">buttonGroup</string>
@@ -219,7 +232,7 @@
       <item row="0" column="1">
        <widget class="QRadioButton" name="mapThemeRadioButton">
         <property name="text">
-         <string>Map Theme</string>
+         <string>Map theme</string>
         </property>
         <attribute name="buttonGroup">
          <string notr="true">buttonGroup</string>
@@ -230,10 +243,19 @@
     </widget>
    </item>
    <item>
-    <widget class="QCheckBox" name="onlyOfflineCopyFeaturesInAoi">
-     <property name="text">
-      <string>Only Copy Features in Area of Interest</string>
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string>Advanced Settings</string>
      </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <item>
+       <widget class="QCheckBox" name="onlyOfflineCopyFeaturesInAoi">
+        <property name="text">
+         <string>Only copy features in area of interest</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
    <item>

--- a/qfieldsync/ui/project_configuration_widget.ui
+++ b/qfieldsync/ui/project_configuration_widget.ui
@@ -1,294 +1,279 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>QFieldProjectConfigurationBase</class>
+ <class>QField</class>
  <widget class="QWidget" name="QField">
   <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>600</width>
+    <width>737</width>
     <height>570</height>
    </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
   </property>
   <property name="windowTitle">
    <string>Configure Project for QField Synchronisation</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout">
-   <item row="1" column="0">
-    <widget class="QTabWidget" name="tabWidget">
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QTabWidget" name="exportTypeTabs">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="currentIndex">
       <number>0</number>
      </property>
-     <widget class="QWidget" name="tab">
+     <widget class="QWidget" name="cloudExportTab">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
       <attribute name="title">
-       <string>Base Map</string>
+       <string>QFieldCloud</string>
       </attribute>
-      <layout class="QGridLayout" name="gridLayout_4">
-       <item row="0" column="0">
-        <widget class="QGroupBox" name="createBaseMapGroupBox">
-         <property name="toolTip">
-          <string>A base map is fully rendered to a raster image. Attributes from layers on a base map are no longer accessible.</string>
+      <layout class="QGridLayout" name="gridLayout_2">
+       <property name="sizeConstraint">
+        <enum>QLayout::SetMinAndMaxSize</enum>
+       </property>
+       <item row="3" column="0" colspan="2">
+        <widget class="QgsCollapsibleGroupBox" name="cloudAdvancedSettings">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
          </property>
          <property name="title">
-          <string>Create Base Map</string>
+          <string>Advanced Settings</string>
          </property>
-         <property name="checkable">
-          <bool>true</bool>
-         </property>
-         <property name="checked">
+         <property name="collapsed">
           <bool>false</bool>
          </property>
-         <layout class="QGridLayout" name="gridLayout_3">
-          <item row="0" column="1">
-           <widget class="QRadioButton" name="mapThemeRadioButton">
-            <property name="text">
-             <string>Map Theme</string>
-            </property>
-            <attribute name="buttonGroup">
-             <string notr="true">buttonGroup</string>
-            </attribute>
-           </widget>
-          </item>
-          <item row="2" column="0" colspan="2">
-           <widget class="QStackedWidget" name="baseMapTypeStack">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="inputMethodHints">
-             <set>Qt::ImhDialableCharactersOnly</set>
-            </property>
-            <widget class="QWidget" name="mapThemePage">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <layout class="QFormLayout" name="formLayout_2">
-              <property name="leftMargin">
-               <number>0</number>
-              </property>
-              <property name="topMargin">
-               <number>0</number>
-              </property>
-              <property name="rightMargin">
-               <number>0</number>
-              </property>
-              <property name="bottomMargin">
-               <number>0</number>
-              </property>
-              <item row="0" column="0">
-               <widget class="QLabel" name="label">
-                <property name="text">
-                 <string>Map Theme</string>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="1">
-               <widget class="QComboBox" name="mapThemeComboBox"/>
-              </item>
-             </layout>
-            </widget>
-            <widget class="QWidget" name="singleLayerPage">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <layout class="QFormLayout" name="formLayout">
-              <item row="0" column="0">
-               <widget class="QLabel" name="label_2">
-                <property name="text">
-                 <string>Layer</string>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="1">
-               <widget class="QgsMapLayerComboBox" name="layerComboBox"/>
-              </item>
-             </layout>
-            </widget>
-           </widget>
-          </item>
-          <item row="4" column="0">
-           <widget class="QLabel" name="label_3">
-            <property name="text">
-             <string>Tile Size</string>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="1">
-           <widget class="QLineEdit" name="tileSize">
-            <property name="toolTip">
-             <string>Rendering will happen in tiles. This number determines the width and height (in pixels) that will be rendered per tile.</string>
-            </property>
-            <property name="inputMethodHints">
-             <set>Qt::ImhDigitsOnly</set>
-            </property>
-            <property name="text">
-             <string>1024</string>
-            </property>
-           </widget>
-          </item>
-          <item row="5" column="0">
-           <widget class="QLabel" name="label_4">
-            <property name="text">
-             <string>Map Units/Pixel</string>
-            </property>
-           </widget>
-          </item>
-          <item row="5" column="1">
-           <widget class="QLineEdit" name="mapUnitsPerPixel">
-            <property name="toolTip">
-             <string>This determines the spatial resolution of the resulting map image. It depends on the CRS of the map canvas. For map units in [m], a value of 1 means each pixel covers an area of 1x1 m, a value of 1000 means 1 pixel per square kilometer.</string>
-            </property>
-            <property name="inputMethodHints">
-             <set>Qt::ImhFormattedNumbersOnly</set>
-            </property>
-            <property name="text">
-             <string>100</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="0">
-           <widget class="QRadioButton" name="singleLayerRadioButton">
-            <property name="text">
-             <string>Single Layer</string>
-            </property>
-            <attribute name="buttonGroup">
-             <string notr="true">buttonGroup</string>
-            </attribute>
-           </widget>
-          </item>
-         </layout>
+         <property name="saveCheckedState">
+          <bool>true</bool>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_4"/>
         </widget>
        </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="tab_2">
-      <attribute name="title">
-       <string>Offline Editing</string>
-      </attribute>
-      <layout class="QGridLayout" name="gridLayout_5">
-       <item row="0" column="0">
-        <widget class="QCheckBox" name="onlyOfflineCopyFeaturesInAoi">
+       <item row="0" column="1">
+        <widget class="QRadioButton" name="preferOfflineLayersRadioButton">
          <property name="text">
-          <string>Only Copy Features in Area of Interest</string>
+          <string>Prefer Offline Layers</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="0">
+        <widget class="QRadioButton" name="preferOnlineLayersRadioButton_2">
+         <property name="text">
+          <string>Prefer Online Layers</string>
+         </property>
+         <property name="checked">
+          <bool>true</bool>
          </property>
         </widget>
        </item>
       </layout>
      </widget>
-     <widget class="QWidget" name="photoNamingTab">
+     <widget class="QWidget" name="cableExportTab">
       <attribute name="title">
-       <string>Photo Naming</string>
+       <string>Cable Export</string>
       </attribute>
-      <layout class="QVBoxLayout" name="photoNamingLayout"/>
+      <layout class="QGridLayout" name="gridLayout_6"/>
      </widget>
     </widget>
    </item>
-   <item row="0" column="0">
-    <widget class="QGroupBox" name="groupBox">
+   <item>
+    <widget class="QgsCollapsibleGroupBox" name="createBaseMapGroupBox">
      <property name="title">
-      <string>Layers</string>
+      <string>Base Map</string>
      </property>
-     <layout class="QGridLayout" name="gridLayout_2">
-      <property name="leftMargin">
-       <number>0</number>
-      </property>
-      <property name="topMargin">
-       <number>0</number>
-      </property>
-      <property name="rightMargin">
-       <number>0</number>
-      </property>
-      <property name="bottomMargin">
-       <number>0</number>
-      </property>
-      <item row="1" column="1">
-       <widget class="QToolButton" name="multipleToggleButton">
-        <property name="toolTip">
-         <string>Toggle layers</string>
-        </property>
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+     <property name="saveCheckedState">
+      <bool>true</bool>
+     </property>
+     <layout class="QGridLayout" name="gridLayout">
+      <item row="0" column="0">
+       <widget class="QRadioButton" name="singleLayerRadioButton">
         <property name="text">
-         <string/>
+         <string>Single Layer</string>
         </property>
-        <property name="icon">
-         <iconset>
-          <normaloff>../resources/visibility.svg</normaloff>../resources/visibility.svg</iconset>
-        </property>
-        <property name="popupMode">
-         <enum>QToolButton::InstantPopup</enum>
-        </property>
-        <property name="autoRaise">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <spacer name="horizontalSpacer">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>40</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item row="2" column="0" colspan="2">
-       <widget class="QTableWidget" name="layersTable">
-        <attribute name="horizontalHeaderStretchLastSection">
-         <bool>true</bool>
+        <attribute name="buttonGroup">
+         <string notr="true">buttonGroup</string>
         </attribute>
-        <column>
-         <property name="text">
-          <string>Layer</string>
-         </property>
-        </column>
-        <column>
-         <property name="text">
-          <string>Lock Geometries</string>
-         </property>
-         <property name="toolTip">
-          <string>When enabled, this option disables adding and deleting features, as well as modifying the geometries of existing features.</string>
-         </property>
-        </column>
-        <column>
-         <property name="text">
-          <string>Action</string>
-         </property>
-        </column>
        </widget>
       </item>
-      <item row="3" column="0" colspan="2">
-       <widget class="QLabel" name="unsupportedLayersLabel">
+      <item row="1" column="0" colspan="2">
+       <widget class="QStackedWidget" name="baseMapTypeStack">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="inputMethodHints">
+         <set>Qt::ImhDialableCharactersOnly</set>
+        </property>
+        <widget class="QWidget" name="mapThemePage">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <layout class="QFormLayout" name="formLayout_2">
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
+           <number>0</number>
+          </property>
+          <item row="0" column="0">
+           <widget class="QLabel" name="label">
+            <property name="text">
+             <string>Map Theme</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QComboBox" name="mapThemeComboBox"/>
+          </item>
+         </layout>
+        </widget>
+        <widget class="QWidget" name="singleLayerPage">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <layout class="QFormLayout" name="formLayout">
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
+           <number>0</number>
+          </property>
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_2">
+            <property name="text">
+             <string>Layer</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QgsMapLayerComboBox" name="layerComboBox"/>
+          </item>
+         </layout>
+        </widget>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QLineEdit" name="tileSize">
+        <property name="toolTip">
+         <string>Rendering will happen in tiles. This number determines the width and height (in pixels) that will be rendered per tile.</string>
+        </property>
+        <property name="inputMethodHints">
+         <set>Qt::ImhDigitsOnly</set>
+        </property>
         <property name="text">
-         <string></string>
+         <string>1024</string>
         </property>
-        <property name="visible">
-         <bool>false</bool>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="QLineEdit" name="mapUnitsPerPixel">
+        <property name="toolTip">
+         <string>This determines the spatial resolution of the resulting map image. It depends on the CRS of the map canvas. For map units in [m], a value of 1 means each pixel covers an area of 1x1 m, a value of 1000 means 1 pixel per square kilometer.</string>
         </property>
-        <property name="textFormat">
-         <enum>Qt::RichText</enum>
+        <property name="inputMethodHints">
+         <set>Qt::ImhFormattedNumbersOnly</set>
         </property>
-        <property name="wordWrap">
-         <bool>true</bool>
+        <property name="text">
+         <string>100</string>
         </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="mapUnitsPerPixelLabel">
+        <property name="text">
+         <string>Map Units per Pixel</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="tileSizeLabel">
+        <property name="text">
+         <string>Tile Size</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QRadioButton" name="mapThemeRadioButton">
+        <property name="text">
+         <string>Map Theme</string>
+        </property>
+        <attribute name="buttonGroup">
+         <string notr="true">buttonGroup</string>
+        </attribute>
        </widget>
       </item>
      </layout>
     </widget>
    </item>
+   <item>
+    <widget class="QgsCollapsibleGroupBox" name="photoNamingGroup">
+     <property name="title">
+      <string>Photo Naming</string>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout"/>
+    </widget>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="onlyOfflineCopyFeaturesInAoi">
+     <property name="text">
+      <string>Only Copy Features in Area of Interest</string>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
  <customwidgets>
+  <customwidget>
+   <class>QgsCollapsibleGroupBox</class>
+   <extends>QGroupBox</extends>
+   <header>qgscollapsiblegroupbox.h</header>
+   <container>1</container>
+  </customwidget>
   <customwidget>
    <class>QgsMapLayerComboBox</class>
    <extends>QComboBox</extends>
@@ -296,6 +281,7 @@
   </customwidget>
  </customwidgets>
  <resources/>
+ <connections/>
  <buttongroups>
   <buttongroup name="buttonGroup"/>
  </buttongroups>

--- a/qfieldsync/ui/project_configuration_widget.ui
+++ b/qfieldsync/ui/project_configuration_widget.ui
@@ -23,7 +23,7 @@
    <item>
     <widget class="QTabWidget" name="exportTypeTabs">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
+      <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
@@ -251,19 +251,24 @@
     </widget>
    </item>
    <item>
-    <widget class="QgsCollapsibleGroupBox" name="photoNamingGroup">
-     <property name="title">
-      <string>Photo Naming</string>
-     </property>
-     <layout class="QHBoxLayout" name="horizontalLayout"/>
-    </widget>
-   </item>
-   <item>
     <widget class="QCheckBox" name="onlyOfflineCopyFeaturesInAoi">
      <property name="text">
       <string>Only Copy Features in Area of Interest</string>
      </property>
     </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
    </item>
   </layout>
  </widget>

--- a/qfieldsync/ui/project_configuration_widget.ui
+++ b/qfieldsync/ui/project_configuration_widget.ui
@@ -22,42 +22,21 @@
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <widget class="QTabWidget" name="exportTypeTabs">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
      <property name="currentIndex">
       <number>0</number>
      </property>
      <widget class="QWidget" name="cloudExportTab">
-      <property name="sizePolicy">
-       <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-        <horstretch>0</horstretch>
-        <verstretch>0</verstretch>
-       </sizepolicy>
-      </property>
       <attribute name="title">
        <string>QFieldCloud</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout_2">
-       <property name="sizeConstraint">
-        <enum>QLayout::SetMinAndMaxSize</enum>
-       </property>
        <item row="3" column="0" colspan="2">
         <widget class="QgsCollapsibleGroupBox" name="cloudAdvancedSettings">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
          <property name="title">
           <string>Advanced Settings</string>
          </property>
          <property name="collapsed">
-          <bool>false</bool>
+          <bool>true</bool>
          </property>
          <property name="saveCheckedState">
           <bool>true</bool>
@@ -73,7 +52,7 @@
         </widget>
        </item>
        <item row="0" column="0">
-        <widget class="QRadioButton" name="preferOnlineLayersRadioButton_2">
+        <widget class="QRadioButton" name="preferOnlineLayersRadioButton">
          <property name="text">
           <string>Prefer Online Layers</string>
          </property>


### PR DESCRIPTION
![Peek 2020-10-14 18-04](https://user-images.githubusercontent.com/2820439/96008759-8d8a0900-0e48-11eb-825f-6ff9db4bbe6e.gif)

More or less the UI I managed to produce is this. Any feedback is welcome, I am not completely happy how it looks. Notable changes:
- now there is `LayerSource.action` and `LayerSource.cloud_action`
- the image naming is moved only in the per layer settings (no more in project settings)
- the "Basemap" configuration is moved out of the tab and it is a checkable box whether to be enabled or not

A note on the "Prefer Off/Online Layers" - it will ignore toggling the layer action, if the layer is already marked as "Remove from Project", it will be annoying if it restarts the action every time.

The last remaining issue is with lock geometry, I need ideas where to move it. It is not kept in sync between the "Cloud" and "Cable" tabs, only the latter is taken. I believe we can remove it from the table and also place it in the Layer Properties dialog only. Ideas?
