### PR TITLE
Shows a success message only when files have been really uploaded

### DIFF
--- a/qfieldsync/gui/cloud_create_project_widget.py
+++ b/qfieldsync/gui/cloud_create_project_widget.py
@@ -244,10 +244,6 @@ class CloudCreateProjectWidget(QWidget, WidgetUi):
 
         self.network_manager.projects_cache.refresh()
 
-        result_message = self.tr(
-            "Finished uploading the project to QFieldCloud, you are now viewing the locally stored copy."
-        )
-        self.iface.messageBar().pushMessage(result_message, Qgis.Success, 0)
         self.finished.emit()
 
     def update_info_visibility(self):
@@ -334,6 +330,11 @@ class CloudCreateProjectWidget(QWidget, WidgetUi):
         self.uploadProgressBar.setValue(int(fraction * 100))
 
     def on_transferrer_finished(self):
+        result_message = self.tr(
+            "Finished uploading the project to QFieldCloud, you are now viewing the locally stored copy."
+        )
+        self.iface.messageBar().pushMessage(result_message, Qgis.Success, 0)
+
         self.after_project_creation_action()
 
     def on_show_warning(self, _, message):


### PR DESCRIPTION
When creating a new empty project it wrongly shows a success message showing the files have been uploaded
![image](https://user-images.githubusercontent.com/2820439/150230046-b69ceaa9-6d93-4f10-a506-4c85fbba7d70.png)
