### PR TITLE
Increase the timeout for all requests to QFC

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -37,7 +37,7 @@ jobs:
 
   # Run unit tests
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         qgis_version: [release-3_16, latest]
@@ -72,7 +72,7 @@ jobs:
           xvfb-run pytest
 
   release:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       OSGEO_USERNAME: mkuhn
       OSGEO_PASSWORD: ${{ secrets.OSGEO_PASSWORD }}
@@ -87,7 +87,7 @@ jobs:
           submodules: recursive
       - name: Install dependencies
         run: |
-          sudo apt update && sudo apt install qttools5-dev-tools qt5-default
+          sudo apt update && sudo apt install qtbase5-dev qttools5-dev-tools
           sudo pip install qgis-plugin-ci
       - name: Release
         run: |
@@ -101,7 +101,7 @@ jobs:
               --osgeo-password ${OSGEO_PASSWORD}
 
   package:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       TX_TOKEN: ${{ secrets.TX_TOKEN }}
@@ -115,7 +115,7 @@ jobs:
           ref: ${{ github.event.inputs.ref }}
       - name: Install dependencies
         run: |
-          sudo apt update && sudo apt install qttools5-dev-tools qt5-default
+          sudo apt update && sudo apt install qtbase5-dev qttools5-dev-tools
           sudo pip install qgis-plugin-ci
       - name: Release
         run: |
@@ -127,7 +127,7 @@ jobs:
           path: ./qfieldsync.${{ github.event.inputs.ref }}.zip
 
   translations:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       TX_TOKEN: ${{ secrets.TX_TOKEN }}
     if: ${{ github.ref == 'refs/heads/master' && github.event_name == 'push' }}

--- a/qfieldsync/core/cloud_api.py
+++ b/qfieldsync/core/cloud_api.py
@@ -401,7 +401,9 @@ class CloudNetworkAccessManager(QObject):
                 b"Authorization", "Token {}".format(self._token).encode("utf-8")
             )
 
-        reply = self._nam.get(request)
+        with disable_nam_timeout(self._nam):
+            reply = self._nam.get(request)
+
         reply.sslErrors.connect(lambda sslErrors: reply.ignoreSslErrors(sslErrors))
         reply.setParent(self)
 
@@ -421,7 +423,9 @@ class CloudNetworkAccessManager(QObject):
             QNetworkRequest.UserVerifiedRedirectPolicy,
         )
 
-        reply = self._nam.get(request)
+        with disable_nam_timeout(self._nam):
+            reply = self._nam.get(request)
+
         reply.sslErrors.connect(lambda sslErrors: reply.ignoreSslErrors(sslErrors))
         reply.setParent(self)
 
@@ -464,7 +468,10 @@ class CloudNetworkAccessManager(QObject):
             )
 
         payload_bytes = b"" if payload is None else json.dumps(payload).encode("utf-8")
-        reply = self._nam.post(request, payload_bytes)
+
+        with disable_nam_timeout(self._nam):
+            reply = self._nam.post(request, payload_bytes)
+
         reply.sslErrors.connect(lambda sslErrors: reply.ignoreSslErrors(sslErrors))
         reply.setParent(self)
 
@@ -487,7 +494,10 @@ class CloudNetworkAccessManager(QObject):
             )
 
         payload_bytes = b"" if payload is None else json.dumps(payload).encode("utf-8")
-        reply = self._nam.put(request, payload_bytes)
+
+        with disable_nam_timeout(self._nam):
+            reply = self._nam.put(request, payload_bytes)
+
         reply.sslErrors.connect(lambda sslErrors: reply.ignoreSslErrors(sslErrors))
         reply.setParent(self)
 
@@ -511,7 +521,9 @@ class CloudNetworkAccessManager(QObject):
 
         payload_bytes = b"" if payload is None else json.dumps(payload).encode("utf-8")
 
-        reply = self._nam.sendCustomRequest(request, b"PATCH", payload_bytes)
+        with disable_nam_timeout(self._nam):
+            reply = self._nam.sendCustomRequest(request, b"PATCH", payload_bytes)
+
         reply.sslErrors.connect(lambda sslErrors: reply.ignoreSslErrors(sslErrors))
         reply.setParent(self)
 
@@ -531,7 +543,9 @@ class CloudNetworkAccessManager(QObject):
                 b"Authorization", "Token {}".format(self._token).encode("utf-8")
             )
 
-        reply = self._nam.deleteResource(request)
+        with disable_nam_timeout(self._nam):
+            reply = self._nam.deleteResource(request)
+
         reply.sslErrors.connect(lambda sslErrors: reply.ignoreSslErrors(sslErrors))
         reply.setParent(self)
 


### PR DESCRIPTION
Whenever QFC API is requested to list the project files, it asks the S3 API to return the list of files and versions. As the file list grows, it only gets slower. In their case it takes 1.5min+ to respond for 4k files.

1) Fastest: make the API respond with files only, so don't iterate 10*N files, but N only.
- server side changes, around 0.5-1 day
- qfieldsync changes, so it calls the new endpoint that serves the files.

2) Medium: store all file metadata in the DB, instead of polling the S3 storage. DB should be way faster.
- server side only, few days

3) Slow: we need to add pagination on pretty much all data.
- server side, few days
- qfieldsynnc
- qfield
- qfieldcloud-sdk
- 