### PR TITLE
Revert `importDirectoryProject` to a preference of type `String`

### DIFF
--- a/qfieldsync/core/preferences.py
+++ b/qfieldsync/core/preferences.py
@@ -23,7 +23,7 @@ class Preferences(SettingManager):
         self.add_setting(
             String("importDirectory", Scope.Global, str(home.joinpath("QField/import")))
         )
-        self.add_setting(Dictionary("importDirectoryProject", Scope.Project, {}))
+        self.add_setting(String("importDirectoryProject", Scope.Project, None))
         self.add_setting(Dictionary("importDirsToCopy", Scope.Global, {}))
         self.add_setting(Stringlist("attachmentDirs", Scope.Project, ["DCIM"]))
         self.add_setting(Dictionary("qfieldCloudProjectLocalDirs", Scope.Global, {}))

--- a/qfieldsync/gui/synchronize_dialog.py
+++ b/qfieldsync/gui/synchronize_dialog.py
@@ -65,10 +65,7 @@ class SynchronizeDialog(QDialog, DialogUi):
         self.button_box.button(QDialogButtonBox.Save).clicked.connect(
             lambda: self.start_synchronization()
         )
-        try:
-            import_dir = self.preferences.value("importDirectoryProject")
-        except ValueError:
-            import_dir = None
+        import_dir = self.preferences.value("importDirectoryProject")
         if not import_dir:
             import_dir = self.preferences.value("importDirectory")
 


### PR DESCRIPTION
By mistake it was set to a `Dictionary`, most probably when I was editing the next line `importDirsToCopy`.

This error caused regressions in 4.3.0 as reported in https://github.com/opengisch/QField/issues/3896