### PR TITLE
Cut the response by the content length, so we can discard other bytes coming from buggy clients

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -61,7 +61,7 @@ jobs:
           submodules: recursive
       - name: Test
         run: |
-          wget -qO - https://qgis.org/downloads/qgis-2021.gpg.key | sudo gpg --no-default-keyring --keyring gnupg-ring:/etc/apt/trusted.gpg.d/qgis-archive.gpg --import
+          wget -qO - https://qgis.org/downloads/qgis-2022.gpg.key | sudo gpg --no-default-keyring --keyring gnupg-ring:/etc/apt/trusted.gpg.d/qgis-archive.gpg --import
           sudo chmod a+r /etc/apt/trusted.gpg.d/qgis-archive.gpg
           sudo add-apt-repository "deb https://qgis.org/ubuntu $(lsb_release -c -s) main"
 

--- a/qfieldsync/core/cloud_api.py
+++ b/qfieldsync/core/cloud_api.py
@@ -81,7 +81,10 @@ def from_reply(reply: QNetworkReply) -> Optional[CloudException]:
 
     message = ""
     try:
-        payload = reply.readAll().data().decode()
+        payload = reply.readAll().data()
+        # workaround to https://github.com/qgis/QGIS/issues/49687
+        content_length = reply.header(QNetworkRequest.ContentLengthHeader)
+        payload = payload[:content_length].decode()
 
         try:
             resp = json.loads(payload)


### PR DESCRIPTION
Workaround to https://github.com/qgis/QGIS/issues/49687