### PR TITLE
Add help button on the projects dialog that shows qfield.org/docs

### DIFF
--- a/qfieldsync/gui/cloud_projects_dialog.py
+++ b/qfieldsync/gui/cloud_projects_dialog.py
@@ -198,6 +198,9 @@ class CloudProjectsDialog(QDialog, CloudProjectsDialogUi):
         self.buttonBox.button(QDialogButtonBox.Close).clicked.connect(
             lambda: self.on_button_box_clicked()
         )
+        self.buttonBox.button(QDialogButtonBox.Help).clicked.connect(
+            lambda: QDesktopServices.openUrl(QUrl("https://qfield.org/docs/"))
+        )
         self.avatarButton.clicked.connect(lambda: self.on_logout_button_clicked())
 
         self.projectsTable.selectionModel().selectionChanged.connect(

--- a/qfieldsync/ui/cloud_projects_dialog.ui
+++ b/qfieldsync/ui/cloud_projects_dialog.ui
@@ -706,7 +706,7 @@
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="standardButtons">
-      <set>QDialogButtonBox::Close</set>
+      <set>QDialogButtonBox::Close|QDialogButtonBox::Help</set>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
We will need to open qfield (cloud) docs.

![image](https://user-images.githubusercontent.com/2820439/150338356-04f61e3d-21fa-4b2a-80cf-06a8d610d51e.png)
