### PR TITLE
Add a new project-level property to define maximum width/height of image attachments

### DIFF
--- a/qfieldsync/gui/project_configuration_widget.py
+++ b/qfieldsync/gui/project_configuration_widget.py
@@ -25,7 +25,7 @@ from qgis.core import (
     QgsPolygon,
     QgsProject,
 )
-from qgis.gui import QgsExtentWidget, QgsOptionsPageWidget
+from qgis.gui import QgsExtentWidget, QgsOptionsPageWidget, QgsSpinBox
 from qgis.PyQt.QtCore import Qt
 from qgis.PyQt.QtGui import QIcon
 from qgis.PyQt.QtWidgets import QLabel
@@ -159,6 +159,13 @@ class ProjectConfigurationWidget(WidgetUi, QgsOptionsPageWidget):
         )
         self.digitizingLogsLayerComboBox.setLayer(digitizingLogsLayer)
 
+        self.maximumImageWidthHeight.setClearValueMode(
+            QgsSpinBox.CustomValue, self.tr("No restriction")
+        )
+        self.maximumImageWidthHeight.setValue(
+            self.__project_configuration.maximum_image_width_height
+        )
+
         self.mapUnitsPerPixel.setValue(self.__project_configuration.base_map_mupp)
         self.tileSize.setValue(self.__project_configuration.base_map_tile_size)
         self.onlyOfflineCopyFeaturesInAoi.setChecked(
@@ -227,6 +234,10 @@ class ProjectConfigurationWidget(WidgetUi, QgsOptionsPageWidget):
             self.mapUnitsPerPixel.value()
         )
         self.__project_configuration.base_map_tile_size = self.tileSize.value()
+
+        self.__project_configuration.maximum_image_width_height = (
+            self.maximumImageWidthHeight.value()
+        )
 
         self.__project_configuration.offline_copy_only_aoi = (
             self.onlyOfflineCopyFeaturesInAoi.isChecked()

--- a/qfieldsync/ui/project_configuration_widget.ui
+++ b/qfieldsync/ui/project_configuration_widget.ui
@@ -65,6 +65,48 @@
         </property>
        </widget>
       </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="maximumImageWidthHeightLabel">
+        <property name="text">
+         <string>Max. image attachment
+(width or height)</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="QgsSpinBox" name="maximumImageWidthHeight">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="toolTip">
+         <string>This number sets the maximum allowed width or height (in pixels) or an image attached to feature forms.</string>
+        </property>
+        <property name="suffix">
+         <string> px</string>
+        </property>
+        <property name="minimum">
+         <number>0</number>
+        </property>
+        <property name="maximum">
+         <number>99999999</number>
+        </property>
+        <property name="value">
+         <number>0</number>
+        </property>
+        <property name="clearValue" stdset="0">
+        <double>0</double>
+        </property>
+        <property name="showClearButton" stdset="0">
+        <bool>true</bool>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>


### PR DESCRIPTION
Title says it all. The UI looks like this when no maximum is entered:
![image](https://user-images.githubusercontent.com/1728657/163154717-02a58371-d38e-4aef-8590-e41c882706ab.png)

When a maximum is set:
![image](https://user-images.githubusercontent.com/1728657/163154784-edca394b-ac0d-4364-a99d-a9aecb9f0b9e.png)

The qfieldsync plugin side of https://github.com/opengisch/QField/pull/2740