### PR TITLE
When cloudifying a project, auto set the approprite cloud action to avoid synchronization dialog errors

### DIFF
--- a/qfieldsync/core/cloud_converter.py
+++ b/qfieldsync/core/cloud_converter.py
@@ -106,8 +106,11 @@ class CloudConverter(QObject):
                             ).format(layer.name()),
                         )
                         self.project.removeMapLayer(layer)
+                    else:
+                        layer.setCustomProperty("QFieldSync/cloud_action", "offline")
                 else:
                     layer_source.copy(self.export_dirname, list())
+                    layer.setCustomProperty("QFieldSync/cloud_action", "no_action")
 
             # save the offline project twice so that the offline plugin can "know" that it's a relative path
             if not self.project.write(str(project_path)):


### PR DESCRIPTION
The project cloudifier should be as friction-less as possible; set good default cloud actions to converted layers so when users hit the synchronize button, they aren't shown a scary dialog full of errors :)

Prevents this dialog from showing:
![image](https://user-images.githubusercontent.com/1728657/151356341-55ed1b1a-85f4-48a3-8823-141a81292e81.png)

@jmad1v07 , this is something you were hitting while doing testing. 