### PR TITLE
Fixes while updating the project details

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,3 +168,4 @@ qfield-sync.*.zip
 qfieldsync/resources_rc.py
 
 .vscode/**
+.qt_for_python/**

--- a/qfieldsync/gui/cloud_projects_dialog.py
+++ b/qfieldsync/gui/cloud_projects_dialog.py
@@ -1026,7 +1026,9 @@ class CloudProjectsDialog(QDialog, CloudProjectsDialogUi):
         self.transfer_dialog.open()
 
     def update_local_dir_feedback(self, local_dir: str) -> None:
-        feedback, feedback_msg = local_dir_feedback(local_dir)
+        feedback, feedback_msg = local_dir_feedback(
+            local_dir, no_path_status=LocalDirFeedback.Warning
+        )
         self.localDirFeedbackLabel.setText(feedback_msg)
 
         if feedback == LocalDirFeedback.Error:

--- a/qfieldsync/gui/cloud_projects_dialog.py
+++ b/qfieldsync/gui/cloud_projects_dialog.py
@@ -194,9 +194,6 @@ class CloudProjectsDialog(QDialog, CloudProjectsDialogUi):
         self.localDirLineEdit.textChanged.connect(
             lambda: self.on_local_dir_line_edit_text_changed()
         )
-        self.localDirLineEdit.editingFinished.connect(
-            lambda: self.on_local_dir_line_edit_editing_finished()
-        )
         self.localDirButton.clicked.connect(lambda: self.on_local_dir_button_clicked())
         self.localDirButton.setMenu(QMenu())
         self.localDirButton.setPopupMode(QToolButton.MenuButtonPopup)
@@ -515,12 +512,6 @@ class CloudProjectsDialog(QDialog, CloudProjectsDialogUi):
     def on_local_dir_line_edit_text_changed(self) -> None:
         local_dir = self.localDirLineEdit.text()
         self.update_local_dir_feedback(local_dir)
-
-    def on_local_dir_line_edit_editing_finished(self) -> None:
-        local_dir = self.localDirLineEdit.text()
-
-        if self.current_cloud_project:
-            self.current_cloud_project.update_data({"local_dir": local_dir})
 
     def on_local_dir_button_clicked(self) -> None:
         dirname = self.select_local_dir()

--- a/qfieldsync/gui/cloud_projects_dialog.py
+++ b/qfieldsync/gui/cloud_projects_dialog.py
@@ -830,39 +830,54 @@ class CloudProjectsDialog(QDialog, CloudProjectsDialogUi):
     def on_submit_button_clicked(self) -> None:
         assert self.current_cloud_project
 
-        cloud_project_data = {
-            "name": self.projectNameLineEdit.text(),
-            "description": self.projectDescriptionTextEdit.toPlainText(),
-            "local_dir": self.localDirLineEdit.text(),
-        }
-
+        should_update_online = False
         if (
-            self.projectNameLineEdit.validator().validate(
-                cloud_project_data["name"], 0
-            )[0]
-            != QValidator.Acceptable
+            self.current_cloud_project.name != self.projectNameLineEdit.text()
+            or self.current_cloud_project.description
+            != self.projectDescriptionTextEdit.toPlainText()
         ):
-            QMessageBox.warning(
-                None,
-                self.tr("Invalid project name"),
-                self.tr(
-                    "You cannot create a new project without setting a valid name first."
-                ),
+            cloud_project_data = {
+                "name": self.projectNameLineEdit.text(),
+                "description": self.projectDescriptionTextEdit.toPlainText(),
+            }
+
+            if (
+                self.projectNameLineEdit.validator().validate(
+                    cloud_project_data["name"], 0
+                )[0]
+                != QValidator.Acceptable
+            ):
+                QMessageBox.warning(
+                    None,
+                    self.tr("Invalid project name"),
+                    self.tr(
+                        "You cannot create a new project without setting a valid name first."
+                    ),
+                )
+                return
+
+            self.projectsFormPage.setEnabled(False)
+            self.feedbackLabel.setVisible(True)
+
+            self.current_cloud_project.update_data(cloud_project_data)
+            self.feedbackLabel.setText(self.tr("Updating project…"))
+
+            reply = self.network_manager.update_project(
+                self.current_cloud_project.id,
+                self.current_cloud_project.name,
+                self.current_cloud_project.description,
             )
-            return
+            reply.finished.connect(lambda: self.on_update_project_finished(reply))
 
-        self.projectsFormPage.setEnabled(False)
-        self.feedbackLabel.setVisible(True)
+            should_update_online = True
 
-        self.current_cloud_project.update_data(cloud_project_data)
-        self.feedbackLabel.setText(self.tr("Updating project…"))
+        if self.current_cloud_project.local_dir != self.localDirLineEdit.text():
+            self.current_cloud_project.update_data(
+                {"local_dir": self.localDirLineEdit.text()}
+            )
 
-        reply = self.network_manager.update_project(
-            self.current_cloud_project.id,
-            self.current_cloud_project.name,
-            self.current_cloud_project.description,
-        )
-        reply.finished.connect(lambda: self.on_update_project_finished(reply))
+        if not should_update_online:
+            self.projectsStack.setCurrentWidget(self.projectsListPage)
 
     def on_edit_online_button_clicked(self) -> None:
         assert self.current_cloud_project

--- a/qfieldsync/ui/cloud_projects_dialog.ui
+++ b/qfieldsync/ui/cloud_projects_dialog.ui
@@ -390,6 +390,9 @@
                 </item>
                 <item>
                  <widget class="QCheckBox" name="projectIsPrivateCheckBox">
+                  <property name="enabled">
+                   <bool>false</bool>
+                  </property>
                   <property name="text">
                    <string>Private</string>
                   </property>


### PR DESCRIPTION
- Disable "Is Private" checkbox in the project edit form. It is only editable using the web UI
- Keep the "Submit" button enabled even if the local project path is empty
- Do not update the local project path while editing, wait for "save" to be clicked
- Skip API update if there is nothing to be updated (name, descr). Allow updating project local path if you don't have permission to do so.
- Add .qt_for_python to .gitignore