### PR TITLE
Virtual layer handling + fix bad error that breaks cloud converter

### DIFF
--- a/qfieldsync/core/cloud_converter.py
+++ b/qfieldsync/core/cloud_converter.py
@@ -107,6 +107,7 @@ class CloudConverter(QObject):
                             ).format(layer.name()),
                         )
                         self.project.removeMapLayer(layer)
+                        continue
                 else:
                     layer_source.copy(self.export_dirname, list())
                 layer.setCustomProperty(


### PR DESCRIPTION
This PR started with wanting to add safeguards to properly handle a subset of virtual (vector) layers, and ended up discovering a bad issue with the converter that must have led to quite a few failures out there.

First, virtual layer handling. When we detected such a layer, we check whether it is composed of only referenced layers (i.e. in the virtual layer SQL, we only refer to project layer names). If we have only referenced layers, we go ahead and keep the virtual layer in-place. If we detected non-referenced layers, we warn the user that it is not supported and remove it. It'll help users better understand the situation and take relevant actions.

As for the bad error, turns out setting custom properties to a layer that's been removed from the project (i.e. leading to a null pointer) is bad :wink: In this case, it meant that any time the converter would have to remove a layer, we'd automatically bail out and throw a "failed convertion" error as the attempt to access the dereferenced layer would throw an exception. 