### PR TITLE
Tweaks to the cloud synchronization and projects dialogs

### DIFF
--- a/qfieldsync/gui/cloud_projects_dialog.py
+++ b/qfieldsync/gui/cloud_projects_dialog.py
@@ -1107,9 +1107,10 @@ class CloudProjectsDialog(QDialog, CloudProjectsDialogUi):
 
             self.projectsTable.item(row_idx, 0).setFont(font)
             self.projectsTable.item(row_idx, 1).setFont(font)
-            self.projectsTable.cellWidget(row_idx, 4).children()[3].setEnabled(
-                not is_currently_open_project
-            )
+            if self.projectsTable.cellWidget(row_idx, 4):
+                self.projectsTable.cellWidget(row_idx, 4).children()[3].setEnabled(
+                    not is_currently_open_project
+                )
 
             if cloud_project == self.current_cloud_project:
                 index = self.projectsTable.model().index(row_idx, 0)

--- a/qfieldsync/gui/cloud_transfer_dialog.py
+++ b/qfieldsync/gui/cloud_transfer_dialog.py
@@ -124,6 +124,8 @@ class CloudTransferDialog(QDialog, CloudTransferDialogUi):
                 )
             )
 
+        self.errorLabel.setVisible(False)
+
         self.buttonBox.button(QDialogButtonBox.Ok).setVisible(False)
         self.buttonBox.button(QDialogButtonBox.Ok).clicked.connect(
             lambda: self.on_project_ok_clicked()
@@ -486,6 +488,7 @@ class CloudTransferDialog(QDialog, CloudTransferDialogUi):
         self.update_detail(item)
 
     def on_error(self, descr: str, error: Exception = None) -> None:
+        self.errorLabel.setVisible(True)
         self.errorLabel.setText(self.errorLabel.text() + "\n" + descr)
 
     def on_upload_transfer_progress(self, fraction: float) -> None:

--- a/qfieldsync/qfield_sync.py
+++ b/qfieldsync/qfield_sync.py
@@ -265,6 +265,7 @@ class QFieldSync(object):
             text=self.tr("Convert Current Project to Cloud Project"),
             callback=self.open_cloud_convert_dialog,
             parent=self.iface.mainWindow(),
+            add_to_toolbar=False,
         )
 
         self.cloud_synchronize_action = self.add_action(

--- a/qfieldsync/ui/cloud_projects_dialog.ui
+++ b/qfieldsync/ui/cloud_projects_dialog.ui
@@ -90,7 +90,7 @@
          <item>
           <widget class="QLabel" name="projectsListLabel">
            <property name="text">
-            <string>Projects List</string>
+            <string>Cloud Projects List</string>
            </property>
            <property name="font">
             <font>
@@ -194,7 +194,7 @@
        <item>
        <widget class="QLabel" name="projectsActionLabel">
          <property name="text">
-         <string>Projects Actions</string>
+         <string>New Cloud Project</string>
          </property>
          <property name="font">
          <font>

--- a/qfieldsync/ui/cloud_projects_dialog.ui
+++ b/qfieldsync/ui/cloud_projects_dialog.ui
@@ -14,58 +14,29 @@
    <string>QFieldCloud Projects Overview</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
-   <property name="topMargin">
-    <number>0</number>
-   </property>
    <item>
-    <widget class="QGroupBox" name="verticalGroupBox">
-     <layout class="QVBoxLayout" name="verticalLayout_4">
+     <layout class="QHBoxLayout" name="headerHLayout">
       <item>
-       <layout class="QHBoxLayout" name="logoutHLayout">
-        <item>
-         <widget class="QLabel" name="welcomeLabel">
-          <property name="text">
-           <string>Welcome,</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QLabel" name="welcomeLabelValue">
-          <property name="font">
-           <font>
-            <weight>75</weight>
-            <bold>true</bold>
-           </font>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="logoutHSpacer">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="QPushButton" name="logoutButton">
-          <property name="toolTip">
-           <string>Logout and close dialog</string>
-          </property>
-          <property name="text">
-           <string>Logout</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
+        <widget class="QLabel" name="welcomeLabel">
+        <property name="text">
+          <string></string>
+        </property>
+        </widget>
+      </item>
+      <item>
+        <spacer name="headerHSpacer">
+        <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+          <size>
+          <width>40</width>
+          <height>20</height>
+          </size>
+        </property>
+        </spacer>
       </item>
      </layout>
-    </widget>
    </item>
    <item>
     <widget class="QLabel" name="feedbackLabel">
@@ -102,6 +73,18 @@
        </sizepolicy>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_2">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
        <item>
         <layout class="QHBoxLayout" name="projectsSelectButtonLayout" stretch="0,0,0,0">
          <item>
@@ -109,8 +92,11 @@
            <property name="text">
             <string>Projects List</string>
            </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
+           <property name="font">
+            <font>
+             <weight>75</weight>
+             <bold>true</bold>
+            </font>
            </property>
           </widget>
          </item>
@@ -126,20 +112,6 @@
             </size>
            </property>
           </spacer>
-         </item>
-         <item>
-          <widget class="QToolButton" name="createButton">
-           <property name="toolTip">
-            <string>Create New QFieldCloud Project</string>
-           </property>
-           <property name="text">
-            <string>Create</string>
-           </property>
-           <property name="icon">
-            <iconset>
-             <normaloff>../resources/add.svg</normaloff>../resources/add.svg</iconset>
-           </property>
-          </widget>
          </item>
          <item>
           <widget class="QToolButton" name="refreshButton">
@@ -219,6 +191,39 @@
          </column>
         </widget>
        </item>
+       <item>
+       <widget class="QLabel" name="projectsActionLabel">
+         <property name="text">
+         <string>Projects Actions</string>
+         </property>
+         <property name="font">
+         <font>
+           <weight>75</weight>
+           <bold>true</bold>
+         </font>
+         </property>
+       </widget>
+       </item>
+       <item>
+       <widget class="QPushButton" name="createButton">
+         <property name="toolTip">
+         <string>Create Blank QFieldCloud Project</string>
+         </property>
+         <property name="text">
+         <string>Create blank cloud project</string>
+         </property>
+       </widget>
+       </item>
+       <item>
+       <widget class="QPushButton" name="convertButton">
+         <property name="toolTip">
+         <string>Convert Current Project to Cloud Project</string>
+         </property>
+         <property name="text">
+         <string>Convert current project to cloud project</string>
+         </property>
+       </widget>
+       </item>
       </layout>
      </widget>
      <widget class="QWidget" name="projectsFormPage">
@@ -229,9 +234,6 @@
        </sizepolicy>
       </property>
       <layout class="QVBoxLayout" name="projectsSelectButtonLayout" stretch="0,0">
-       <property name="spacing">
-        <number>6</number>
-       </property>
        <property name="leftMargin">
         <number>0</number>
        </property>
@@ -636,7 +638,7 @@
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="standardButtons">
-      <set>QDialogButtonBox::Close</set>
+      <set>QDialogButtonBox::Close|QDialogButtonBox::Reset</set>
      </property>
     </widget>
    </item>

--- a/qfieldsync/ui/cloud_transfer_dialog.ui
+++ b/qfieldsync/ui/cloud_transfer_dialog.ui
@@ -15,25 +15,6 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QLabel" name="memoryLayersLabel">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Ignored">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="styleSheet">
-      <string notr="true">color: darkorange</string>
-     </property>
-     <property name="text">
-      <string/>
-     </property>
-     <property name="wordWrap">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
-   <item>
     <widget class="QStackedWidget" name="stackedWidget">
      <property name="currentIndex">
       <number>1</number>
@@ -438,6 +419,25 @@
        </item>
       </layout>
      </widget>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="memoryLayersLabel">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Ignored">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">color: darkorange</string>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
     </widget>
    </item>
    <item>


### PR DESCRIPTION
@suricactus , as discussed, this PR moves the memory layer warning to sit just above the standard buttons box.

The commit also hides the error label by default until there's an actual string in there. That removes the visually awkward spacing between the collapsing details box and the download progress bar.

Finally, the PR also improves the cloud projects dialog. Here's how it looks now:
![image](https://user-images.githubusercontent.com/1728657/128588815-8b8a3547-fbaa-49d5-8a70-1e3981d1ce95.png)

Improvements include:
- Add a convert current project to cloud project button
- Rework margins to save some white space and harmonize with other dialogs across QGIS
- Move the create blank project away from the projects list header into the newly introduced new cloud projects actions section and transform into into a push button so text appears on the button

@mbernasocchi , as suggested during the lightning talk, the convert current project action was removed from the toolbar in favor of being located in the cloud projects dialog. It remains available in the qfieldsync plugin sub-menu.