### PR TITLE
Add "Attachement Directories" configuration on QFieldSync

### DIFF
--- a/qfieldsync/core/cloud_converter.py
+++ b/qfieldsync/core/cloud_converter.py
@@ -25,8 +25,9 @@ from qgis.core import QgsMapLayer, QgsProject
 from qgis.PyQt.QtCore import QCoreApplication, QObject, pyqtSignal
 from qgis.utils import iface
 
+from qfieldsync.core.preferences import Preferences
 from qfieldsync.libqfieldsync.layer import LayerSource
-from qfieldsync.libqfieldsync.utils.file_utils import copy_images
+from qfieldsync.libqfieldsync.utils.file_utils import copy_attachments
 from qfieldsync.libqfieldsync.utils.qgis import (
     get_qgis_files_within_dir,
     make_temp_qgis_file,
@@ -119,10 +120,12 @@ class CloudConverter(QObject):
                 )
 
             # export the DCIM folder
-            copy_images(
-                str(Path(original_project_path).parent.joinpath("DCIM")),
-                str(project_path.parent.joinpath("DCIM")),
-            )
+            for attachment_dir in Preferences().value("attachmentDirs"):
+                copy_attachments(
+                    Path(original_project_path).parent,
+                    project_path.parent,
+                    attachment_dir,
+                )
 
             title = self.project.title()
             title_suffix = self.tr("(QFieldCloud)")

--- a/qfieldsync/core/preferences.py
+++ b/qfieldsync/core/preferences.py
@@ -1,6 +1,13 @@
 from pathlib import Path
 
-from qfieldsync.setting_manager import Bool, Dictionary, Scope, SettingManager, String
+from qfieldsync.setting_manager import (
+    Bool,
+    Dictionary,
+    Scope,
+    SettingManager,
+    String,
+    Stringlist,
+)
 
 pluginName = "QFieldSync"
 
@@ -17,6 +24,7 @@ class Preferences(SettingManager):
             String("importDirectory", Scope.Global, str(home.joinpath("QField/import")))
         )
         self.add_setting(String("importDirectoryProject", Scope.Project, None))
+        self.add_setting(Stringlist("attachmentDirs", Scope.Project, ["DCIM"]))
         self.add_setting(Dictionary("qfieldCloudProjectLocalDirs", Scope.Global, {}))
         self.add_setting(Dictionary("qfieldCloudLastProjectFiles", Scope.Global, {}))
         self.add_setting(String("qfieldCloudServerUrl", Scope.Global, ""))

--- a/qfieldsync/gui/package_dialog.py
+++ b/qfieldsync/gui/package_dialog.py
@@ -146,6 +146,7 @@ class PackageDialog(QDialog, DialogUi):
             export_folder,
             area_of_interest,
             area_of_interest_crs,
+            self.qfield_preferences.value("attachmentDirs"),
             self.offline_editing,
         )
 

--- a/qfieldsync/gui/synchronize_dialog.py
+++ b/qfieldsync/gui/synchronize_dialog.py
@@ -32,7 +32,7 @@ from qfieldsync.core.preferences import Preferences
 from qfieldsync.libqfieldsync import ProjectConfiguration
 from qfieldsync.libqfieldsync.utils.exceptions import NoProjectFoundError
 from qfieldsync.libqfieldsync.utils.file_utils import (
-    copy_images,
+    copy_attachments,
     get_project_in_folder,
     import_file_checksum,
 )
@@ -137,10 +137,13 @@ class SynchronizeDialog(QDialog, DialogUi):
             if original_path.exists() and open_project(
                 str(original_path), backup_project_path
             ):
-                copy_images(
-                    os.path.join(qfield_path, "DCIM"),
-                    os.path.join(original_path.parent, "DCIM"),
-                )
+                for attachment_dir in self.preferences.value("attachmentDirs"):
+                    copy_attachments(
+                        qfield_path,
+                        original_path.parent,
+                        attachment_dir,
+                    )
+
                 # save the data_file_checksum to the project and save it
                 imported_files_checksums.append(import_file_checksum(str(qfield_path)))
                 ProjectConfiguration(

--- a/qfieldsync/tests/test_export.py
+++ b/qfieldsync/tests/test_export.py
@@ -58,6 +58,7 @@ class OfflineConverterTest(unittest.TestCase):
             export_folder,
             "POLYGON((1 1, 5 0, 5 5, 0 5, 1 1))",
             QgsProject.instance().crs().authid(),
+            ["DCIM"],
             offline_editing,
         )
         offline_converter.convert()
@@ -106,6 +107,7 @@ class OfflineConverterTest(unittest.TestCase):
             export_folder,
             "POLYGON((1 1, 5 0, 5 5, 0 5, 1 1))",
             QgsProject.instance().crs().authid(),
+            ["DCIM"],
             offline_editing,
         )
         offline_converter.convert()

--- a/qfieldsync/ui/project_configuration_widget.ui
+++ b/qfieldsync/ui/project_configuration_widget.ui
@@ -29,7 +29,7 @@
       <bool>false</bool>
      </property>
      <property name="collapsed">
-      <bool>true</bool>
+      <bool>false</bool>
      </property>
      <property name="saveCollapsedState">
       <bool>true</bool>
@@ -54,7 +54,7 @@
          <string>Area of interest</string>
         </property>
         <property name="alignment">
-          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
         </property>
        </widget>
       </item>
@@ -106,6 +106,22 @@
         <bool>true</bool>
         </property>
        </widget>
+      </item>
+      <item row="4" column="0">
+       <widget class="QLabel" name="attachmentDirsLabel">
+        <property name="toolTip">
+         <string>A list of directories and files to be treated as attachments. Usually the directories that store images and/or SVG are here.</string>
+        </property>
+        <property name="text">
+         <string>Attachment directories</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1">
+       <widget class="QListWidget" name="attachmentDirsListWidget" />
       </item>
      </layout>
     </widget>


### PR DESCRIPTION
So far QFieldSync automatically syncs only the `DCIM` directory. Now this is the default behaviour, but the user can set a list of directories that can be copied in the package too.


![image](https://user-images.githubusercontent.com/2820439/182481739-b2d3a3bb-3d67-44af-ba2d-bceca692d253.png)
