### PR TITLE
UX when using the transferring dialog

### DIFF
--- a/qfieldsync/gui/cloud_browser_tree.py
+++ b/qfieldsync/gui/cloud_browser_tree.py
@@ -268,8 +268,9 @@ class QFieldCloudItemGuiProvider(QgsDataItemGuiProvider):
 
     def show_cloud_synchronize_dialog(self, item):
         project = self.network_manager.projects_cache.find_project(item.project_id)
-        dlg = CloudTransferDialog(self.network_manager, project, iface.mainWindow())
-        dlg.show()
+        CloudTransferDialog.show_transfer_dialog(
+            self.network_manager, project, None, None, iface.mainWindow()
+        )
 
     def open_project(self, item) -> bool:
         project = self.network_manager.projects_cache.find_project(item.project_id)

--- a/qfieldsync/gui/cloud_projects_dialog.py
+++ b/qfieldsync/gui/cloud_projects_dialog.py
@@ -1051,8 +1051,8 @@ class CloudProjectsDialog(QDialog, CloudProjectsDialogUi):
     def show_sync_popup(self) -> None:
         assert self.current_cloud_project is not None, "No project to download selected"
 
-        self.transfer_dialog = CloudTransferDialog(
-            self.network_manager, self.current_cloud_project, self
+        self.transfer_dialog = CloudTransferDialog.show_transfer_dialog(
+            self.network_manager, self.current_cloud_project, None, None, self
         )
         self.transfer_dialog.rejected.connect(self.on_transfer_dialog_rejected)
         self.transfer_dialog.accepted.connect(self.on_transfer_dialog_accepted)

--- a/qfieldsync/gui/cloud_transfer_dialog.py
+++ b/qfieldsync/gui/cloud_transfer_dialog.py
@@ -275,6 +275,15 @@ class CloudTransferDialog(QDialog, CloudTransferDialogUi):
     def prepare_project_transfer(self):
         assert self.cloud_project
 
+        # Failed to update project files
+        if self.cloud_project.cloud_files is None:
+            self.show_end_page(
+                self.tr("Failed to update the project files status from the server.")
+            )
+            self.openProjectCheck.setChecked(False)
+            self.openProjectCheck.setVisible(False)
+            return
+
         if len(list(self.cloud_project.files_to_sync)) == 0:
             files_total = len(self.cloud_project.get_files())
             if files_total > 0:

--- a/qfieldsync/qfield_sync.py
+++ b/qfieldsync/qfield_sync.py
@@ -368,12 +368,13 @@ class QFieldSync(object):
         Synchornize cloud project.
         """
         if self.network_manager.projects_cache.is_currently_open_project_cloud_local:
-            self.transfer_dialog = CloudTransferDialog(
+            self.transfer_dialog = CloudTransferDialog.show_transfer_dialog(
                 self.network_manager,
+                None,
+                None,
                 None,
                 self.iface.mainWindow(),
             )
-            self.transfer_dialog.show()
 
     def show_package_dialog(self):
         """


### PR DESCRIPTION
- Use CloudTransferDialog.show_transfer_dialog static method to prevent multiple dialogs
- If the updating the files list is unsuccessful before transferring, show an error message, instead of silently showing all the local files as changed.

![image](https://user-images.githubusercontent.com/2820439/142020673-64cdc36d-e64f-4e46-ba7e-09e3776c3ae9.png)
