### PR TITLE
Fix the icons without changing the current workdir globally

### DIFF
--- a/qfieldsync/gui/cloud_projects_dialog.py
+++ b/qfieldsync/gui/cloud_projects_dialog.py
@@ -20,6 +20,7 @@
  *                                                                         *
  ***************************************************************************/
 """
+import os
 from pathlib import Path
 from typing import Callable, Optional
 
@@ -88,7 +89,13 @@ class CloudProjectsDialog(QDialog, CloudProjectsDialogUi):
     ) -> None:
         """Constructor."""
         super(CloudProjectsDialog, self).__init__(parent=parent)
+        # workaround for older QT (M$ QGIS <3.16.5) to make the custom icons load with relative path
+        old_cwd = os.getcwd()
+        os.chdir(str(Path(__file__).parent.parent.joinpath("ui")))
+        # we need to call setupUi with or without the workaround, so keep it
         self.setupUi(self)
+        os.chdir(old_cwd)
+        # / workaround
         self.setWindowModality(Qt.WindowModal)
         self.preferences = Preferences()
         self.network_manager = network_manager

--- a/qfieldsync/gui/cloud_projects_dialog.py
+++ b/qfieldsync/gui/cloud_projects_dialog.py
@@ -77,6 +77,20 @@ CloudProjectsDialogUi, _ = loadUiType(
 )
 
 
+class WindowsIconFixWorkDir(object):
+    """Workaround for older QT (M$ QGIS <3.16.5) to make the custom icons load with relative path."""
+
+    def __init__(self, path):
+        self.path = path
+        self.old_cwd = os.getcwd()
+
+    def __enter__(self):
+        os.chdir(self.path)
+
+    def __exit__(self, *_args):
+        os.chdir(self.old_cwd)
+
+
 class CloudProjectsDialog(QDialog, CloudProjectsDialogUi):
     projects_refreshed = pyqtSignal()
     _current_cloud_project = None
@@ -89,13 +103,10 @@ class CloudProjectsDialog(QDialog, CloudProjectsDialogUi):
     ) -> None:
         """Constructor."""
         super(CloudProjectsDialog, self).__init__(parent=parent)
-        # workaround for older QT (M$ QGIS <3.16.5) to make the custom icons load with relative path
-        old_cwd = os.getcwd()
-        os.chdir(str(Path(__file__).parent.parent.joinpath("ui")))
-        # we need to call setupUi with or without the workaround, so keep it
-        self.setupUi(self)
-        os.chdir(old_cwd)
-        # / workaround
+
+        with WindowsIconFixWorkDir(Path(__file__).parent.parent.joinpath("ui")):
+            self.setupUi(self)
+
         self.setWindowModality(Qt.WindowModal)
         self.preferences = Preferences()
         self.network_manager = network_manager

--- a/qfieldsync/qfield_sync.py
+++ b/qfieldsync/qfield_sync.py
@@ -22,7 +22,6 @@
 """
 
 import os
-from pathlib import Path
 
 from qgis.core import Qgis, QgsApplication, QgsOfflineEditing, QgsProject
 from qgis.gui import QgsGui, QgsOptionsWidgetFactory
@@ -45,9 +44,6 @@ from qfieldsync.gui.preferences_widget import PreferencesWidget
 from qfieldsync.gui.project_configuration_dialog import ProjectConfigurationDialog
 from qfieldsync.gui.project_configuration_widget import ProjectConfigurationWidget
 from qfieldsync.gui.synchronize_dialog import SynchronizeDialog
-
-old_cwd = os.getcwd()
-os.chdir(str(Path(__file__).parent.joinpath("ui")))
 
 
 class QFieldSyncProjectPropertiesFactory(QgsOptionsWidgetFactory):


### PR DESCRIPTION
The old solution cause the whole python environment in QGIS to change.
This will break so many scripts!  Fixes the fix in #327 