### PR TITLE
Read baseName from project instance instead of filename

### DIFF
--- a/qfieldsync/core/offline_converter.py
+++ b/qfieldsync/core/offline_converter.py
@@ -89,7 +89,7 @@ class OfflineConverter(QObject):
         original_project = project
 
         original_project_path = project.fileName()
-        project_filename, _ = os.path.splitext(os.path.basename(original_project_path))
+        project_filename = project.baseName()
 
         # Write a backup of the current project to a temporary file
         project_backup_folder = tempfile.mkdtemp()


### PR DESCRIPTION
Current implementation results in a destination filename:
*connection string_qfield.qgs*
in case of a postgres stored project.