### PR TITLE
Improve browser panel cloud project item's double click action

### DIFF
--- a/qfieldsync/gui/cloud_browser_tree.py
+++ b/qfieldsync/gui/cloud_browser_tree.py
@@ -242,7 +242,7 @@ class QFieldCloudItemGuiProvider(QgsDataItemGuiProvider):
     def handleDoubleClick(self, item, context):
         if type(item) is QFieldCloudProjectItem:
             if not self.open_project(item):
-                self._create_projects_dialog(item).show_project_form()
+                self.show_cloud_synchronize_dialog(item)
             return True
         return False
 


### PR DESCRIPTION
This commit updates the browser panel cloud project item's double left click action for cloud projects that aren't locally present. Prior to now, a cloud project properties dialog would show up. IMHO, this isn't optimal. We should insure that a double left click action should always lead to a project being opened whether directly when a cloud project is locally available, or by relying on the revamped synchronization dialog that defaults to auto-opening downloaded/synchronized cloud projects.

The cloud project properties dialog remains accessible via right click on browser panel cloud items (matching behavior of other browser panel items, file explorers, etc.)

(Forgot this commit in my last PR)