### PR TITLE
Add QGIS 3.16 LTR in the test matrix

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        qgis_version: [release_3_10, release_3_16, latest]
+        qgis_version: [release-3_10, release-3_16, latest]
     env:
       QGIS_TEST_VERSION: ${{ matrix.qgis_version }}
     steps:

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        qgis_version: [final-3_10_9, latest]
+        qgis_version: [release_3_10, release_3_16, latest]
     env:
       QGIS_TEST_VERSION: ${{ matrix.qgis_version }}
     steps:


### PR DESCRIPTION
Turns out QGIS no longer produces `final_3_XX_XX` docker tags, so I also switched to `release_3_10`.