### PR TITLE
Don't overexpand the photo naming table horizontally

### DIFF
--- a/qfieldsync/gui/photo_naming_widget.py
+++ b/qfieldsync/gui/photo_naming_widget.py
@@ -39,7 +39,6 @@ class PhotoNamingTableWidget(QTableWidget):
         self.setRowCount(0)
         self.resizeColumnsToContents()
         self.setMinimumHeight(100)
-        self.setSizeAdjustPolicy(QAbstractScrollArea.AdjustToContents)
 
 
     def addLayerFields(self, layer_source):


### PR DESCRIPTION
Fixes #198 