### PR TITLE
Kill pyqt slots for QGIS 3.20

### DIFF
--- a/qfieldsync/core/offline_converter.py
+++ b/qfieldsync/core/offline_converter.py
@@ -29,7 +29,6 @@ from qgis.PyQt.QtCore import (
     Qt,
     QObject,
     pyqtSignal,
-    pyqtSlot,
     QCoreApplication
 )
 from qgis.PyQt.QtWidgets import (
@@ -378,16 +377,13 @@ class OfflineConverter(QObject):
         layer_tree = QgsProject.instance().layerTreeRoot()
         layer_tree.insertLayer(len(layer_tree.children()), new_layer)
 
-    @pyqtSlot(int, int)
     def on_offline_editing_next_layer(self, layer_index, layer_count):
         msg = self.trUtf8('Packaging layer {layer_name}…').format(layer_name=self.__offline_layer_names[layer_index - 1])
         self.total_progress_updated.emit(layer_index, layer_count, msg)
 
-    @pyqtSlot('QgsOfflineEditing::ProgressMode', int)
     def on_offline_editing_max_changed(self, _, mode_count):
         self.__max_task_progress = mode_count
 
-    @pyqtSlot(int)
     def offline_editing_task_progress(self, progress):
         self.task_progress_updated.emit(progress, self.__max_task_progress)
 

--- a/qfieldsync/gui/package_dialog.py
+++ b/qfieldsync/gui/package_dialog.py
@@ -29,7 +29,6 @@ from qfieldsync.core import (
 )
 from qfieldsync.gui.project_configuration_dialog import ProjectConfigurationDialog
 from qgis.PyQt.QtCore import (
-    pyqtSlot,
     Qt
 )
 from qgis.PyQt.QtGui import (
@@ -185,18 +184,15 @@ class PackageDialog(QDialog, DialogUi):
             dlg.exec_()
         self.update_info_visibility()
 
-    @pyqtSlot(int, int, str)
     def update_total(self, current, layer_count, message):
         self.totalProgressBar.setMaximum(layer_count)
         self.totalProgressBar.setValue(current)
         self.statusLabel.setText(message)
 
-    @pyqtSlot(int, int)
     def update_task(self, progress, max_progress):
         self.layerProgressBar.setMaximum(max_progress)
         self.layerProgressBar.setValue(progress)
 
-    @pyqtSlot()
     def extent_changed(self):
         extent = self.iface.mapCanvas().extent()
         self.xMinLabel.setText(str(extent.xMinimum()))
@@ -204,7 +200,6 @@ class PackageDialog(QDialog, DialogUi):
         self.yMinLabel.setText(str(extent.yMinimum()))
         self.yMaxLabel.setText(str(extent.yMaximum()))
 
-    @pyqtSlot(str, str)
     def show_warning(self, _, message):
         # Most messages from the offline editing plugin are not important enough to show in the message bar.
         # In case we find important ones in the future, we need to filter them.

--- a/qfieldsync/gui/synchronize_dialog.py
+++ b/qfieldsync/gui/synchronize_dialog.py
@@ -21,7 +21,6 @@
  ***************************************************************************/
 """
 import os
-from qgis.PyQt.QtCore import pyqtSlot
 from qgis.PyQt.QtWidgets import (
     QDialog,
     QDialogButtonBox,
@@ -98,21 +97,17 @@ class SynchronizeDialog(QDialog, DialogUi):
         except NoProjectFoundError as e:
             self.iface.messageBar().pushWarning('QFieldSync', str(e))
 
-    @pyqtSlot(int, int)
     def update_total(self, current, layer_count):
         self.totalProgressBar.setMaximum(layer_count)
         self.totalProgressBar.setValue(current)
 
-    @pyqtSlot(int)
     def update_value(self, progress):
         self.layerProgressBar.setValue(progress)
 
-    @pyqtSlot('QgsOfflineEditing::ProgressMode', int)
     def update_mode(self, _, mode_count):
         self.layerProgressBar.setMaximum(mode_count)
         self.layerProgressBar.setValue(0)
 
-    @pyqtSlot()
     def update_done(self):
         self.offline_editing.progressStopped.disconnect(self.update_done)
         self.offline_editing.layerProgressUpdated.disconnect(self.update_total)


### PR DESCRIPTION
Still not sure why the slots no longer work in 3.20, but they are not needed anyways.

Fixes https://github.com/opengisch/qfieldsync/issues/256
