### PR TITLE
Add community projects to the cloud projects dialogs

### DIFF
--- a/qfieldsync/gui/cloud_browser_tree.py
+++ b/qfieldsync/gui/cloud_browser_tree.py
@@ -107,7 +107,7 @@ class QFieldCloudRootItem(QgsDataCollectionItem):
         items.append(my_projects)
 
         public_projects = QFieldCloudGroupItem(
-            self, "Public projects", "public", "../resources/cloud.svg", 2
+            self, "Community", "public", "../resources/cloud.svg", 2
         )
         items.append(public_projects)
 

--- a/qfieldsync/gui/cloud_projects_dialog.py
+++ b/qfieldsync/gui/cloud_projects_dialog.py
@@ -132,7 +132,6 @@ class CloudProjectsDialog(QDialog, CloudProjectsDialogUi):
         )
 
         self.projectsType.addItem(self.tr("My projects"))
-        self.projectsType.addItem(self.tr("Community"))
         self.projectsType.setCurrentIndex(0)
         self.projectsType.currentIndexChanged.connect(lambda: self.show_projects())
 

--- a/qfieldsync/ui/cloud_projects_dialog.ui
+++ b/qfieldsync/ui/cloud_projects_dialog.ui
@@ -114,48 +114,7 @@
         <number>0</number>
        </property>
        <item>
-        <layout class="QHBoxLayout" name="projectsSelectButtonLayout" stretch="0,0,0">
-         <item>
-          <widget class="QLabel" name="projectsListLabel">
-           <property name="font">
-            <font>
-             <weight>75</weight>
-             <bold>true</bold>
-            </font>
-           </property>
-           <property name="text">
-            <string>Cloud Projects List</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <spacer name="projectsSelectButtonSpacer">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item>
-          <widget class="QToolButton" name="refreshButton">
-           <property name="toolTip">
-            <string>Refresh Projects List</string>
-           </property>
-           <property name="text">
-            <string>Refresh</string>
-           </property>
-           <property name="icon">
-            <iconset>
-             <normaloff>../resources/refresh.svg</normaloff>../resources/refresh.svg</iconset>
-           </property>
-          </widget>
-         </item>
-        </layout>
+        <widget class="QComboBox" name="projectsType"/>
        </item>
        <item>
         <widget class="QTableWidget" name="projectsTable">
@@ -274,6 +233,20 @@
            </property>
           </spacer>
          </item>
+         <item>
+          <widget class="QPushButton" name="refreshButton">
+           <property name="toolTip">
+            <string>Refresh Cloud Projects List</string>
+           </property>
+           <property name="text">
+            <string></string>
+           </property>
+           <property name="icon">
+            <iconset>
+             <normaloff>../resources/refresh.svg</normaloff>../resources/refresh.svg</iconset>
+           </property>
+          </widget>
+         </item>
         </layout>
        </item>
        <item>
@@ -335,6 +308,12 @@
         <layout class="QHBoxLayout" name="horizontalLayout">
          <item>
           <widget class="QLabel" name="projectPropertiesLabel">
+           <property name="font">
+            <font>
+             <weight>75</weight>
+             <bold>true</bold>
+            </font>
+           </property>
            <property name="text">
             <string>Project Properties</string>
            </property>


### PR DESCRIPTION
GIF time:
![Peek 2021-08-08 11-23](https://user-images.githubusercontent.com/1728657/128620784-da223c13-44e1-4112-a79a-bd11653b3b53.gif)

Improvements include:
- the cloud projects dialog now allow users to see and download / synchronize community projects (making the QGIS desktop experience closer to that of QField)
- relocating the refresh button to avoid awkward look following @suricactus 's fantastic avatar work
- renamed the browser panel QFieldCloud's "public projects" to "community" so we share the same keyword across QField, QGIS, and the web app