### PR TITLE
Make sure the configuration made using project properties -> layer properties is not lost

### DIFF
--- a/qfieldsync/gui/layers_config_widget.py
+++ b/qfieldsync/gui/layers_config_widget.py
@@ -88,6 +88,10 @@ class LayersConfigWidget(QWidget, LayersConfigWidgetUi):
         self.toggleMenu.triggered.connect(self.toggleMenu_triggered)
         self.unsupportedLayersList = list()
 
+        if Qgis.QGIS_VERSION_INT >= 31900:
+            self._on_dirtyset = self._on_dirtyset_wrapper()
+            self.project.dirtySet.connect(self._on_dirtyset)
+
         self.reloadProject()
 
     def get_available_actions(self, layer_source):
@@ -242,6 +246,15 @@ class LayersConfigWidget(QWidget, LayersConfigWidgetUi):
 
         self.reloadProject()
 
+    def _on_dirtyset_wrapper(self):
+        def _on_dirtyset():
+            for layer_source in self.layer_sources:
+                layer_source.read_layer()
+
+            self.reloadProject()
+
+        return _on_dirtyset
+
     def apply(self):
         is_project_dirty = False
 
@@ -253,6 +266,9 @@ class LayersConfigWidget(QWidget, LayersConfigWidgetUi):
             self.set_layer_action(layer_source, cmb.itemData(cmb.currentIndex()))
 
             is_project_dirty |= layer_source.apply()
+
+        if Qgis.QGIS_VERSION_INT >= 31900:
+            self.project.dirtySet.disconnect(self._on_dirtyset)
 
         if is_project_dirty:
             self.project.setDirty(True)


### PR DESCRIPTION
When user opens layer properties via project properties and click Apply/Ok on both dialog windows, the layer settings (layer action or image path) get lost as they are cached in the layer source of the project properties window. This PR aims to fix this.

There are a few extra CPU cycles involved as the project "setdirty" signal is triggered multiple times.

Fix #413 