### PR TITLE
Filepath selection and display improvements

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,20 @@
+name: 👓 Close stale issues
+on:
+  schedule:
+  - cron: "30 1 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/stale@v4
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: |
+                            The QFieldSync project highly values your report and would love to see it addressed. However, this issue has been left in feedback mode for the last 14 days and is being automatically marked as "stale". If you would like to continue with this issue, please provide any missing information or answer any open questions. If you could resolve the issue yourself meanwhile, please leave a note for future readers with the same problem and close the issue.
+                            In case you should have any uncertainty, please leave a comment and we will be happy to help you proceed with this issue.
+                            If there is no further activity on this issue, it will be closed in a week.
+        stale-issue-label: 'stale'
+        only-labels: 'feedback'
+        days-before-stale: 14
+        days-before-close: 7

--- a/qfieldsync/core/cloud_project.py
+++ b/qfieldsync/core/cloud_project.py
@@ -155,10 +155,8 @@ class CloudProject:
         self._data = {**self._data, **new_data}
         # make sure empty string is converted to None
 
-        if "local_dir" in new_data and self._local_dir != (
-            new_data.get("local_dir") or None
-        ):
-            self._local_dir = self._data.get("local_dir") or None
+        if "local_dir" in new_data and self._local_dir != new_data.get("local_dir"):
+            self._local_dir = (self._data.get("local_dir") or "").strip() or None
 
             del self._data["local_dir"]
 

--- a/qfieldsync/gui/cloud_converter_dialog.py
+++ b/qfieldsync/gui/cloud_converter_dialog.py
@@ -26,7 +26,7 @@ import re
 from pathlib import Path
 
 from qgis.core import Qgis, QgsProject, QgsProviderRegistry
-from qgis.PyQt.QtCore import Qt
+from qgis.PyQt.QtCore import QDir, Qt
 from qgis.PyQt.QtWidgets import QApplication, QDialog, QDialogButtonBox, QMessageBox
 from qgis.PyQt.uic import loadUiType
 
@@ -82,22 +82,20 @@ class CloudConverterDialog(QDialog, DialogUi):
 
     def setup_gui(self):
         """Populate gui and connect signals of the push dialog"""
-        project_file_name = QgsProject.instance().fileName()
-        if project_file_name:
-            export_folder_name = fileparts(project_file_name)[1]
-        else:
-            export_folder_name = "new_cloud_project"
-        export_folder_path = os.path.join(
-            self.qfield_preferences.value("cloudDirectory"), export_folder_name
+        project_filename = QgsProject.instance().fileName()
+        export_dirname = Path(self.qfield_preferences.value("cloudDirectory")).joinpath(
+            fileparts(project_filename)[1] if project_filename else "new_cloud_project"
         )
 
-        self.mExportDir.setText(export_folder_path)
-        self.mExportDirBtn.clicked.connect(make_folder_selector(self.mExportDir))
+        self.exportDirLineEdit.setText(QDir.toNativeSeparators(str(export_dirname)))
+        self.exportDirButton.clicked.connect(
+            make_folder_selector(self.exportDirLineEdit)
+        )
         self.update_info_visibility()
 
     def get_export_folder_from_dialog(self):
         """Get the export folder according to the inputs in the selected"""
-        return self.mExportDir.text()
+        return self.exportDirLineEdit.text()
 
     def convert_project(self):
         for cloud_project in self.network_manager.projects_cache.projects:
@@ -111,8 +109,8 @@ class CloudConverterDialog(QDialog, DialogUi):
                 )
                 return
 
-        if sorted(Path(self.mExportDir.text()).rglob("*.qgs")) or sorted(
-            Path(self.mExportDir.text()).rglob("*.qgz")
+        if sorted(Path(self.exportDirLineEdit.text()).rglob("*.qgs")) or sorted(
+            Path(self.exportDirLineEdit.text()).rglob("*.qgz")
         ):
             QMessageBox.warning(
                 None,

--- a/qfieldsync/gui/cloud_converter_dialog.py
+++ b/qfieldsync/gui/cloud_converter_dialog.py
@@ -236,7 +236,7 @@ class CloudConverterDialog(QDialog, DialogUi):
 
     def update_upload(self, fraction):
         self.uploadProgressBar.setMaximum(100)
-        self.uploadProgressBar.setValue(fraction * 100)
+        self.uploadProgressBar.setValue(int(fraction * 100))
 
     def show_warning(self, _, message):
         self.iface.messageBar().pushMessage(message, Qgis.Warning, 0)

--- a/qfieldsync/gui/cloud_transfer_dialog.py
+++ b/qfieldsync/gui/cloud_transfer_dialog.py
@@ -27,7 +27,7 @@ from pathlib import Path
 from typing import Dict, List
 
 from qgis.core import QgsProject
-from qgis.PyQt.QtCore import Qt, pyqtSignal
+from qgis.PyQt.QtCore import QDir, Qt, pyqtSignal
 from qgis.PyQt.QtGui import QShowEvent
 from qgis.PyQt.QtWidgets import (
     QCheckBox,
@@ -177,7 +177,7 @@ class CloudTransferDialog(QDialog, CloudTransferDialogUi):
             self.qfield_preferences.value("cloudDirectory"), self.cloud_project.name
         )
 
-        self.localDirectoryLineEdit.setText(export_folder_path)
+        self.localDirectoryLineEdit.setText(QDir.toNativeSeparators(export_folder_path))
         self.localDirectoryButton.clicked.connect(
             make_folder_selector(self.localDirectoryLineEdit)
         )

--- a/qfieldsync/gui/cloud_transfer_dialog.py
+++ b/qfieldsync/gui/cloud_transfer_dialog.py
@@ -47,6 +47,7 @@ from qfieldsync.core.cloud_api import CloudNetworkAccessManager
 from qfieldsync.core.cloud_project import CloudProject, ProjectFile, ProjectFileCheckout
 from qfieldsync.core.cloud_transferrer import CloudTransferrer
 from qfieldsync.core.preferences import Preferences
+from qfieldsync.libqfieldsync.utils.file_utils import get_unique_empty_dirname
 
 from ..utils.qgis_utils import get_memory_layers
 from ..utils.qt_utils import make_folder_selector, make_icon, make_pixmap
@@ -79,7 +80,7 @@ class CloudTransferDialog(QDialog, CloudTransferDialogUi):
         super(CloudTransferDialog, self).__init__(parent=parent)
         self.setupUi(self)
 
-        self.qfield_preferences = Preferences()
+        self.preferences = Preferences()
         self.network_manager = network_manager
         self.cloud_project = cloud_project
         self.project_transfer = None
@@ -173,11 +174,15 @@ class CloudTransferDialog(QDialog, CloudTransferDialogUi):
         self.buttonBox.button(QDialogButtonBox.Apply).setVisible(True)
         self.buttonBox.button(QDialogButtonBox.Apply).setText(self.tr("Next"))
 
-        export_folder_path = os.path.join(
-            self.qfield_preferences.value("cloudDirectory"), self.cloud_project.name
+        export_dirname = get_unique_empty_dirname(
+            Path(self.preferences.value("cloudDirectory")).joinpath(
+                self.cloud_project.name
+            )
         )
 
-        self.localDirectoryLineEdit.setText(QDir.toNativeSeparators(export_folder_path))
+        self.localDirectoryLineEdit.setText(
+            QDir.toNativeSeparators(str(export_dirname))
+        )
         self.localDirectoryButton.clicked.connect(
             make_folder_selector(self.localDirectoryLineEdit)
         )

--- a/qfieldsync/gui/package_dialog.py
+++ b/qfieldsync/gui/package_dialog.py
@@ -31,7 +31,10 @@ from qgis.PyQt.uic import loadUiType
 from qfieldsync.core.preferences import Preferences
 from qfieldsync.gui.project_configuration_dialog import ProjectConfigurationDialog
 from qfieldsync.libqfieldsync import LayerSource, OfflineConverter, ProjectConfiguration
-from qfieldsync.libqfieldsync.utils.file_utils import fileparts
+from qfieldsync.libqfieldsync.utils.file_utils import (
+    fileparts,
+    get_unique_empty_dirname,
+)
 
 from ..utils.qgis_utils import get_project_title
 from ..utils.qt_utils import make_folder_selector
@@ -83,15 +86,16 @@ class PackageDialog(QDialog, DialogUi):
 
     def setup_gui(self):
         """Populate gui and connect signals of the push dialog"""
-        export_folder_path = self.qfield_preferences.value("exportDirectoryProject")
-        if not export_folder_path:
-            project_fn = QgsProject.instance().fileName()
-            export_folder_name = fileparts(project_fn)[1]
-            export_folder_path = os.path.join(
-                self.qfield_preferences.value("exportDirectory"), export_folder_name
+        export_dirname = self.qfield_preferences.value("exportDirectoryProject")
+        if not export_dirname:
+            export_dirname = os.path.join(
+                self.qfield_preferences.value("exportDirectory"),
+                fileparts(QgsProject.instance().fileName())[1],
             )
 
-        self.manualDir.setText(QDir.toNativeSeparators(export_folder_path))
+        export_dirname = get_unique_empty_dirname(export_dirname)
+
+        self.manualDir.setText(QDir.toNativeSeparators(str(export_dirname)))
         self.manualDir_btn.clicked.connect(make_folder_selector(self.manualDir))
         self.update_info_visibility()
 

--- a/qfieldsync/gui/package_dialog.py
+++ b/qfieldsync/gui/package_dialog.py
@@ -23,7 +23,7 @@
 import os
 
 from qgis.core import Qgis, QgsApplication, QgsProject, QgsProviderRegistry
-from qgis.PyQt.QtCore import Qt
+from qgis.PyQt.QtCore import QDir, Qt
 from qgis.PyQt.QtGui import QIcon
 from qgis.PyQt.QtWidgets import QApplication, QDialog, QDialogButtonBox, QMessageBox
 from qgis.PyQt.uic import loadUiType
@@ -91,7 +91,7 @@ class PackageDialog(QDialog, DialogUi):
                 self.qfield_preferences.value("exportDirectory"), export_folder_name
             )
 
-        self.manualDir.setText(export_folder_path)
+        self.manualDir.setText(QDir.toNativeSeparators(export_folder_path))
         self.manualDir_btn.clicked.connect(make_folder_selector(self.manualDir))
         self.update_info_visibility()
 

--- a/qfieldsync/gui/synchronize_dialog.py
+++ b/qfieldsync/gui/synchronize_dialog.py
@@ -24,6 +24,7 @@ import os
 from pathlib import Path
 
 from qgis.core import QgsProject
+from qgis.PyQt.QtCore import QDir
 from qgis.PyQt.QtWidgets import QDialog, QDialogButtonBox, QMessageBox
 from qgis.PyQt.uic import loadUiType
 
@@ -63,7 +64,7 @@ class SynchronizeDialog(QDialog, DialogUi):
         if not import_dir:
             import_dir = self.preferences.value("importDirectory")
 
-        self.qfieldDir.setText(import_dir)
+        self.qfieldDir.setText(QDir.toNativeSeparators(import_dir))
         self.qfieldDir_button.clicked.connect(make_folder_selector(self.qfieldDir))
 
         self.offline_editing_done = False

--- a/qfieldsync/ui/cloud_converter_dialog.ui
+++ b/qfieldsync/ui/cloud_converter_dialog.ui
@@ -73,7 +73,7 @@
          <widget class="QLineEdit" name="exportDirLineEdit"/>
         </item>
         <item row="0" column="1">
-         <widget class="QPushButton" name="exportDirButton">
+         <widget class="QToolButton" name="exportDirButton">
           <property name="text">
            <string>...</string>
           </property>

--- a/qfieldsync/ui/cloud_converter_dialog.ui
+++ b/qfieldsync/ui/cloud_converter_dialog.ui
@@ -15,7 +15,7 @@
   </property>
   <layout class="QGridLayout" name="gridLayout_2">
    <item row="0" column="0" colspan="2">
-    <widget class="QLabel" name="mExportDirLbl">
+    <widget class="QLabel" name="infoLabel">
      <property name="wordWrap">
        <bool>true</bool>
      </property>
@@ -61,7 +61,7 @@
        </widget>
       </item>
       <item row="1" column="0">
-       <widget class="QLabel" name="mExportDirLbl">
+       <widget class="QLabel" name="exportDirLabel">
         <property name="text">
          <string>Export directory</string>
         </property>
@@ -70,10 +70,10 @@
       <item row="1" column="1">
        <layout class="QGridLayout" name="gridLayout">
         <item row="0" column="0">
-         <widget class="QLineEdit" name="mExportDir"/>
+         <widget class="QLineEdit" name="exportDirLineEdit"/>
         </item>
         <item row="0" column="1">
-         <widget class="QPushButton" name="mExportDirBtn">
+         <widget class="QPushButton" name="exportDirButton">
           <property name="text">
            <string>...</string>
           </property>

--- a/qfieldsync/ui/cloud_transfer_dialog.ui
+++ b/qfieldsync/ui/cloud_transfer_dialog.ui
@@ -75,7 +75,7 @@
           <widget class="QLineEdit" name="localDirectoryLineEdit"/>
          </item>
          <item row="0" column="2">
-          <widget class="QPushButton" name="localDirectoryButton">
+          <widget class="QToolButton" name="localDirectoryButton">
            <property name="text">
             <string>...</string>
            </property>


### PR DESCRIPTION
- Convert visible filepaths with QDir.toNativeSeparators, so we dont get `C:\\users\suricactus/ugly/path`
- Fix implicit float -> int conversion warning
- Ensure unique empty dirname when selecting local project dir. It will try to create `~/qfield/cloud/project_name_1`, `~/qfield/cloud/project_name_2`, `~/qfield/cloud/project_name_55`, until it finds an nonexisting path or empty dir.
- Fix reset dirname - when deleting the dirname, it was impossible to force the empty value
- Prefer tool button - they look way better