### PR TITLE
Add UI to pick a digitizing logs layer

### DIFF
--- a/qfieldsync/gui/project_configuration_widget.py
+++ b/qfieldsync/gui/project_configuration_widget.py
@@ -84,7 +84,7 @@ class ProjectConfigurationWidget(WidgetUi, QgsOptionsPageWidget):
             )
 
         self.advancedSettingsGroupBox.layout().addWidget(
-            self.areaOfInterestExtentWidget, 0, 1
+            self.areaOfInterestExtentWidget, 1, 1
         )
 
         self.preferOnlineLayersRadioButton.clicked.connect(
@@ -129,6 +129,8 @@ class ProjectConfigurationWidget(WidgetUi, QgsOptionsPageWidget):
             self.mapThemeComboBox.addItem(theme)
 
         self.layerComboBox.setFilters(QgsMapLayerProxyModel.RasterLayer)
+        self.digitizingLogsLayerComboBox.setFilters(QgsMapLayerProxyModel.PointLayer)
+        self.digitizingLogsLayerComboBox.setAllowEmptyLayer(True)
 
         self.__project_configuration = ProjectConfiguration(self.project)
         self.createBaseMapGroupBox.setChecked(
@@ -146,10 +148,17 @@ class ProjectConfigurationWidget(WidgetUi, QgsOptionsPageWidget):
         self.mapThemeComboBox.setCurrentIndex(
             self.mapThemeComboBox.findText(self.__project_configuration.base_map_theme)
         )
+
         layer = QgsProject.instance().mapLayer(
             self.__project_configuration.base_map_layer
         )
         self.layerComboBox.setLayer(layer)
+
+        digitizingLogsLayer = QgsProject.instance().mapLayer(
+            self.__project_configuration.digitizing_logs_layer
+        )
+        self.digitizingLogsLayerComboBox.setLayer(digitizingLogsLayer)
+
         self.mapUnitsPerPixel.setValue(self.__project_configuration.base_map_mupp)
         self.tileSize.setValue(self.__project_configuration.base_map_tile_size)
         self.onlyOfflineCopyFeaturesInAoi.setChecked(
@@ -190,6 +199,14 @@ class ProjectConfigurationWidget(WidgetUi, QgsOptionsPageWidget):
         try:
             self.__project_configuration.base_map_layer = (
                 self.layerComboBox.currentLayer().id()
+            )
+        except AttributeError:
+            pass
+        try:
+            self.__project_configuration.digitizing_logs_layer = (
+                self.digitizingLogsLayerComboBox.currentLayer().id()
+                if self.digitizingLogsLayerComboBox.currentLayer()
+                else ""
             )
         except AttributeError:
             pass

--- a/qfieldsync/ui/project_configuration_widget.ui
+++ b/qfieldsync/ui/project_configuration_widget.ui
@@ -38,7 +38,7 @@
       <item row="0" column="0">
       <widget class="QLabel" name="labelDigitizingLogsLayer">
       <property name="text">
-       <string>Digitizing Logs Layer</string>
+       <string>Digitizing logs layer</string>
       </property>
       <property name="alignment">
        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>

--- a/qfieldsync/ui/project_configuration_widget.ui
+++ b/qfieldsync/ui/project_configuration_widget.ui
@@ -36,6 +36,19 @@
      </property>
      <layout class="QGridLayout" name="gridLayout_8" columnstretch="1,3">
       <item row="0" column="0">
+      <widget class="QLabel" name="labelDigitizingLogsLayer">
+      <property name="text">
+       <string>Digitizing Logs Layer</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+      </property>
+      </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QgsMapLayerComboBox" name="digitizingLogsLayerComboBox"/>
+      </item>
+      <item row="1" column="0">
        <widget class="QLabel" name="areaOfInterestLabel">
         <property name="text">
          <string>Area of interest</string>
@@ -45,7 +58,7 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="1">
+      <item row="2" column="1">
        <widget class="QCheckBox" name="onlyOfflineCopyFeaturesInAoi">
         <property name="text">
          <string>Only copy features in area of interest</string>


### PR DESCRIPTION
A new digitizing logs layer combo box was added in the project properties' QField panel:
![image](https://user-images.githubusercontent.com/1728657/121330835-8fa55880-c940-11eb-9e81-ba5867ce47f7.png)

This is to accompany the new feature being developed for QField 2.0, see https://github.com/opengisch/QField/pull/1971