### PR TITLE
Fix sign out if there is no avatar

### DIFF
--- a/qfieldsync/gui/cloud_projects_dialog.py
+++ b/qfieldsync/gui/cloud_projects_dialog.py
@@ -926,12 +926,16 @@ class CloudProjectsDialog(QDialog, CloudProjectsDialogUi):
     def update_welcome_label(self) -> None:
         if self.network_manager.has_token():
             avatar_filename = self.network_manager.user_details.get("avatar_filename")
+            self.avatarButton.setVisible(True)
+
             if avatar_filename:
-                self.avatarButton.setVisible(True)
                 pixmap = rounded_pixmap(avatar_filename, self.avatarButton.height())
+                self.avatarButton.setText("")
+                self.avatarButton.setFlat(True)
                 self.avatarButton.setIcon(QIcon(pixmap))
             else:
-                self.avatarButton.setVisible(False)
+                self.avatarButton.setText(self.tr("Sign out"))
+                self.avatarButton.setFlat(False)
                 self.avatarButton.setIcon(QIcon())
 
             self.welcomeLabel.setText(

--- a/qfieldsync/gui/cloud_projects_dialog.py
+++ b/qfieldsync/gui/cloud_projects_dialog.py
@@ -1109,6 +1109,6 @@ class CloudProjectsDialog(QDialog, CloudProjectsDialogUi):
         self.close()
 
     def _on_logout_failed(self, err: str) -> None:
-        self.feedbackLabel.setText("Logout failed: {}".format(str(err)))
+        self.feedbackLabel.setText("Sign out failed: {}".format(str(err)))
         self.feedbackLabel.setVisible(True)
         self.avatarButton.setEnabled(True)

--- a/qfieldsync/ui/cloud_projects_dialog.ui
+++ b/qfieldsync/ui/cloud_projects_dialog.ui
@@ -55,7 +55,7 @@
        </property>
        <property name="maximumSize">
         <size>
-         <width>50</width>
+         <width>16777215</width>
          <height>50</height>
         </size>
        </property>

--- a/qfieldsync/ui/cloud_projects_dialog.ui
+++ b/qfieldsync/ui/cloud_projects_dialog.ui
@@ -60,7 +60,7 @@
         </size>
        </property>
        <property name="toolTip">
-        <string>Click to logout</string>
+        <string>Click to sign out</string>
        </property>
        <property name="iconSize">
         <size>


### PR DESCRIPTION
Tried my best to make it round, however applying custom CSS style is Qt kills all other styling. 

![image](https://user-images.githubusercontent.com/2820439/151028728-00c4f0d2-4634-4a64-b2c0-bf514baeda66.png)
