### PR TITLE
Cloud synchronization improvements

### DIFF
--- a/qfieldsync/core/cloud_project.py
+++ b/qfieldsync/core/cloud_project.py
@@ -62,14 +62,14 @@ class ProjectFile:
         if not self.versions:
             return
 
-        return self.versions[-1].get("created_at")
+        return self.versions[-1].get("last_modified")
 
     @property
     def updated_at(self) -> Optional[str]:
         if not self.versions:
             return
 
-        return self.versions[-1].get("updated_at")
+        return self.versions[0].get("last_modified")
 
     @property
     def versions(self) -> Optional[List[Dict[str, str]]]:

--- a/qfieldsync/gui/cloud_transfer_dialog.py
+++ b/qfieldsync/gui/cloud_transfer_dialog.py
@@ -267,6 +267,10 @@ class CloudTransferDialog(QDialog, CloudTransferDialogUi):
             self._file_tree_set_checkboxes(ProjectFileCheckout.Cloud)
             self._start_synchronization()
         else:
+            if self.cloud_project.user_role == "reader":
+                self.preferNoneButton.setVisible(False)
+                self.preferLocalButton.setVisible(False)
+                self.preferCloudButton.setVisible(False)
 
             self.stackedWidget.setCurrentWidget(self.filesPage)
             self.buttonBox.button(QDialogButtonBox.Apply).setVisible(True)
@@ -442,11 +446,14 @@ class CloudTransferDialog(QDialog, CloudTransferDialogUi):
     def add_file_checkbox_buttons(
         self, item: QTreeWidgetItem, project_file: ProjectFile
     ) -> None:
-        is_local_enabled = project_file.local_path_exists
+        is_local_enabled = (
+            project_file.local_path_exists and self.cloud_project.user_role != "reader"
+        )
         is_cloud_enabled = bool(project_file.checkout & ProjectFileCheckout.Cloud)
-        is_local_checked = is_local_enabled
+        is_local_checked = is_local_enabled  # TODO: don't assume users always want to upload what's local, check latest modified time
 
         local_checkbox = QCheckBox()
+        local_checkbox.setEnabled(is_local_enabled)
         local_checkbox.setChecked(is_local_checked)
         local_checkbox.toggled.connect(
             lambda _is_checked: self.on_local_checkbox_toggled(item)

--- a/qfieldsync/gui/cloud_transfer_dialog.py
+++ b/qfieldsync/gui/cloud_transfer_dialog.py
@@ -21,6 +21,7 @@
  ***************************************************************************/
 """
 import os
+from datetime import datetime
 from enum import Enum
 from pathlib import Path
 from typing import Dict, List
@@ -450,7 +451,15 @@ class CloudTransferDialog(QDialog, CloudTransferDialogUi):
             project_file.local_path_exists and self.cloud_project.user_role != "reader"
         )
         is_cloud_enabled = bool(project_file.checkout & ProjectFileCheckout.Cloud)
-        is_local_checked = is_local_enabled  # TODO: don't assume users always want to upload what's local, check latest modified time
+        is_local_checked = False
+        if is_local_enabled:
+            local_updated_at = os.path.getmtime(
+                os.path.join(self.cloud_project.local_dir, project_file.path)
+            )
+            cloud_updated_at = datetime.strptime(
+                project_file.updated_at, "%d.%m.%Y %H:%M:%S %Z"
+            ).timestamp()
+            is_local_checked = local_updated_at > cloud_updated_at
 
         local_checkbox = QCheckBox()
         local_checkbox.setEnabled(is_local_enabled)

--- a/qfieldsync/gui/cloud_transfer_dialog.py
+++ b/qfieldsync/gui/cloud_transfer_dialog.py
@@ -456,9 +456,11 @@ class CloudTransferDialog(QDialog, CloudTransferDialogUi):
             local_updated_at = os.path.getmtime(
                 os.path.join(self.cloud_project.local_dir, project_file.path)
             )
-            cloud_updated_at = datetime.strptime(
-                project_file.updated_at, "%d.%m.%Y %H:%M:%S %Z"
-            ).timestamp()
+            cloud_updated_at = 0.0
+            if project_file.updated_at:
+                cloud_updated_at = datetime.strptime(
+                    project_file.updated_at, "%d.%m.%Y %H:%M:%S %Z"
+                ).timestamp()
             is_local_checked = local_updated_at > cloud_updated_at
 
         local_checkbox = QCheckBox()

--- a/qfieldsync/gui/cloud_transfer_dialog.py
+++ b/qfieldsync/gui/cloud_transfer_dialog.py
@@ -250,6 +250,14 @@ class CloudTransferDialog(QDialog, CloudTransferDialogUi):
                     "The locally stored cloud project is already synchronized with QFieldCloud, no action is required."
                 )
             )
+            # if the cloud project being synchronize matches the currently open project, don't offer to open
+            if (
+                self.network_manager.projects_cache.currently_open_project
+                and self.cloud_project.id
+                == self.network_manager.projects_cache.currently_open_project.id
+            ):
+                self.openProjectCheck.setChecked(False)
+                self.openProjectCheck.setVisible(False)
             return
 
         self.project_transfer = CloudTransferrer(
@@ -400,6 +408,16 @@ class CloudTransferDialog(QDialog, CloudTransferDialogUi):
             self.downloadLabel.setVisible(hasDownloads)
             self.downloadProgressBar.setVisible(hasDownloads)
             self.downloadProgressFeedbackLabel.setVisible(hasDownloads)
+
+            # if the cloud project being synchronize matches the currently open project, don't offer to open if nothing is being downloaded
+            if (
+                not hasDownloads
+                and self.network_manager.projects_cache.currently_open_project
+                and self.cloud_project.id
+                == self.network_manager.projects_cache.currently_open_project.id
+            ):
+                self.openProjectCheck.setChecked(False)
+                self.openProjectCheck.setVisible(False)
 
             self.show_progress_page(files)
 

--- a/qfieldsync/gui/cloud_transfer_dialog.py
+++ b/qfieldsync/gui/cloud_transfer_dialog.py
@@ -114,7 +114,7 @@ class CloudTransferDialog(QDialog, CloudTransferDialogUi):
                 self.tr('Synchronizing project "{}"').format(self.cloud_project.name)
             )
         else:
-            self.setWindowTitle(self.tr("Synchronizing current project"))
+            self.setWindowTitle(self.tr("Synchronizing Current Project"))
 
         memory_layers = get_memory_layers(QgsProject.instance())
 
@@ -284,9 +284,9 @@ class CloudTransferDialog(QDialog, CloudTransferDialogUi):
             self.stackedWidget.setCurrentWidget(self.filesPage)
             self.buttonBox.button(QDialogButtonBox.Apply).setVisible(True)
             self.buttonBox.button(QDialogButtonBox.Apply).setText(
-                self.tr("Synchronize project")
+                self.tr("Synchronize Project")
                 if len(self.cloud_project.get_files(ProjectFileCheckout.Cloud)) > 0
-                else self.tr("Upload project")
+                else self.tr("Upload Project")
             )
 
     def build_files_tree(self):

--- a/qfieldsync/ui/cloud_transfer_dialog.ui
+++ b/qfieldsync/ui/cloud_transfer_dialog.ui
@@ -397,7 +397,7 @@
          <item>
           <widget class="QPushButton" name="preferNoneButton">
            <property name="text">
-            <string>Prefer None</string>
+            <string>Prefer No Action</string>
            </property>
           </widget>
          </item>


### PR DESCRIPTION
This PR improves the cloud synchronization process through two changes.

First, if users are synchronizing a project where they are assigned the role of 'reader', the UI will disable all upload-related functionality, simplifying the UI quite a lot:
![image](https://user-images.githubusercontent.com/1728657/135563665-afb96c48-14e5-4290-a511-0e6415436ab6.png)

The second is IMHO an important UX improvement: instead of always forcing uploads by default, the synchronization dialog will pick a better default based on last modified date. If the cloud-stored file has a modification date that's newer than the locally stored file, we now default to downloading from the cloud. 