### PR TITLE
Rely on default_cloud_action property when cloudifying

### DIFF
--- a/qfieldsync/core/cloud_converter.py
+++ b/qfieldsync/core/cloud_converter.py
@@ -106,11 +106,11 @@ class CloudConverter(QObject):
                             ).format(layer.name()),
                         )
                         self.project.removeMapLayer(layer)
-                    else:
-                        layer.setCustomProperty("QFieldSync/cloud_action", "offline")
                 else:
                     layer_source.copy(self.export_dirname, list())
-                    layer.setCustomProperty("QFieldSync/cloud_action", "no_action")
+                layer.setCustomProperty(
+                    "QFieldSync/cloud_action", layer_source.default_cloud_action
+                )
 
             # save the offline project twice so that the offline plugin can "know" that it's a relative path
             if not self.project.write(str(project_path)):


### PR DESCRIPTION
@suricactus , as suggested, the better way (tm).