### PR TITLE
Improve synchornizing of cloud projects missing a local directory

### DIFF
--- a/qfieldsync/gui/cloud_browser_tree.py
+++ b/qfieldsync/gui/cloud_browser_tree.py
@@ -264,7 +264,6 @@ class QFieldCloudItemGuiProvider(QgsDataItemGuiProvider):
             project_file_name = glob.glob(
                 os.path.join(project.local_dir, "*.qgs")
             ) + glob.glob(os.path.join(project.local_dir, "*.qgz"))
-            print(project_file_name)
             if project_file_name:
                 iface.addProject(os.path.join(project.local_dir, project_file_name[0]))
                 return True

--- a/qfieldsync/gui/cloud_projects_dialog.py
+++ b/qfieldsync/gui/cloud_projects_dialog.py
@@ -734,15 +734,6 @@ class CloudProjectsDialog(QDialog, CloudProjectsDialogUi):
 
     def sync(self) -> None:
         assert self.current_cloud_project is not None
-
-        if not self.current_cloud_project.local_dir:
-            self.current_cloud_project.update_data(
-                {"local_dir": self.select_local_dir()}
-            )
-
-        if not self.current_cloud_project.local_dir:
-            return
-
         self.show_sync_popup()
 
     def launch(self) -> None:
@@ -1149,9 +1140,6 @@ class CloudProjectsDialog(QDialog, CloudProjectsDialogUi):
 
     def show_sync_popup(self) -> None:
         assert self.current_cloud_project is not None, "No project to download selected"
-        assert (
-            self.current_cloud_project.local_dir
-        ), "Cannot download a project without `local_dir` properly set"
 
         self.transfer_dialog = CloudTransferDialog(
             self.network_manager, self.current_cloud_project, self

--- a/qfieldsync/qfield_sync.py
+++ b/qfieldsync/qfield_sync.py
@@ -407,11 +407,6 @@ class QFieldSync(object):
                 None,
                 self.iface.mainWindow(),
             )
-            self.transfer_dialog.project_synchronized.connect(
-                lambda: QgsProject.instance().read(
-                    QgsProject.instance().absoluteFilePath()
-                )
-            )
             self.transfer_dialog.show()
 
     def show_package_dialog(self):

--- a/qfieldsync/ui/cloud_transfer_dialog.ui
+++ b/qfieldsync/ui/cloud_transfer_dialog.ui
@@ -19,6 +19,66 @@
      <property name="currentIndex">
       <number>1</number>
      </property>
+     <widget class="QWidget" name="setProjectLocalDirPage">
+      <layout class="QVBoxLayout" name="verticalLayout_3">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="QLabel" name="projectFilesLabel">
+         <property name="text">
+          <string>Please provider a folder within which a local copy of the QFieldCloud project will be stored.</string>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <layout class="QGridLayout" name="gridLayout">
+         <item row="0" column="0">
+          <widget class="QLabel" name="mLocalDirLbl">
+           <property name="text">
+            <string>Local directory</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QLineEdit" name="mLocalDir"/>
+         </item>
+         <item row="0" column="2">
+          <widget class="QPushButton" name="mLocalDirBtn">
+           <property name="text">
+            <string>...</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_1">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
      <widget class="QWidget" name="getProjectFilesPage">
       <layout class="QVBoxLayout" name="verticalLayout_3">
        <property name="leftMargin">
@@ -54,9 +114,38 @@
         </widget>
        </item>
        <item>
-        <widget class="QLabel" name="projectFilesSynchronizedLabel">
+        <spacer name="verticalSpacer_2">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="endPage">
+      <layout class="QVBoxLayout" name="verticalLayout_2">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="QLabel" name="feedbackLabel">
          <property name="text">
-          <string>The locally stored cloud project is already synchronized with QFieldCloud, no action is required.</string>
+          <string>...</string>
          </property>
          <property name="wordWrap">
           <bool>true</bool>
@@ -64,7 +153,17 @@
         </widget>
        </item>
        <item>
-        <spacer name="verticalSpacer">
+        <widget class="QCheckBox" name="openProjectCheck">
+         <property name="text">
+          <string>Open project after closing this dialog</string>
+         </property>
+         <property name="checked">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_3">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
          </property>
@@ -95,7 +194,7 @@
        <item>
         <widget class="QLabel" name="messageLabel">
          <property name="text">
-          <string>Please wait while project is being synchornized…</string>
+          <string>Please wait while project is being synchronized…</string>
          </property>
          <property name="wordWrap">
           <bool>true</bool>
@@ -174,7 +273,7 @@
         </widget>
        </item>
        <item>
-        <spacer name="verticalSpacer">
+        <spacer name="verticalSpacer_4">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
          </property>


### PR DESCRIPTION
This is the last bit of UI/UX improvement I had on my to-do list for qfieldsync's QFieldCloud support.

This IMHO greatly improves the first-time download/synchronization of a cloud project that hasn't had a local directory set up yet. The changes include:
- Instead of being thrown a directory picker dialog out of nowhere, the synchronization dialog informs the user of what's happening
- To ease the process, a default local directory is provided (derived from the cloud project name and the default cloud directory set in the user preferences)
- Instead of being shown the intimidating file tree widget on first synchronization, proceed with downloading all files directly
- At the end of a successful download/synchronization, the user is provided with a useful checkbox to automatically load the downloaded/sync'ed project after closing the dialog.

This is how the UI/UX now looks like when downloading a cloud project from the QFieldCloud server:
![Peek 2021-07-29 11-59](https://user-images.githubusercontent.com/1728657/127434448-ee929727-c766-4f35-bb3b-8a506dcefcbf.gif)

I think with that in, we've just made opening new server-stored cloud projects much, _much_ easier.

(@suricactus , this fixes the stracktrace thrown in the browser panel)