### PR TITLE
Do not pretend there is a project on completely empty cloud project

### DIFF
--- a/qfieldsync/gui/cloud_transfer_dialog.py
+++ b/qfieldsync/gui/cloud_transfer_dialog.py
@@ -245,13 +245,21 @@ class CloudTransferDialog(QDialog, CloudTransferDialogUi):
         assert self.cloud_project
 
         if len(list(self.cloud_project.files_to_sync)) == 0:
-            self.show_end_page(
-                self.tr(
-                    "The locally stored cloud project is already synchronized with QFieldCloud, no action is required."
+            files_total = len(self.cloud_project.get_files())
+            if files_total > 0:
+                self.show_end_page(
+                    self.tr(
+                        "The locally stored cloud project is already synchronized with QFieldCloud, no action is required."
+                    )
                 )
-            )
+            else:
+                self.show_end_page(
+                    self.tr(
+                        "This cloud project currently has no file stored either locally on on the server."
+                    )
+                )
             # if the cloud project being synchronize matches the currently open project, don't offer to open
-            if (
+            if files_total == 0 or (
                 self.network_manager.projects_cache.currently_open_project
                 and self.cloud_project.id
                 == self.network_manager.projects_cache.currently_open_project.id


### PR DESCRIPTION
Title says it all. With this PR, the user will be aware of completely empty cloud project:

![image](https://user-images.githubusercontent.com/1728657/135703314-bcc0716c-1168-4a36-b3dc-5254c967c7b1.png)
