### PR TITLE
More love to the cloud projects dialog

### DIFF
--- a/qfieldsync/gui/cloud_projects_dialog.py
+++ b/qfieldsync/gui/cloud_projects_dialog.py
@@ -109,6 +109,8 @@ class CloudProjectsDialog(QDialog, CloudProjectsDialogUi):
         self.transfer_dialog = None
         self.project_transfer = None
 
+        self.update_welcome_label()
+
         if not self.network_manager.has_token():
             CloudLoginDialog.show_auth_dialog(
                 self.network_manager,
@@ -117,24 +119,6 @@ class CloudProjectsDialog(QDialog, CloudProjectsDialogUi):
                 parent=self,
             )
         else:
-            self.welcomeLabel.setText(
-                self.tr("Greetings {}.").format(
-                    self.network_manager.auth().config("username")
-                )
-            )
-
-        if self.network_manager.url == self.network_manager.server_urls()[0]:
-            self.welcomeLabel.setToolTip(
-                self.tr("You are logged in with the following username")
-            )
-        else:
-            self.welcomeLabel.setToolTip(
-                self.tr("You are logged in with the following username at {}").format(
-                    self.network_manager.url
-                )
-            )
-
-        if self.network_manager.has_token():
             self.show_projects()
 
         self.use_current_project_directory_action = QAction(
@@ -257,11 +241,7 @@ class CloudProjectsDialog(QDialog, CloudProjectsDialogUi):
         self.update_ui_state()
 
     def on_auth_accepted(self):
-        self.welcomeLabel.setText(
-            self.tr("Greetings {}.").format(
-                self.network_manager.auth().config("username")
-            )
-        )
+        self.update_welcome_label()
         self.network_manager.projects_cache.refresh()
 
     def on_projects_cached_projects_started(self) -> None:
@@ -1046,6 +1026,27 @@ class CloudProjectsDialog(QDialog, CloudProjectsDialogUi):
         reply.finished.connect(
             lambda: self.on_create_project_finished_projects_refreshed(project.id)
         )
+
+    def update_welcome_label(self) -> None:
+        if self.network_manager.has_token():
+            self.welcomeLabel.setText(
+                self.tr("Greetings {}.").format(
+                    self.network_manager.auth().config("username")
+                )
+            )
+            if self.network_manager.url == self.network_manager.server_urls()[0]:
+                self.welcomeLabel.setToolTip(
+                    self.tr("You are logged in with the following username")
+                )
+            else:
+                self.welcomeLabel.setToolTip(
+                    self.tr(
+                        "You are logged in with the following username at {}"
+                    ).format(self.network_manager.url)
+                )
+        else:
+            self.welcomeLabel.setText(self.tr("Logged out"))
+            self.welcomeLabel.setToolTip("")
 
     def update_ui_state(self) -> None:
         if (

--- a/qfieldsync/ui/cloud_projects_dialog.ui
+++ b/qfieldsync/ui/cloud_projects_dialog.ui
@@ -155,9 +155,6 @@
          <attribute name="horizontalHeaderShowSortIndicator" stdset="0">
           <bool>true</bool>
          </attribute>
-         <attribute name="horizontalHeaderStretchLastSection">
-          <bool>true</bool>
-         </attribute>
          <column>
           <property name="text">
            <string>Name</string>
@@ -170,26 +167,86 @@
          </column>
          <column>
           <property name="text">
-           <string>Private</string>
-          </property>
-         </column>
-         <column>
-          <property name="text">
            <string>Local</string>
           </property>
           <property name="toolTip">
            <string>Whether the file has a configured local directory</string>
           </property>
          </column>
-         <column>
-          <property name="text">
-           <string>Actions</string>
-          </property>
-          <property name="toolTip">
-           <string>Synchronize| Edit | Delete | Open</string>
-          </property>
-         </column>
         </widget>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="projectsActionsHLayout">
+         <item>
+          <widget class="QPushButton" name="synchronizeButton">
+           <property name="toolTip">
+            <string>Synchronize Selected Cloud Project</string>
+           </property>
+           <property name="text">
+            <string></string>
+           </property>
+           <property name="icon">
+            <iconset>
+             <normaloff>../resources/cloud_synchronize.svg</normaloff>../resources/cloud_synchronize.svg</iconset>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="editButton">
+           <property name="toolTip">
+            <string>Edit Selected Cloud Project</string>
+           </property>
+           <property name="text">
+            <string></string>
+           </property>
+           <property name="icon">
+            <iconset>
+             <normaloff>../resources/edit.svg</normaloff>../resources/edit.svg</iconset>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="openButton">
+           <property name="toolTip">
+            <string>Open Selected Cloud Project</string>
+           </property>
+           <property name="text">
+            <string></string>
+           </property>
+           <property name="icon">
+            <iconset>
+             <normaloff>../resources/launch.svg</normaloff>../resources/launch.svg</iconset>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="deleteButton">
+           <property name="toolTip">
+            <string>Delete Selected Cloud Project</string>
+           </property>
+           <property name="text">
+            <string></string>
+           </property>
+           <property name="icon">
+            <iconset>
+             <normaloff>../resources/delete.svg</normaloff>../resources/delete.svg</iconset>
+           </property>
+          </widget>
+         </item>
+         <item>
+           <spacer name="headerHSpacer">
+           <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+             <size>
+             <width>40</width>
+             <height>20</height>
+             </size>
+           </property>
+           </spacer>
+         </item>
+        </layout>
        </item>
        <item>
        <widget class="QLabel" name="projectsActionLabel">


### PR DESCRIPTION
Feeling inspired:
![image](https://user-images.githubusercontent.com/1728657/128596891-a2f4ad3c-91ee-44c7-bc37-23ac05d494af.png)

Improvements include:
- massive de-cluttering of the table widget by moving the repeated actions tool button out of the table
- the set of actions now sit under the table widget (much like QGIS does in many other places) -> harmony
- relying on QGIS icons to both fit better in the overall QGIS desktop environment (bonus: we decrease icon maintenance burden on our side)
