### PR TITLE
Remove the release version parameter and cleanup duplicated args

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -91,14 +91,9 @@ jobs:
           sudo pip install qgis-plugin-ci
       - name: Release
         run: |
-          RELEASE_VERSION=${GITHUB_REF/refs\/tags\/v/}
+          RELEASE_VERSION=${GITHUB_REF##*/}
           RELEASE_TAG=${GITHUB_REF##*/}
           qgis-plugin-ci release ${RELEASE_VERSION} \
-              --release-tag ${RELEASE_TAG} \
-              --transifex-token ${TX_TOKEN} \
-              --github-token ${GITHUB_TOKEN} \
-              --osgeo-username ${OSGEO_USERNAME} \
-              --osgeo-password ${OSGEO_PASSWORD}
               --release-tag ${RELEASE_TAG} \
               --transifex-token ${TX_TOKEN} \
               --github-token ${GITHUB_TOKEN} \


### PR DESCRIPTION
For whatever reason we did not see the args were duplicated.

Also, releasing with release version without the leading `v` was causing the plugin version not to be easily accessible on QGIS plugins repo.