### PR TITLE
Avoid crashing when the importDirectoryProject preference is not a valid JSON

### DIFF
--- a/qfieldsync/gui/synchronize_dialog.py
+++ b/qfieldsync/gui/synchronize_dialog.py
@@ -65,7 +65,10 @@ class SynchronizeDialog(QDialog, DialogUi):
         self.button_box.button(QDialogButtonBox.Save).clicked.connect(
             lambda: self.start_synchronization()
         )
-        import_dir = self.preferences.value("importDirectoryProject")
+        try:
+            import_dir = self.preferences.value("importDirectoryProject")
+        except ValueError:
+            import_dir = None
         if not import_dir:
             import_dir = self.preferences.value("importDirectory")
 


### PR DESCRIPTION
This should fix https://github.com/opengisch/QField/issues/3896 -- not sure why 4.3.0 would have triggered the regression since none of the code / preference involved here is new. In any case, this commit harden the code.