### PR TITLE
Don't use layer suffix ` (offline)`

### DIFF
--- a/qfieldsync/core/offline_converter.py
+++ b/qfieldsync/core/offline_converter.py
@@ -201,9 +201,9 @@ class OfflineConverter(QObject):
                     if not self.offline_editing.convertToOfflineProject(self.export_folder, gpkg_filename,
                                                                         offline_layer_ids,
                                                                         only_selected,
-                                                                        self.offline_editing.GPKG):
+                                                                        self.offline_editing.GPKG,
+                                                                        ''):
                         raise Exception(self.tr("Error trying to convert layers to offline layers"))
-
             except AttributeError:
                 # Run the offline plugin for spatialite
                 spatialite_filename = "data.sqlite"
@@ -212,7 +212,9 @@ class OfflineConverter(QObject):
                     only_selected = self.project_configuration.offline_copy_only_aoi or self.project_configuration.offline_copy_only_selected_features
                     if not self.offline_editing.convertToOfflineProject(self.export_folder, spatialite_filename,
                                                                         offline_layer_ids,
-                                                                        only_selected):
+                                                                        only_selected,
+                                                                        self.offline_editing.SpatiaLite,
+                                                                        ''):
                         raise Exception(self.tr("Error trying to convert layers to offline layers"))
 
             # Disable project options that could create problems on a portable

--- a/qfieldsync/core/offline_converter.py
+++ b/qfieldsync/core/offline_converter.py
@@ -202,7 +202,7 @@ class OfflineConverter(QObject):
                                                                         offline_layer_ids,
                                                                         only_selected,
                                                                         self.offline_editing.GPKG,
-                                                                        ''):
+                                                                        None):
                         raise Exception(self.tr("Error trying to convert layers to offline layers"))
             except AttributeError:
                 # Run the offline plugin for spatialite
@@ -214,7 +214,7 @@ class OfflineConverter(QObject):
                                                                         offline_layer_ids,
                                                                         only_selected,
                                                                         self.offline_editing.SpatiaLite,
-                                                                        ''):
+                                                                        None):
                         raise Exception(self.tr("Error trying to convert layers to offline layers"))
 
             # Disable project options that could create problems on a portable

--- a/qfieldsync/core/offline_converter.py
+++ b/qfieldsync/core/offline_converter.py
@@ -37,6 +37,7 @@ from qgis.PyQt.QtWidgets import (
     QMessageBox
 )
 from qgis.core import (
+    Qgis,
     QgsProject,
     QgsRasterLayer,
     QgsCubicRasterResampler,
@@ -198,24 +199,38 @@ class OfflineConverter(QObject):
                 if self.__offline_layers:
                     offline_layer_ids = [l.id() for l in self.__offline_layers]
                     only_selected = self.project_configuration.offline_copy_only_aoi or self.project_configuration.offline_copy_only_selected_features
-                    if not self.offline_editing.convertToOfflineProject(self.export_folder, gpkg_filename,
-                                                                        offline_layer_ids,
-                                                                        only_selected,
-                                                                        self.offline_editing.GPKG,
-                                                                        None):
-                        raise Exception(self.tr("Error trying to convert layers to offline layers"))
+                    if Qgis.QGIS_VERSION_INT < 31601:
+                        if not self.offline_editing.convertToOfflineProject(self.export_folder, gpkg_filename,
+                                                                            offline_layer_ids,
+                                                                            only_selected,
+                                                                            self.offline_editing.GPKG):
+                            raise Exception(self.tr("Error trying to convert layers to offline layers"))
+                    else:
+                        if not self.offline_editing.convertToOfflineProject(self.export_folder, gpkg_filename,
+                                                                            offline_layer_ids,
+                                                                            only_selected,
+                                                                            self.offline_editing.GPKG,
+                                                                            None):
+                            raise Exception(self.tr("Error trying to convert layers to offline layers"))
             except AttributeError:
                 # Run the offline plugin for spatialite
                 spatialite_filename = "data.sqlite"
                 if self.__offline_layers:
                     offline_layer_ids = [l.id() for l in self.__offline_layers]
                     only_selected = self.project_configuration.offline_copy_only_aoi or self.project_configuration.offline_copy_only_selected_features
-                    if not self.offline_editing.convertToOfflineProject(self.export_folder, spatialite_filename,
-                                                                        offline_layer_ids,
-                                                                        only_selected,
-                                                                        self.offline_editing.SpatiaLite,
-                                                                        None):
-                        raise Exception(self.tr("Error trying to convert layers to offline layers"))
+                    if Qgis.QGIS_VERSION_INT < 31601:
+                        if not self.offline_editing.convertToOfflineProject(self.export_folder, spatialite_filename,
+                                                                            offline_layer_ids,
+                                                                            only_selected,
+                                                                            self.offline_editing.SpatiaLite):
+                            raise Exception(self.tr("Error trying to convert layers to offline layers"))
+                    else:
+                        if not self.offline_editing.convertToOfflineProject(self.export_folder, gpkg_filename,
+                                                                            offline_layer_ids,
+                                                                            only_selected,
+                                                                            self.offline_editing.GPKG,
+                                                                            None):
+                            raise Exception(self.tr("Error trying to convert layers to offline layers"))
 
             # Disable project options that could create problems on a portable
             # project with offline layers
@@ -239,28 +254,29 @@ class OfflineConverter(QObject):
                                     'QFieldSync/sourceDataPrimaryKeys',
                                     stored_fields)
 
-                        for field in layer.fields():
-                            ews = field.editorWidgetSetup()
-                            if ews.type() == 'ValueRelation':
-                                widget_config = ews.config()
-                                online_layer_id = widget_config['Layer']
-                                if project.mapLayer(online_layer_id):
-                                    continue
+                        if Qgis.QGIS_VERSION_INT < 31601:
+                            for field in layer.fields():
+                                ews = field.editorWidgetSetup()
+                                if ews.type() == 'ValueRelation':
+                                    widget_config = ews.config()
+                                    online_layer_id = widget_config['Layer']
+                                    if project.mapLayer(online_layer_id):
+                                        continue
 
-                                layer_id = None
-                                loose_layer_id = None
-                                for offline_layer in project.mapLayers().values():
-                                    if offline_layer.customProperty('remoteSource') == original_layer_info[online_layer_id][0]:
-                                        #  First try strict matching: the offline layer should have a "remoteSource" property
-                                        layer_id = offline_layer.id()
-                                        break
-                                    elif offline_layer.name().startswith(original_layer_info[online_layer_id][1] + ' '):
-                                        #  If that did not work, go with loose matching
-                                        #    The offline layer should start with the online layer name + a translated version of " (offline)"
-                                        loose_layer_id = offline_layer.id()
-                                widget_config['Layer'] = layer_id or loose_layer_id
-                                offline_ews = QgsEditorWidgetSetup(ews.type(), widget_config)
-                                layer.setEditorWidgetSetup(layer.fields().indexOf(field.name()), offline_ews)
+                                    layer_id = None
+                                    loose_layer_id = None
+                                    for offline_layer in project.mapLayers().values():
+                                        if offline_layer.customProperty('remoteSource') == original_layer_info[online_layer_id][0]:
+                                            #  First try strict matching: the offline layer should have a "remoteSource" property
+                                            layer_id = offline_layer.id()
+                                            break
+                                        elif offline_layer.name().startswith(original_layer_info[online_layer_id][1] + ' '):
+                                            #  If that did not work, go with loose matching
+                                            #    The offline layer should start with the online layer name + a translated version of " (offline)"
+                                            loose_layer_id = offline_layer.id()
+                                    widget_config['Layer'] = layer_id or loose_layer_id
+                                    offline_ews = QgsEditorWidgetSetup(ews.type(), widget_config)
+                                    layer.setEditorWidgetSetup(layer.fields().indexOf(field.name()), offline_ews)
 
             # Now we have a project state which can be saved as offline project
             QgsProject.instance().write(project_path)

--- a/qfieldsync/core/offline_converter.py
+++ b/qfieldsync/core/offline_converter.py
@@ -225,10 +225,10 @@ class OfflineConverter(QObject):
                                                                             self.offline_editing.SpatiaLite):
                             raise Exception(self.tr("Error trying to convert layers to offline layers"))
                     else:
-                        if not self.offline_editing.convertToOfflineProject(self.export_folder, gpkg_filename,
+                        if not self.offline_editing.convertToOfflineProject(self.export_folder, spatialite_filename,
                                                                             offline_layer_ids,
                                                                             only_selected,
-                                                                            self.offline_editing.GPKG,
+                                                                            self.offline_editing.SpatiaLite,
                                                                             None):
                             raise Exception(self.tr("Error trying to convert layers to offline layers"))
 

--- a/qfieldsync/tests/test_export.py
+++ b/qfieldsync/tests/test_export.py
@@ -25,7 +25,7 @@ import tempfile
 
 from qfieldsync.core.offline_converter import OfflineConverter
 from qfieldsync.tests.utilities import test_data_folder
-from qgis.core import QgsProject, QgsRectangle, QgsOfflineEditing
+from qgis.core import Qgis, QgsProject, QgsRectangle, QgsOfflineEditing
 from qgis.testing import start_app, unittest
 from qgis.testing.mocked import get_iface
 
@@ -93,7 +93,10 @@ class OfflineConverterTest(unittest.TestCase):
         offline_converter.convert()
 
         exported_project = self.load_project(os.path.join(export_folder, 'project_qfield.qgs'))
-        layer = exported_project.mapLayersByName('somedata (offline)')[0]
+        if Qgis.QGIS_VERSION_INT < 31601:
+            layer = exported_project.mapLayersByName('somedata (offline)')[0]
+        else:
+            layer = exported_project.mapLayersByName('somedata')[0]
         self.assertEqual(layer.customProperty('QFieldSync/sourceDataPrimaryKeys'), 'pk')
 
         shutil.rmtree(export_folder)


### PR DESCRIPTION
Since this https://github.com/qgis/QGIS/pull/39492 the suffix ` (offline)` can be avoided to avoid issues with expressions etc.

So let's don't use it anymore.