### PR TITLE
Add option to auto login

### DIFF
--- a/qfieldsync/gui/cloud_converter_dialog.py
+++ b/qfieldsync/gui/cloud_converter_dialog.py
@@ -60,7 +60,7 @@ class CloudConverterDialog(QDialog, DialogUi):
 
         if not self.network_manager.has_token():
             CloudLoginDialog.show_auth_dialog(
-                self.network_manager, lambda: self.close()
+                self.network_manager, lambda: self.close(), None, parent=self
             )
         else:
             self.network_manager.projects_cache.refresh()

--- a/qfieldsync/gui/cloud_login_dialog.py
+++ b/qfieldsync/gui/cloud_login_dialog.py
@@ -45,12 +45,15 @@ class CloudLoginDialog(QDialog, CloudLoginDialogUi):
         network_manager: CloudNetworkAccessManager,
         accepted_cb: Callable = None,
         rejected_cb: Callable = None,
+        parent: QWidget = None,
     ):
         if CloudLoginDialog.instance:
+            if parent:
+                CloudLoginDialog.instance.setParent(parent)
             CloudLoginDialog.instance.show()
             return
 
-        CloudLoginDialog.instance = CloudLoginDialog(network_manager)
+        CloudLoginDialog.instance = CloudLoginDialog(network_manager, parent)
         CloudLoginDialog.instance.authenticate()
 
         if accepted_cb:

--- a/qfieldsync/gui/cloud_projects_dialog.py
+++ b/qfieldsync/gui/cloud_projects_dialog.py
@@ -120,6 +120,7 @@ class CloudProjectsDialog(QDialog, CloudProjectsDialogUi):
                 self.network_manager,
                 lambda: self.on_auth_accepted(),
                 lambda: self.close(),
+                parent=self,
             )
         else:
             self.welcomeLabelValue.setText(

--- a/qfieldsync/qfield_sync.py
+++ b/qfieldsync/qfield_sync.py
@@ -145,6 +145,12 @@ class QFieldSync(object):
             self.cloud_item_gui_provider
         )
 
+        # autologin
+        if self.preferences.value("qfieldCloudRememberMe"):
+            dialog = CloudLoginDialog(self.network_manager)
+            dialog.authenticate()
+            dialog.hide()
+
     # noinspection PyMethodMayBeStatic
     def tr(self, message):
         """Get the translation for a string using Qt translation API.

--- a/qfieldsync/ui/cloud_login_dialog.ui
+++ b/qfieldsync/ui/cloud_login_dialog.ui
@@ -89,7 +89,10 @@
       <item row="4" column="1">
 	   <widget class="QCheckBox" name="rememberMeCheckBox">
         <property name="text">
-         <string>Remember Me</string>
+         <string>Stay logged in</string>
+        </property>
+        <property name="toolTip">
+         <string>Store QFieldCloud credentials and automatically login on QGIS startup</string>
         </property>
        </widget>
       </item>

--- a/qfieldsync/ui/preferences_widget.ui
+++ b/qfieldsync/ui/preferences_widget.ui
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>QFieldPreferencesBase</class>
+ <class>QFieldPreferences</class>
  <widget class="QWidget" name="QFieldPreferences">
   <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>285</width>
-    <height>190</height>
+    <width>378</width>
+    <height>342</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -20,6 +20,13 @@
       <string>QFieldCloud Settings</string>
      </property>
      <layout class="QGridLayout" name="cloudGridLayout">
+      <item row="1" column="0">
+       <widget class="QLabel" name="cloudDirectoryLabel">
+        <property name="text">
+         <string>Default cloud directory</string>
+        </property>
+       </widget>
+      </item>
       <item row="0" column="0" colspan="2">
        <widget class="QLabel" name="cloudIntroLabel">
         <property name="text">
@@ -33,15 +40,18 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="cloudDirectoryLabel">
-        <property name="text">
-         <string>Default cloud directory</string>
-        </property>
-       </widget>
-      </item>
       <item row="1" column="1">
        <widget class="QgsFileWidget" name="cloudDirectory"/>
+      </item>
+      <item row="2" column="0" colspan="2">
+       <widget class="QCheckBox" name="qfieldCloudRememberMe">
+        <property name="text">
+         <string>Stay logged in</string>
+        </property>
+        <property name="toolTip">
+         <string>Store QFieldCloud credentials and automatically login on QGIS startup</string>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>
@@ -111,4 +121,5 @@
   </customwidget>
  </customwidgets>
  <resources/>
+ <connections/>
 </ui>


### PR DESCRIPTION
After a quick discussion with @m-kuhn seems the "remember me" checkbox was exactly that, it was not doing the login. You will only be logged in on next session if you logged in and you have the possibility to log out. If someone intentionally never logs in, then all is good.

Enabled by default. 

Added a tooltip and changed it to "stay logged in":
![image](https://user-images.githubusercontent.com/2820439/128469382-f21afca6-67f7-4378-877a-15bbeebb302d.png)

Also fix #284 