### PR TITLE
Fix missing HTTP code from the reply for unknown reason

### DIFF
--- a/qfieldsync/core/cloud_api.py
+++ b/qfieldsync/core/cloud_api.py
@@ -420,7 +420,7 @@ class CloudNetworkAccessManager(QObject):
         self, reply: QNetworkReply, local_filename: str
     ) -> None:
         http_code = reply.attribute(QNetworkRequest.HttpStatusCodeAttribute)
-        if http_code >= 301 and http_code <= 308:
+        if http_code is not None and http_code >= 301 and http_code <= 308:
             # redirects should not be saved as files, just ignore them
             return
 


### PR DESCRIPTION
Otherwise we get:
```
TypeError: '>=' not supported between instances of 'NoneType' and 'int'
Traceback (most recent call last):
  File "/home/suricactus/.local/share/QGIS/QGIS3/profiles/default/python/plugins/qfieldsync/core/cloud_api.py", line 392, in
    lambda: self._on_cloud_get_download_finished(
  File "/home/suricactus/.local/share/QGIS/QGIS3/profiles/default/python/plugins/qfieldsync/core/cloud_api.py", line 423, in _on_cloud_get_download_finished
    if http_code >= 301 and http_code TypeError: '>=' not supported between instances of 'NoneType' and 'int'
```