### PR TITLE
Improvements to project properties panel

### DIFF
--- a/qfieldsync/gui/layers_config_widget.py
+++ b/qfieldsync/gui/layers_config_widget.py
@@ -25,7 +25,7 @@ from typing import Callable
 from PyQt5.QtWidgets import QPushButton
 from PyQt5.uic import properties
 
-from qgis.core import Qgis, QgsProject
+from qgis.core import Qgis, QgsProject, QgsMapLayerModel
 
 from qgis.utils import iface
 from qgis.PyQt.uic import loadUiType
@@ -106,6 +106,7 @@ class LayersConfigWidget(QWidget, LayersConfigWidgetUi):
             item = QTableWidgetItem(layer_source.layer.name())
             item.setData(Qt.UserRole, layer_source)
             item.setData(Qt.EditRole, layer_source.layer.name())
+            item.setIcon(QgsMapLayerModel.iconForLayer(layer_source.layer))
             self.layersTable.setItem(count, 0, item)
 
             cmb = QComboBox()

--- a/qfieldsync/gui/map_layer_config_widget.py
+++ b/qfieldsync/gui/map_layer_config_widget.py
@@ -69,7 +69,7 @@ class MapLayerConfigWidget(QgsMapLayerConfigWidget, WidgetUi):
         
         # insert the table as a second row only for vector layers
         if Qgis.QGIS_VERSION_INT >= 31300 and layer.type() == QgsMapLayer.VectorLayer:
-            self.layout().insertRow(2, self.tr('Photo Naming'), self.photoNamingTable)
+            self.layout().insertRow(2, self.tr('Photo naming'), self.photoNamingTable)
             self.photoNamingTable.setEnabled(self.photoNamingTable.rowCount() > 0)
 
 

--- a/qfieldsync/gui/project_configuration_widget.py
+++ b/qfieldsync/gui/project_configuration_widget.py
@@ -97,8 +97,8 @@ class ProjectConfigurationWidget(WidgetUi, QgsOptionsPageWidget):
             self.mapThemeComboBox.findText(self.__project_configuration.base_map_theme))
         layer = QgsProject.instance().mapLayer(self.__project_configuration.base_map_layer)
         self.layerComboBox.setLayer(layer)
-        self.mapUnitsPerPixel.setText(str(self.__project_configuration.base_map_mupp))
-        self.tileSize.setText(str(self.__project_configuration.base_map_tile_size))
+        self.mapUnitsPerPixel.setValue(self.__project_configuration.base_map_mupp)
+        self.tileSize.setValue(self.__project_configuration.base_map_tile_size)
         self.onlyOfflineCopyFeaturesInAoi.setChecked(self.__project_configuration.offline_copy_only_aoi)
         self.preferOnlineLayersRadioButton.setChecked(self.__project_configuration.layer_action_preference == 'online')
         self.preferOfflineLayersRadioButton.setChecked(self.__project_configuration.layer_action_preference == 'offline')
@@ -130,8 +130,8 @@ class ProjectConfigurationWidget(WidgetUi, QgsOptionsPageWidget):
         else:
             self.__project_configuration.base_map_type = ProjectProperties.BaseMapType.MAP_THEME
 
-        self.__project_configuration.base_map_mupp = float(self.mapUnitsPerPixel.text())
-        self.__project_configuration.base_map_tile_size = int(self.tileSize.text())
+        self.__project_configuration.base_map_mupp = float(self.mapUnitsPerPixel.value())
+        self.__project_configuration.base_map_tile_size = self.tileSize.value()
 
         self.__project_configuration.offline_copy_only_aoi = self.onlyOfflineCopyFeaturesInAoi.isChecked()
         self.__project_configuration.layer_action_preference = 'online' if self.preferOnlineLayersRadioButton.isChecked() else 'offline'

--- a/qfieldsync/ui/map_layer_config_widget.ui
+++ b/qfieldsync/ui/map_layer_config_widget.ui
@@ -27,14 +27,14 @@
    <item row="0" column="0">
     <widget class="QLabel" name="cloudLayerActionLabel">
      <property name="text">
-      <string>Cloud Layer Action</string>
+      <string>Cloud layer action</string>
      </property>
     </widget>
    </item>
    <item row="1" column="0">
     <widget class="QLabel" name="cableLayerActionLabel">
      <property name="text">
-      <string>Cable Layer Action</string>
+      <string>Cable layer action</string>
      </property>
     </widget>
    </item>
@@ -44,7 +44,7 @@
       <string>When enabled, this option disables adding and deleting features, as well as modifying the geometries of existing features.</string>
      </property>
      <property name="text">
-      <string>Lock Geometries</string>
+      <string>Lock geometries</string>
      </property>
     </widget>
    </item>

--- a/qfieldsync/ui/project_configuration_widget.ui
+++ b/qfieldsync/ui/project_configuration_widget.ui
@@ -63,7 +63,7 @@
        <item row="3" column="0" colspan="3">
         <widget class="QgsCollapsibleGroupBox" name="cloudAdvancedSettings">
          <property name="title">
-          <string>Advanced Settings</string>
+          <string>Individual Layers Settings</string>
          </property>
          <property name="collapsed">
           <bool>true</bool>
@@ -243,9 +243,18 @@
     </widget>
    </item>
    <item>
-    <widget class="QGroupBox" name="groupBox">
+    <widget class="QgsCollapsibleGroupBox" name="groupBox">
      <property name="title">
       <string>Advanced Settings</string>
+     </property>
+     <property name="checkable">
+      <bool>false</bool>
+     </property>
+     <property name="collapsed">
+      <bool>true</bool>
+     </property>
+     <property name="saveCollapsedState">
+      <bool>true</bool>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_2">
       <item>

--- a/qfieldsync/ui/project_configuration_widget.ui
+++ b/qfieldsync/ui/project_configuration_widget.ui
@@ -109,7 +109,7 @@
       <item row="1" column="0" colspan="2">
        <widget class="QStackedWidget" name="baseMapTypeStack">
         <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
           <horstretch>0</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
@@ -119,7 +119,7 @@
         </property>
         <widget class="QWidget" name="mapThemePage">
          <property name="sizePolicy">
-          <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
+          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>
@@ -151,7 +151,7 @@
         </widget>
         <widget class="QWidget" name="singleLayerPage">
          <property name="sizePolicy">
-          <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
+          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>
@@ -185,6 +185,12 @@
       </item>
       <item row="2" column="1">
        <widget class="QgsSpinBox" name="tileSize">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
         <property name="toolTip">
          <string>Rendering will happen in tiles. This number determines the width and height (in pixels) that will be rendered per tile.</string>
         </property>
@@ -204,6 +210,12 @@
       </item>
       <item row="3" column="1">
        <widget class="QgsDoubleSpinBox" name="mapUnitsPerPixel">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
         <property name="toolTip">
          <string>This determines the spatial resolution of the resulting map image. It depends on the CRS of the map canvas. For map units in [m], a value of 1 means each pixel covers an area of 1x1 m, a value of 1000 means 1 pixel per square kilometer.</string>
         </property>

--- a/qfieldsync/ui/project_configuration_widget.ui
+++ b/qfieldsync/ui/project_configuration_widget.ui
@@ -184,35 +184,41 @@
        </widget>
       </item>
       <item row="2" column="1">
-       <widget class="QLineEdit" name="tileSize">
+       <widget class="QgsSpinBox" name="tileSize">
         <property name="toolTip">
          <string>Rendering will happen in tiles. This number determines the width and height (in pixels) that will be rendered per tile.</string>
         </property>
-        <property name="inputMethodHints">
-         <set>Qt::ImhDigitsOnly</set>
+        <property name="suffix">
+         <string> px</string>
         </property>
-        <property name="text">
-         <string>1024</string>
+        <property name="minimum">
+         <number>1</number>
+        </property>
+        <property name="maximum">
+         <number>10240</number>
+        </property>
+        <property name="value">
+         <number>1024</number>
         </property>
        </widget>
       </item>
       <item row="3" column="1">
-       <widget class="QLineEdit" name="mapUnitsPerPixel">
+       <widget class="QgsDoubleSpinBox" name="mapUnitsPerPixel">
         <property name="toolTip">
          <string>This determines the spatial resolution of the resulting map image. It depends on the CRS of the map canvas. For map units in [m], a value of 1 means each pixel covers an area of 1x1 m, a value of 1000 means 1 pixel per square kilometer.</string>
         </property>
-        <property name="inputMethodHints">
-         <set>Qt::ImhFormattedNumbersOnly</set>
+        <property name="suffix">
+         <string> mupp</string>
         </property>
-        <property name="text">
-         <string>100</string>
+        <property name="value">
+         <string>100.0</string>
         </property>
        </widget>
       </item>
       <item row="3" column="0">
        <widget class="QLabel" name="mapUnitsPerPixelLabel">
         <property name="text">
-         <string>Map Units per Pixel</string>
+         <string>Map units per pixel</string>
         </property>
         <property name="alignment">
          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -222,7 +228,7 @@
       <item row="2" column="0">
        <widget class="QLabel" name="tileSizeLabel">
         <property name="text">
-         <string>Tile Size</string>
+         <string>Tile size</string>
         </property>
         <property name="alignment">
          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -293,6 +299,16 @@
    <class>QgsMapLayerComboBox</class>
    <extends>QComboBox</extends>
    <header>qgsmaplayercombobox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>qgsspinbox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>qgsdoublespinbox.h</header>
   </customwidget>
  </customwidgets>
  <resources/>


### PR DESCRIPTION
Screenshot:
![image](https://user-images.githubusercontent.com/1728657/118356832-4b24d800-b5a1-11eb-8630-17ef476acc6a.png)

Improvements include:
- layer icons in the table widget to easily identify layer type (helps skip through the list)
- use proper spinners for numbers, add suffixes
- avoid double "advanced settings" group box, make the bottom advanced settings collapsible
- better placement / stretch / spacing of widgets all around
