### PR TITLE
qgis:rasterize processing tool changed it's parameters from QGIS 3.10 to QGIS 3.16

### DIFF
--- a/qfieldsync/core/offline_converter.py
+++ b/qfieldsync/core/offline_converter.py
@@ -310,10 +310,13 @@ class OfflineConverter(QObject):
                                              self.extent.yMaximum())
 
         alg = QgsApplication.instance().processingRegistry().createAlgorithmById('qgis:rasterize')
-
+        
+        # passing the LAYER and LAYERS parameters since QGIS 3.10 uses the LAYER parameter and 3.16+ uses the LAYERS parameter instead
+        # keeping both ensures backward compatibility
         params = {
             'EXTENT': extent_string,
             'MAP_THEME': map_theme,
+            'LAYER': layer,
             'LAYERS': [layer],
             'MAP_UNITS_PER_PIXEL': map_units_per_pixel,
             'TILE_SIZE': tile_size,

--- a/qfieldsync/core/offline_converter.py
+++ b/qfieldsync/core/offline_converter.py
@@ -314,7 +314,7 @@ class OfflineConverter(QObject):
         params = {
             'EXTENT': extent_string,
             'MAP_THEME': map_theme,
-            'LAYER': layer,
+            'LAYERS': [layer],
             'MAP_UNITS_PER_PIXEL': map_units_per_pixel,
             'TILE_SIZE': tile_size,
             'MAKE_BACKGROUND_TRANSPARENT': False,


### PR DESCRIPTION
From QGIS 3.10 to QGIS 3.16, the qgis:rasterize processing tool changed it's parameters, specifically the "LAYER" parameter does not exist anymore, and has been replaced by the "LAYERS" parameter, expecting a list. This change fixes the QGIS 3.16 compatibility problem.

The symptom is that the raster created still exists, but instead of containing only one layer (normally the map layer) it contains by default all visible layers, therefore rasterizing not only the basemap but also the vectorial objects into it.

This change fixes the bug and makes the Qpackage compatible with QGIS 3.16 which is now the "long term stable" version.