### PR TITLE
Make the QField tab in project preferences scrollable

### DIFF
--- a/qfieldsync/ui/project_configuration_widget.ui
+++ b/qfieldsync/ui/project_configuration_widget.ui
@@ -19,371 +19,420 @@
   <property name="windowTitle">
    <string>Configure Project for QField Synchronisation</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout_3">
-   <item row="2" column="0">
-    <widget class="QgsCollapsibleGroupBox" name="advancedSettingsGroupBox">
-     <property name="title">
-      <string>Advanced Settings</string>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item>
+    <widget class="QScrollArea" name="scrollArea">
+     <property name="frameShape">
+      <enum>QFrame::NoFrame</enum>
      </property>
-     <property name="checkable">
-      <bool>false</bool>
-     </property>
-     <property name="collapsed">
-      <bool>false</bool>
-     </property>
-     <property name="saveCollapsedState">
+     <property name="widgetResizable">
       <bool>true</bool>
      </property>
-     <layout class="QGridLayout" name="gridLayout_8" columnstretch="1,3">
-      <item row="0" column="0">
-      <widget class="QLabel" name="labelDigitizingLogsLayer">
-      <property name="text">
-       <string>Digitizing logs layer</string>
+     <widget class="QWidget" name="scrollAreaWidgetContents">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>716</width>
+        <height>897</height>
+       </rect>
       </property>
-      <property name="alignment">
-       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-      </property>
-      </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QgsMapLayerComboBox" name="digitizingLogsLayerComboBox"/>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="areaOfInterestLabel">
-        <property name="text">
-         <string>Area of interest</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="QCheckBox" name="onlyOfflineCopyFeaturesInAoi">
-        <property name="text">
-         <string>Only copy features in area of interest</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="0">
-       <widget class="QLabel" name="maximumImageWidthHeightLabel">
-        <property name="text">
-         <string>Max. image attachment
-(width or height)</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="1">
-       <widget class="QgsSpinBox" name="maximumImageWidthHeight">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="toolTip">
-         <string>This number sets the maximum allowed width or height (in pixels) of an image attached to feature forms.</string>
-        </property>
-        <property name="suffix">
-         <string> px</string>
-        </property>
-        <property name="minimum">
-         <number>0</number>
-        </property>
-        <property name="maximum">
-         <number>99999999</number>
-        </property>
-        <property name="value">
-         <number>0</number>
-        </property>
-        <property name="clearValue" stdset="0">
-        <double>0</double>
-        </property>
-        <property name="showClearButton" stdset="0">
-        <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="0">
-       <widget class="QLabel" name="attachmentDirsLabel">
-        <property name="toolTip">
-         <string>A list of directories and files to be treated as attachments. Usually the directories that store images and/or SVG are here.</string>
-        </property>
-        <property name="text">
-         <string>Attachment directories</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="1">
-       <widget class="QListWidget" name="attachmentDirsListWidget" />
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="0" column="0">
-    <widget class="QTabWidget" name="exportTypeTabs">
-     <property name="currentIndex">
-      <number>0</number>
-     </property>
-     <widget class="QWidget" name="cloudExportTab">
-      <attribute name="title">
-       <string>QFieldCloud</string>
-      </attribute>
-      <layout class="QGridLayout" name="gridLayout_2" columnstretch="1,1,0">
-       <item row="0" column="0">
-        <widget class="QRadioButton" name="preferOnlineLayersRadioButton">
-         <property name="text">
-          <string>Prefer online layers</string>
+      <layout class="QVBoxLayout" name="verticalLayout">
+       <item>
+        <widget class="QTabWidget" name="exportTypeTabs">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
          </property>
-         <property name="checked">
+         <property name="currentIndex">
+          <number>0</number>
+         </property>
+         <widget class="QWidget" name="cloudExportTab">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <attribute name="title">
+           <string>QFieldCloud</string>
+          </attribute>
+          <layout class="QGridLayout" name="gridLayout_2" columnstretch="1,0,0">
+           <item row="0" column="0">
+            <widget class="QRadioButton" name="preferOnlineLayersRadioButton">
+             <property name="text">
+              <string>Prefer online layers</string>
+             </property>
+             <property name="checked">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="0" colspan="3">
+            <widget class="QgsCollapsibleGroupBox" name="cloudAdvancedSettings">
+             <property name="title">
+              <string>Individual Layers Settings</string>
+             </property>
+             <property name="collapsed">
+              <bool>true</bool>
+             </property>
+             <property name="saveCheckedState">
+              <bool>true</bool>
+             </property>
+             <layout class="QVBoxLayout" name="verticalLayout_4"/>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <widget class="QRadioButton" name="preferOfflineLayersRadioButton">
+             <property name="text">
+              <string>Prefer offline layers</string>
+             </property>
+            </widget>
+           </item>
+           <item row="4" column="0" colspan="3">
+            <spacer name="verticalSpacer_2">
+             <property name="orientation">
+              <enum>Qt::Vertical</enum>
+             </property>
+             <property name="sizeType">
+              <enum>QSizePolicy::MinimumExpanding</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>20</width>
+               <height>0</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
+         </widget>
+         <widget class="QWidget" name="cableExportTab">
+          <attribute name="title">
+           <string>Cable Export</string>
+          </attribute>
+          <layout class="QGridLayout" name="gridLayout_6"/>
+         </widget>
+        </widget>
+       </item>
+       <item>
+        <widget class="QgsCollapsibleGroupBox" name="createBaseMapGroupBox">
+         <property name="title">
+          <string>Base Map</string>
+         </property>
+         <property name="checkable">
           <bool>true</bool>
          </property>
-        </widget>
-       </item>
-       <item row="0" column="1">
-        <widget class="QRadioButton" name="preferOfflineLayersRadioButton">
-         <property name="text">
-          <string>Prefer offline layers</string>
+         <property name="saveCheckedState">
+          <bool>true</bool>
          </property>
+         <layout class="QGridLayout" name="gridLayout" columnstretch="1,3">
+          <item row="3" column="0">
+           <widget class="QLabel" name="mapUnitsPerPixelLabel">
+            <property name="text">
+             <string>Map units per pixel</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0">
+           <widget class="QRadioButton" name="singleLayerRadioButton">
+            <property name="text">
+             <string>Single layer</string>
+            </property>
+            <attribute name="buttonGroup">
+             <string notr="true">buttonGroup</string>
+            </attribute>
+           </widget>
+          </item>
+          <item row="1" column="0" colspan="2">
+           <widget class="QStackedWidget" name="baseMapTypeStack">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="inputMethodHints">
+             <set>Qt::ImhDialableCharactersOnly</set>
+            </property>
+            <widget class="QWidget" name="mapThemePage">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <layout class="QGridLayout" name="gridLayout_4" columnstretch="1,3">
+              <property name="leftMargin">
+               <number>0</number>
+              </property>
+              <property name="topMargin">
+               <number>0</number>
+              </property>
+              <property name="rightMargin">
+               <number>0</number>
+              </property>
+              <property name="bottomMargin">
+               <number>0</number>
+              </property>
+              <item row="0" column="0">
+               <widget class="QLabel" name="label">
+                <property name="text">
+                 <string>Map Theme</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="1">
+               <widget class="QComboBox" name="mapThemeComboBox"/>
+              </item>
+             </layout>
+            </widget>
+            <widget class="QWidget" name="singleLayerPage">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <layout class="QGridLayout" name="gridLayout_5" columnstretch="1,3">
+              <property name="leftMargin">
+               <number>0</number>
+              </property>
+              <property name="topMargin">
+               <number>0</number>
+              </property>
+              <property name="rightMargin">
+               <number>0</number>
+              </property>
+              <property name="bottomMargin">
+               <number>0</number>
+              </property>
+              <item row="0" column="0">
+               <widget class="QLabel" name="label_2">
+                <property name="text">
+                 <string>Layer</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="1">
+               <widget class="QgsMapLayerComboBox" name="layerComboBox"/>
+              </item>
+             </layout>
+            </widget>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QgsSpinBox" name="tileSize">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="toolTip">
+             <string>Rendering will happen in tiles. This number determines the width and height (in pixels) that will be rendered per tile.</string>
+            </property>
+            <property name="suffix">
+             <string> px</string>
+            </property>
+            <property name="minimum">
+             <number>1</number>
+            </property>
+            <property name="maximum">
+             <number>10240</number>
+            </property>
+            <property name="value">
+             <number>1024</number>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="QgsDoubleSpinBox" name="mapUnitsPerPixel">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="toolTip">
+             <string>This determines the spatial resolution of the resulting map image. It depends on the CRS of the map canvas. For map units in [m], a value of 1 means each pixel covers an area of 1x1 m, a value of 1000 means 1 pixel per square kilometer.</string>
+            </property>
+            <property name="suffix">
+             <string> mupp</string>
+            </property>
+            <property name="value">
+             <double>99.989999999999995</double>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QRadioButton" name="mapThemeRadioButton">
+            <property name="text">
+             <string>Map theme</string>
+            </property>
+            <attribute name="buttonGroup">
+             <string notr="true">buttonGroup</string>
+            </attribute>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="tileSizeLabel">
+            <property name="text">
+             <string>Tile size</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </widget>
        </item>
-       <item row="4" column="0" colspan="3">
-        <spacer name="verticalSpacer_2">
+       <item>
+        <widget class="QgsCollapsibleGroupBox" name="advancedSettingsGroupBox">
+         <property name="title">
+          <string>Advanced Settings</string>
+         </property>
+         <property name="checkable">
+          <bool>false</bool>
+         </property>
+         <property name="collapsed">
+          <bool>false</bool>
+         </property>
+         <property name="saveCollapsedState">
+          <bool>true</bool>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_8" columnstretch="1,3">
+          <item row="4" column="0">
+           <widget class="QLabel" name="attachmentDirsLabel">
+            <property name="toolTip">
+             <string>A list of directories and files to be treated as attachments. Usually the directories that store images and/or SVG are here.</string>
+            </property>
+            <property name="text">
+             <string>Attachment directories</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="1">
+           <widget class="QListWidget" name="attachmentDirsListWidget"/>
+          </item>
+          <item row="0" column="0">
+           <widget class="QLabel" name="labelDigitizingLogsLayer">
+            <property name="text">
+             <string>Digitizing logs layer</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QCheckBox" name="onlyOfflineCopyFeaturesInAoi">
+            <property name="text">
+             <string>Only copy features in area of interest</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="QgsSpinBox" name="maximumImageWidthHeight">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="toolTip">
+             <string>This number sets the maximum allowed width or height (in pixels) of an image attached to feature forms.</string>
+            </property>
+            <property name="suffix">
+             <string> px</string>
+            </property>
+            <property name="minimum">
+             <number>0</number>
+            </property>
+            <property name="maximum">
+             <number>99999999</number>
+            </property>
+            <property name="value">
+             <number>0</number>
+            </property>
+            <property name="showClearButton">
+             <bool>true</bool>
+            </property>
+            <property name="clearValue">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="maximumImageWidthHeightLabel">
+            <property name="text">
+             <string>Max. image attachment
+(width or height)</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="areaOfInterestLabel">
+            <property name="text">
+             <string>Area of interest</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QgsMapLayerComboBox" name="digitizingLogsLayerComboBox"/>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
            <width>20</width>
-           <height>0</height>
+           <height>40</height>
           </size>
          </property>
         </spacer>
        </item>
-       <item row="3" column="0" colspan="3">
-        <widget class="QgsCollapsibleGroupBox" name="cloudAdvancedSettings">
-         <property name="title">
-          <string>Individual Layers Settings</string>
-         </property>
-         <property name="collapsed">
-          <bool>true</bool>
-         </property>
-         <property name="saveCheckedState">
-          <bool>true</bool>
-         </property>
-         <layout class="QVBoxLayout" name="verticalLayout_4"/>
-        </widget>
-       </item>
       </layout>
      </widget>
-     <widget class="QWidget" name="cableExportTab">
-      <attribute name="title">
-       <string>Cable Export</string>
-      </attribute>
-      <layout class="QGridLayout" name="gridLayout_6"/>
-     </widget>
     </widget>
-   </item>
-   <item row="1" column="0">
-    <widget class="QgsCollapsibleGroupBox" name="createBaseMapGroupBox">
-     <property name="title">
-      <string>Base Map</string>
-     </property>
-     <property name="checkable">
-      <bool>true</bool>
-     </property>
-     <property name="saveCheckedState">
-      <bool>true</bool>
-     </property>
-     <layout class="QGridLayout" name="gridLayout" columnstretch="1,3">
-      <item row="3" column="0">
-       <widget class="QLabel" name="mapUnitsPerPixelLabel">
-        <property name="text">
-         <string>Map units per pixel</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0">
-       <widget class="QRadioButton" name="singleLayerRadioButton">
-        <property name="text">
-         <string>Single layer</string>
-        </property>
-        <attribute name="buttonGroup">
-         <string notr="true">buttonGroup</string>
-        </attribute>
-       </widget>
-      </item>
-      <item row="1" column="0" colspan="2">
-       <widget class="QStackedWidget" name="baseMapTypeStack">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="inputMethodHints">
-         <set>Qt::ImhDialableCharactersOnly</set>
-        </property>
-        <widget class="QWidget" name="mapThemePage">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <layout class="QGridLayout" name="gridLayout_4" columnstretch="1,3">
-          <property name="leftMargin">
-           <number>0</number>
-          </property>
-          <property name="topMargin">
-           <number>0</number>
-          </property>
-          <property name="rightMargin">
-           <number>0</number>
-          </property>
-          <property name="bottomMargin">
-           <number>0</number>
-          </property>
-          <item row="0" column="0">
-           <widget class="QLabel" name="label">
-            <property name="text">
-             <string>Map Theme</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="QComboBox" name="mapThemeComboBox"/>
-          </item>
-         </layout>
-        </widget>
-        <widget class="QWidget" name="singleLayerPage">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <layout class="QGridLayout" name="gridLayout_5" columnstretch="1,3">
-          <property name="leftMargin">
-           <number>0</number>
-          </property>
-          <property name="topMargin">
-           <number>0</number>
-          </property>
-          <property name="rightMargin">
-           <number>0</number>
-          </property>
-          <property name="bottomMargin">
-           <number>0</number>
-          </property>
-          <item row="0" column="0">
-           <widget class="QLabel" name="label_2">
-            <property name="text">
-             <string>Layer</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="QgsMapLayerComboBox" name="layerComboBox"/>
-          </item>
-         </layout>
-        </widget>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="QgsSpinBox" name="tileSize">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="toolTip">
-         <string>Rendering will happen in tiles. This number determines the width and height (in pixels) that will be rendered per tile.</string>
-        </property>
-        <property name="suffix">
-         <string> px</string>
-        </property>
-        <property name="minimum">
-         <number>1</number>
-        </property>
-        <property name="maximum">
-         <number>10240</number>
-        </property>
-        <property name="value">
-         <number>1024</number>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="1">
-       <widget class="QgsDoubleSpinBox" name="mapUnitsPerPixel">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="toolTip">
-         <string>This determines the spatial resolution of the resulting map image. It depends on the CRS of the map canvas. For map units in [m], a value of 1 means each pixel covers an area of 1x1 m, a value of 1000 means 1 pixel per square kilometer.</string>
-        </property>
-        <property name="suffix">
-         <string> mupp</string>
-        </property>
-        <property name="value">
-         <double>99.989999999999995</double>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QRadioButton" name="mapThemeRadioButton">
-        <property name="text">
-         <string>Map theme</string>
-        </property>
-        <attribute name="buttonGroup">
-         <string notr="true">buttonGroup</string>
-        </attribute>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="tileSizeLabel">
-        <property name="text">
-         <string>Tile size</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="3" column="0">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
Fix https://github.com/opengisch/qfieldsync/issues/475.  Can be quite annoying on smaller screens (and not only).

![image](https://user-images.githubusercontent.com/2820439/218272649-6b29b038-0418-478b-a412-02164d618fb4.png)
