### PR TITLE
Fix logout button missing for avatar-less accounts

### DIFF
--- a/qfieldsync/gui/cloud_projects_dialog.py
+++ b/qfieldsync/gui/cloud_projects_dialog.py
@@ -927,16 +927,14 @@ class CloudProjectsDialog(QDialog, CloudProjectsDialogUi):
         if self.network_manager.has_token():
             avatar_filename = self.network_manager.user_details.get("avatar_filename")
             self.avatarButton.setVisible(True)
+            if not avatar_filename:
+                avatar_filename = os.path.join(
+                    os.path.dirname(__file__), "../resources/qfieldcloud_logo.png"
+                )
 
-            if avatar_filename:
-                pixmap = rounded_pixmap(avatar_filename, self.avatarButton.height())
-                self.avatarButton.setText("")
-                self.avatarButton.setFlat(True)
-                self.avatarButton.setIcon(QIcon(pixmap))
-            else:
-                self.avatarButton.setText(self.tr("Sign out"))
-                self.avatarButton.setFlat(False)
-                self.avatarButton.setIcon(QIcon())
+            self.avatarButton.setVisible(True)
+            pixmap = rounded_pixmap(avatar_filename, self.avatarButton.height())
+            self.avatarButton.setIcon(QIcon(pixmap))
 
             self.welcomeLabel.setText(
                 self.tr("Greetings {}.").format(


### PR DESCRIPTION
This PR fixes the logout button (now merged with the avatar display) going missing for avatar-less cloud accounts.

Our beautiful favorite bee acts as the avatar when missing:
![image](https://user-images.githubusercontent.com/1728657/151148468-523fffbf-22b7-42da-adb2-5ae3d9f4cb44.png)
