### PR TITLE
Try fixing the release workflow

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -91,7 +91,7 @@ jobs:
           sudo pip install qgis-plugin-ci
       - name: Release
         run: |
-          qgis-plugin-ci release ${GITHUB_REF##*/} --transifex-token ${TX_TOKEN} --github-token ${GITHUB_TOKEN} --osgeo-username ${OSGEO_USERNAME} --osgeo-password ${OSGEO_PASSWORD}
+          qgis-plugin-ci release ${GITHUB_REF/refs\/tags\/v/} --transifex-token ${TX_TOKEN} --github-token ${GITHUB_TOKEN} --osgeo-username ${OSGEO_USERNAME} --osgeo-password ${OSGEO_PASSWORD}
 
   package:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
There is a problem releasing versions with `qgis-plugin-ci` and getting 400 errors from the RPC api endpoint. No idea why, but I would blame the leading `v` in front of the version.

So intead of `v4.0.0` I would try to release `4.0.0` from now on.