### PR TITLE
Remove assert in cloudify_project as new cloud users have _no_ projects, which have them hit the assert

### DIFF
--- a/qfieldsync/gui/cloud_create_project_widget.py
+++ b/qfieldsync/gui/cloud_create_project_widget.py
@@ -131,8 +131,6 @@ class CloudCreateProjectWidget(QWidget, WidgetUi):
             self.cloudifyInfoLabel.setEnabled(True)
 
     def cloudify_project(self):
-        assert self.network_manager.projects_cache.projects
-
         for cloud_project in self.network_manager.projects_cache.projects:
             if cloud_project.name == self.get_cloud_project_name():
                 QMessageBox.warning(


### PR DESCRIPTION
@suricactus , because of course dev accounts are already full of projects and we never hit this ;)