### PR TITLE
Clodify converter improvements

### DIFF
--- a/qfieldsync/core/cloud_api.py
+++ b/qfieldsync/core/cloud_api.py
@@ -639,6 +639,23 @@ class CloudProjectsCache(QObject):
             if cloud_project is not None:
                 return cloud_project
 
+    def get_unique_name(self, name: str) -> Optional[str]:
+        if not self.projects:
+            return None
+
+        names = [p.name for p in self.projects]
+        if name not in names:
+            return name
+
+        i = 1
+        while True:
+            new_name = f"{name}_{i}"
+
+            if new_name not in names:
+                return new_name
+
+            i += 1
+
     def refresh(self) -> QNetworkReply:
         # TODO this abort appears sometimes in the UI, think how to hide it?
         if self._projects_reply:

--- a/qfieldsync/core/cloud_converter.py
+++ b/qfieldsync/core/cloud_converter.py
@@ -76,7 +76,7 @@ class CloudConverter(QObject):
             self.__layers = list(self.project.mapLayers().values())
 
             # Loop through all layers and copy them to the destination folder
-            pathResolver = self.project.pathResolver()
+            path_resolver = self.project.pathResolver()
             for current_layer_index, layer in enumerate(self.__layers):
                 self.total_progress_updated.emit(
                     current_layer_index,
@@ -96,7 +96,7 @@ class CloudConverter(QObject):
                     if provider_metadata is not None:
                         decoded = provider_metadata.decodeUri(layer.source())
                         if "path" in decoded:
-                            path = pathResolver.writePath(decoded["path"])
+                            path = path_resolver.writePath(decoded["path"])
                             if path.startswith("localized:"):
                                 # layer stored in localized data path, skip
                                 continue

--- a/qfieldsync/core/cloud_converter.py
+++ b/qfieldsync/core/cloud_converter.py
@@ -24,6 +24,7 @@ import os
 
 from qgis.core import QgsMapLayer, QgsProject, QgsProviderRegistry
 from qgis.PyQt.QtCore import QCoreApplication, QObject, pyqtSignal
+from qgis.utils import iface
 
 from qfieldsync.libqfieldsync.layer import LayerSource
 from qfieldsync.libqfieldsync.utils.file_utils import copy_images
@@ -135,10 +136,10 @@ class CloudConverter(QObject):
 
             # TODO whatcha gonna do if QgsProject::read()/write() fails
             if is_converted:
-                self.project.read(project_path)
+                iface.addProject(project_path)
                 self.project.setFileName(project_path)
             else:
-                self.project.read(original_project_path)
+                iface.addProject(original_project_path)
                 self.project.setFileName(original_project_path)
 
         self.total_progress_updated.emit(100, 100, self.tr("Finished"))

--- a/qfieldsync/core/cloud_converter.py
+++ b/qfieldsync/core/cloud_converter.py
@@ -27,7 +27,11 @@ from qgis.utils import iface
 
 from qfieldsync.libqfieldsync.layer import LayerSource
 from qfieldsync.libqfieldsync.utils.file_utils import copy_images
-from qfieldsync.utils.qgis_utils import get_qgis_files_within_dir
+from qfieldsync.utils.qgis_utils import (
+    get_qgis_files_within_dir,
+    make_temp_qgis_file,
+    open_project,
+)
 
 
 class CloudConverter(QObject):
@@ -59,8 +63,9 @@ class CloudConverter(QObject):
         project_path = self.export_dirname.joinpath(
             f"{self.project.baseName()}_cloud.qgs"
         )
-
+        backup_project_path = make_temp_qgis_file(self.project)
         is_converted = False
+
         try:
             if not self.export_dirname.exists():
                 self.export_dirname.mkdir(parents=True, exist_ok=True)
@@ -138,10 +143,8 @@ class CloudConverter(QObject):
 
             # TODO whatcha gonna do if QgsProject::read()/write() fails
             if is_converted:
-                iface.addProject(project_path)
-                self.project.setFileName(project_path)
+                iface.addProject(str(project_path))
             else:
-                iface.addProject(original_project_path)
-                self.project.setFileName(original_project_path)
+                open_project(original_project_path, backup_project_path)
 
         self.total_progress_updated.emit(100, 100, self.tr("Finished"))

--- a/qfieldsync/core/cloud_converter.py
+++ b/qfieldsync/core/cloud_converter.py
@@ -19,8 +19,7 @@
  ***************************************************************************/
 """
 
-import glob
-import os
+from pathlib import Path
 
 from qgis.core import QgsMapLayer, QgsProject, QgsProviderRegistry
 from qgis.PyQt.QtCore import QCoreApplication, QObject, pyqtSignal
@@ -28,6 +27,7 @@ from qgis.utils import iface
 
 from qfieldsync.libqfieldsync.layer import LayerSource
 from qfieldsync.libqfieldsync.utils.file_utils import copy_images
+from qfieldsync.utils.qgis_utils import get_qgis_files_within_dir
 
 
 class CloudConverter(QObject):
@@ -48,7 +48,7 @@ class CloudConverter(QObject):
         # elipsis workaround
         self.trUtf8 = self.tr
 
-        self.export_dirname = export_dirname
+        self.export_dirname = Path(export_dirname)
 
     def convert(self) -> None:  # noqa: C901
         """
@@ -56,18 +56,16 @@ class CloudConverter(QObject):
         """
 
         original_project_path = self.project.fileName()
-        project_path = os.path.join(
-            self.export_dirname, f"{self.project.baseName()}_cloud.qgs"
+        project_path = self.export_dirname.joinpath(
+            f"{self.project.baseName()}_cloud.qgs"
         )
 
         is_converted = False
         try:
-            if not os.path.exists(self.export_dirname):
-                os.makedirs(self.export_dirname)
+            if not self.export_dirname.exists():
+                self.export_dirname.mkdir(parents=True, exist_ok=True)
 
-            if glob.glob(os.path.join(self.export_dirname, "*.qgs")) or glob.glob(
-                os.path.join(self.export_dirname, "*.qgz")
-            ):
+            if get_qgis_files_within_dir(self.export_dirname):
                 raise Exception(
                     self.tr("The destination folder already contains a project file")
                 )
@@ -115,22 +113,22 @@ class CloudConverter(QObject):
                     layer_source.copy(self.export_dirname, list())
 
             # save the offline project twice so that the offline plugin can "know" that it's a relative path
-            if not self.project.write(project_path):
+            if not self.project.write(str(project_path)):
                 raise Exception(
                     self.tr('Failed to save project to "{}".').format(project_path)
                 )
 
             # export the DCIM folder
             copy_images(
-                os.path.join(os.path.dirname(original_project_path), "DCIM"),
-                os.path.join(os.path.dirname(project_path), "DCIM"),
+                str(Path(original_project_path).parent.joinpath("DCIM")),
+                str(project_path.parent.joinpath("DCIM")),
             )
 
             self.project.setTitle(
                 self.tr("{} (QFieldCloud)").format(self.project.title())
             )
             # Now we have a project state which can be saved as cloud project
-            self.project.write(project_path)
+            self.project.write(str(project_path))
             is_converted = True
         finally:
             # We need to let the app handle events before loading the next project or QGIS will crash with rasters

--- a/qfieldsync/core/cloud_project.py
+++ b/qfieldsync/core/cloud_project.py
@@ -29,6 +29,7 @@ from typing import Any, Dict, Iterator, List, Optional
 from qgis.core import QgsProject
 
 from qfieldsync.core.preferences import Preferences
+from qfieldsync.utils.qgis_utils import get_qgis_files_within_dir
 
 
 class ProjectFileCheckout(IntFlag):
@@ -197,14 +198,6 @@ class CloudProject:
             self.refresh_files()
 
     @staticmethod
-    def project_files(path: str) -> List[str]:
-        project_filenames = []
-        project_filenames += list(Path(path).glob("*.qgs"))
-        project_filenames += list(Path(path).glob("*.qgz"))
-
-        return project_filenames
-
-    @staticmethod
     def get_cloud_project_id(path: str) -> Optional[str]:
         project_local_dirs: Dict[str, str] = Preferences().value(
             "qfieldCloudProjectLocalDirs"
@@ -295,9 +288,9 @@ class CloudProject:
         return f"a/{self.owner}/{self.name}"
 
     @property
-    def root_project_files(self) -> List[str]:
+    def root_project_files(self) -> List[Path]:
         if self.local_dir:
-            return CloudProject.project_files(self.local_dir)
+            return get_qgis_files_within_dir(Path(self.local_dir))
         else:
             return []
 

--- a/qfieldsync/gui/cloud_browser_tree.py
+++ b/qfieldsync/gui/cloud_browser_tree.py
@@ -19,8 +19,8 @@
  ***************************************************************************/
 """
 
-import glob
 import os
+from pathlib import Path
 from typing import List
 
 from qgis.core import (
@@ -40,6 +40,7 @@ from qfieldsync.core.cloud_project import CloudProject
 from qfieldsync.gui.cloud_login_dialog import CloudLoginDialog
 from qfieldsync.gui.cloud_projects_dialog import CloudProjectsDialog
 from qfieldsync.gui.cloud_transfer_dialog import CloudTransferDialog
+from qfieldsync.utils.qgis_utils import get_qgis_files_within_dir
 
 
 class QFieldCloudItemProvider(QgsDataItemProvider):
@@ -260,9 +261,7 @@ class QFieldCloudItemGuiProvider(QgsDataItemGuiProvider):
     def open_project(self, item) -> bool:
         project = self.network_manager.projects_cache.find_project(item.project_id)
         if project and project.local_dir:
-            project_file_name = glob.glob(
-                os.path.join(project.local_dir, "*.qgs")
-            ) + glob.glob(os.path.join(project.local_dir, "*.qgz"))
+            project_file_name = get_qgis_files_within_dir(Path(project.local_dir))
             if project_file_name:
                 iface.addProject(os.path.join(project.local_dir, project_file_name[0]))
                 return True

--- a/qfieldsync/gui/cloud_browser_tree.py
+++ b/qfieldsync/gui/cloud_browser_tree.py
@@ -191,7 +191,7 @@ class QFieldCloudItemGuiProvider(QgsDataItemGuiProvider):
     def populateContextMenu(self, item, menu, selectedItems, context):
         if type(item) is QFieldCloudProjectItem:
             project = self.network_manager.projects_cache.find_project(item.project_id)
-            if project.local_dir:
+            if project and project.local_dir:
                 open_action = menu.addAction(QObject().tr("Open Project"))
                 open_action.triggered.connect(lambda: self.open_project(item))
 
@@ -259,7 +259,7 @@ class QFieldCloudItemGuiProvider(QgsDataItemGuiProvider):
 
     def open_project(self, item) -> bool:
         project = self.network_manager.projects_cache.find_project(item.project_id)
-        if project.local_dir:
+        if project and project.local_dir:
             project_file_name = glob.glob(
                 os.path.join(project.local_dir, "*.qgs")
             ) + glob.glob(os.path.join(project.local_dir, "*.qgz"))

--- a/qfieldsync/gui/cloud_converter_dialog.py
+++ b/qfieldsync/gui/cloud_converter_dialog.py
@@ -38,6 +38,7 @@ from qfieldsync.core.cloud_transferrer import CloudTransferrer
 from qfieldsync.core.preferences import Preferences
 from qfieldsync.gui.cloud_login_dialog import CloudLoginDialog
 from qfieldsync.libqfieldsync.utils.file_utils import fileparts
+from qfieldsync.utils.qgis_utils import get_qgis_files_within_dir
 
 from ..utils.qt_utils import make_folder_selector
 
@@ -111,9 +112,7 @@ class CloudConverterDialog(QDialog, DialogUi):
                 )
                 return
 
-        if sorted(Path(self.exportDirLineEdit.text()).rglob("*.qgs")) or sorted(
-            Path(self.exportDirLineEdit.text()).rglob("*.qgz")
-        ):
+        if get_qgis_files_within_dir(self.exportDirLineEdit.text()):
             QMessageBox.warning(
                 None,
                 self.tr("Warning"),

--- a/qfieldsync/gui/cloud_converter_dialog.py
+++ b/qfieldsync/gui/cloud_converter_dialog.py
@@ -37,7 +37,10 @@ from qfieldsync.core.cloud_project import CloudProject
 from qfieldsync.core.cloud_transferrer import CloudTransferrer
 from qfieldsync.core.preferences import Preferences
 from qfieldsync.gui.cloud_login_dialog import CloudLoginDialog
-from qfieldsync.libqfieldsync.utils.file_utils import fileparts
+from qfieldsync.libqfieldsync.utils.file_utils import (
+    fileparts,
+    get_unique_empty_dirname,
+)
 from qfieldsync.utils.qgis_utils import get_qgis_files_within_dir
 
 from ..utils.qt_utils import make_folder_selector
@@ -89,6 +92,7 @@ class CloudConverterDialog(QDialog, DialogUi):
         export_dirname = Path(self.qfield_preferences.value("cloudDirectory")).joinpath(
             fileparts(project_filename)[1] if project_filename else "new_cloud_project"
         )
+        export_dirname = get_unique_empty_dirname(export_dirname)
 
         self.exportDirLineEdit.setText(QDir.toNativeSeparators(str(export_dirname)))
         self.exportDirButton.clicked.connect(

--- a/qfieldsync/gui/cloud_converter_dialog.py
+++ b/qfieldsync/gui/cloud_converter_dialog.py
@@ -27,11 +27,22 @@ from pathlib import Path
 from typing import Optional
 
 from qgis.core import Qgis, QgsProject, QgsProviderRegistry
+from qgis.gui import QgisInterface
 from qgis.PyQt.QtCore import QDir, Qt
-from qgis.PyQt.QtWidgets import QApplication, QDialog, QDialogButtonBox, QMessageBox
+from qgis.PyQt.QtWidgets import (
+    QApplication,
+    QDialog,
+    QDialogButtonBox,
+    QMessageBox,
+    QWidget,
+)
 from qgis.PyQt.uic import loadUiType
 
-from qfieldsync.core.cloud_api import CloudException, from_reply
+from qfieldsync.core.cloud_api import (
+    CloudException,
+    CloudNetworkAccessManager,
+    from_reply,
+)
 from qfieldsync.core.cloud_converter import CloudConverter
 from qfieldsync.core.cloud_project import CloudProject
 from qfieldsync.core.cloud_transferrer import CloudTransferrer
@@ -51,7 +62,13 @@ DialogUi, _ = loadUiType(
 
 
 class CloudConverterDialog(QDialog, DialogUi):
-    def __init__(self, iface, network_manager, project, parent=None):
+    def __init__(
+        self,
+        iface: QgisInterface,
+        network_manager: CloudNetworkAccessManager,
+        project: QgsProject,
+        parent: QWidget = None,
+    ) -> None:
         """Constructor."""
         super(CloudConverterDialog, self).__init__(parent=parent)
         self.setupUi(self)
@@ -75,6 +92,9 @@ class CloudConverterDialog(QDialog, DialogUi):
             project_name = pattern.sub("", project_name)
         else:
             project_name = "CloudProject"
+
+        project_name = self.network_manager.projects_cache.get_unique_name(project_name)
+
         self.mProjectName.setText(project_name)
         self.button_box.button(QDialogButtonBox.Save).setText(self.tr("Create"))
         self.button_box.button(QDialogButtonBox.Save).clicked.connect(

--- a/qfieldsync/gui/cloud_converter_dialog.py
+++ b/qfieldsync/gui/cloud_converter_dialog.py
@@ -132,6 +132,10 @@ class CloudConverterDialog(QDialog, DialogUi):
         self.projectGroupBox.setVisible(False)
         self.progressGroupBox.setVisible(True)
 
+        if not self.project.title():
+            self.project.setTitle(self.get_cloud_project_name())
+            self.project.setDirty()
+
         cloud_convertor = CloudConverter(
             self.project, self.get_export_folder_from_dialog()
         )
@@ -152,12 +156,13 @@ class CloudConverterDialog(QDialog, DialogUi):
 
         self.create_cloud_project()
 
-    def create_cloud_project(self):
+    def get_cloud_project_name(self) -> str:
         pattern = re.compile(r"[\W_]+")
-        project_name = pattern.sub("", self.mProjectName.text())
+        return pattern.sub("", self.mProjectName.text())
 
+    def create_cloud_project(self):
         reply = self.network_manager.create_project(
-            project_name,
+            self.get_cloud_project_name(),
             self.network_manager.auth().config("username"),
             self.project.metadata().abstract(),
             True,

--- a/qfieldsync/gui/cloud_converter_dialog.py
+++ b/qfieldsync/gui/cloud_converter_dialog.py
@@ -105,6 +105,8 @@ class CloudConverterDialog(QDialog, DialogUi):
         return self.exportDirLineEdit.text()
 
     def convert_project(self):
+        assert self.network_manager.projects_cache.projects
+
         for cloud_project in self.network_manager.projects_cache.projects:
             if cloud_project.name == self.mProjectName.text():
                 QMessageBox.warning(

--- a/qfieldsync/gui/cloud_projects_dialog.py
+++ b/qfieldsync/gui/cloud_projects_dialog.py
@@ -69,6 +69,7 @@ from qfieldsync.gui.cloud_login_dialog import CloudLoginDialog
 from qfieldsync.gui.cloud_transfer_dialog import CloudTransferDialog
 from qfieldsync.utils.cloud_utils import closure, to_cloud_title
 from qfieldsync.utils.permissions import can_change_project_owner
+from qfieldsync.utils.qgis_utils import get_qgis_files_within_dir
 
 CloudProjectsDialogUi, _ = loadUiType(
     str(Path(__file__).parent.joinpath("../ui/cloud_projects_dialog.ui"))
@@ -573,7 +574,7 @@ class CloudProjectsDialog(QDialog, CloudProjectsDialogUi):
             return LocalDirFeedback.Warning, self.tr(
                 "The entered path is not an existing directory. It will be created after you submit this form."
             )
-        elif len(CloudProject.project_files(local_dir)) == 0:
+        elif len(get_qgis_files_within_dir(Path(local_dir))) == 0:
             message = self.tr(
                 "The entered path does not contain a QGIS project file yet."
             )
@@ -585,7 +586,7 @@ class CloudProjectsDialog(QDialog, CloudProjectsDialogUi):
                 message += self.tr("You can always add one later.")
 
             return status, message
-        elif len(CloudProject.project_files(local_dir)) == 1:
+        elif len(get_qgis_files_within_dir(Path(local_dir))) == 1:
             message = self.tr("The entered path contains one QGIS project file.")
             status = LocalDirFeedback.Warning
 

--- a/qfieldsync/gui/cloud_transfer_dialog.py
+++ b/qfieldsync/gui/cloud_transfer_dialog.py
@@ -20,7 +20,6 @@
  *                                                                         *
  ***************************************************************************/
 """
-import glob
 import os
 from enum import Enum
 from pathlib import Path
@@ -48,6 +47,7 @@ from qfieldsync.core.cloud_project import CloudProject, ProjectFile, ProjectFile
 from qfieldsync.core.cloud_transferrer import CloudTransferrer, TransferFileLogsModel
 from qfieldsync.core.preferences import Preferences
 from qfieldsync.libqfieldsync.utils.file_utils import get_unique_empty_dirname
+from qfieldsync.utils.qgis_utils import get_qgis_files_within_dir
 
 from ..utils.qgis_utils import get_memory_layers
 from ..utils.qt_utils import make_folder_selector, make_icon, make_pixmap
@@ -319,9 +319,7 @@ class CloudTransferDialog(QDialog, CloudTransferDialogUi):
         if not self.openProjectCheck.isChecked() or not self.cloud_project.local_dir:
             return
 
-        project_file_name = glob.glob(
-            os.path.join(self.cloud_project.local_dir, "*.qgs")
-        ) + glob.glob(os.path.join(self.cloud_project.local_dir, "*.qgz"))
+        project_file_name = get_qgis_files_within_dir(self.cloud_project.local_dir)
         if project_file_name:
             iface.addProject(
                 os.path.join(self.cloud_project.local_dir, project_file_name[0])
@@ -341,9 +339,7 @@ class CloudTransferDialog(QDialog, CloudTransferDialogUi):
                     self.tr("Please provide a local directory."),
                 )
                 return
-            elif sorted(
-                Path(self.localDirectoryLineEdit.text()).rglob("*.qgs")
-            ) or sorted(Path(self.localDirectoryLineEdit.text()).rglob("*.qgz")):
+            elif get_qgis_files_within_dir(self.localDirectoryLineEdit.text()):
                 QMessageBox.warning(
                     None,
                     self.tr("Warning"),

--- a/qfieldsync/utils/qgis_utils.py
+++ b/qfieldsync/utils/qgis_utils.py
@@ -49,20 +49,18 @@ def open_project(filename: str, filename_to_read: str = None) -> bool:
 
 
 def make_temp_qgis_file(project: QgsProject) -> str:
-    project_backup_folder = tempfile.mkdtemp()
+    project_backup_dir = tempfile.mkdtemp()
     original_filename = project.fileName()
-    backup_project_path = os.path.join(
-        project_backup_folder, project.baseName() + ".qgs"
-    )
-    project.write(backup_project_path)
+    backup_filename = os.path.join(project_backup_dir, f"{project.baseName()}.qgs")
+    project.write(backup_filename)
     project.setFileName(original_filename)
 
-    return backup_project_path
+    return backup_filename
 
 
-def import_checksums_of_project(folder):
+def import_checksums_of_project(dirname: str) -> List[str]:
     project = QgsProject.instance()
-    qgs_file = get_project_in_folder(folder)
+    qgs_file = get_project_in_folder(dirname)
     open_project(qgs_file)
     original_project_path = ProjectConfiguration(project).original_project_path
     open_project(original_project_path)

--- a/qfieldsync/utils/qgis_utils.py
+++ b/qfieldsync/utils/qgis_utils.py
@@ -22,7 +22,7 @@
 import os
 import tempfile
 from pathlib import Path
-from typing import List
+from typing import List, Union
 
 from qgis.core import QgsMapLayer, QgsProject
 
@@ -73,3 +73,8 @@ def get_memory_layers(project: QgsProject) -> List[QgsMapLayer]:
         for layer in project.mapLayers().values()
         if layer.isValid() and layer.dataProvider().name() == "memory"
     ]
+
+
+def get_qgis_files_within_dir(dirname: Union[str, Path]) -> List[Path]:
+    dirname = Path(dirname)
+    return list(dirname.glob("*.qgs")) + list(dirname.glob("*.qgz"))


### PR DESCRIPTION
UI/UX:
- suggest a unique project name
- suggest a unique local project directory
- add the opened project in "recent projects" history
- keep a backup of the original project
- append ` (QFieldCloud)` in the converted project
- set the title on the original project, if missing

Code:
- always prefer pathlib
- fix a few static analysis issues
- `folder` -> `directory`, sorry for the strong opinion on this :)
- python naming convention