### PR TITLE
Fix missing public projects in the browser panel's qfieldcloud node

### DIFF
--- a/qfieldsync/core/cloud_api.py
+++ b/qfieldsync/core/cloud_api.py
@@ -231,10 +231,11 @@ class CloudNetworkAccessManager(QObject):
 
         return reply
 
-    def get_projects(self, should_include_public: bool = False) -> QNetworkReply:
+    def get_projects(self, should_include_public: bool = True) -> QNetworkReply:
         """Get QFieldCloud projects"""
-
-        return self.cloud_get("projects/")
+        return self.cloud_get(
+            "projects", {"include-public": "true" if should_include_public else "false"}
+        )
 
     def get_projects_not_async(self, should_include_public: bool = False) -> List[Dict]:
         """Get QFieldCloud projects synchronously"""


### PR DESCRIPTION
Hey there public/community cloud projects:
![image](https://user-images.githubusercontent.com/1728657/128589270-4b13fd23-1f4b-47cf-bf76-d14e64b33d0c.png)
