### PR TITLE
Show server side error when login failed

### DIFF
--- a/qfieldsync/core/cloud_api.py
+++ b/qfieldsync/core/cloud_api.py
@@ -682,14 +682,16 @@ class CloudNetworkAccessManager(QObject):
 
         error = self.user_details.get("error")
         if self._login_error:
-            if self._login_error.httpCode is None:
+            if self._login_error.httpCode is None or (
+                self._login_error.httpCode >= 400 and self._login_error.httpCode < 500
+            ):
                 error = str(self._login_error)
             elif self._login_error.httpCode >= 500:
                 error = self.tr("Server error {}").format(self._login_error.httpCode)
-            else:
-                error = str(error)
 
-        error = strip_html(error).strip()
+        if error:
+            error = strip_html(error).strip()
+
         html = '<a href="https://app.qfield.cloud/accounts/password/reset/">{}?</a>'.format(
             self.tr("Forgot password")
         )

--- a/qfieldsync/core/cloud_api.py
+++ b/qfieldsync/core/cloud_api.py
@@ -680,25 +680,24 @@ class CloudNetworkAccessManager(QObject):
         if self.has_token():
             return ""
 
-        error = self.user_details.get("error")
+        error_str = ""
         if self._login_error:
-            if self._login_error.httpCode is None or (
-                self._login_error.httpCode >= 400 and self._login_error.httpCode < 500
-            ):
-                error = str(self._login_error)
-            elif self._login_error.httpCode >= 500:
-                error = self.tr("Server error {}").format(self._login_error.httpCode)
+            http_code = self._login_error.httpCode
+            if http_code and http_code >= 500:
+                error_str = self.tr("Server error {}").format(http_code)
+            elif http_code is None or (http_code >= 400 and http_code < 500):
+                error_str = str(self._login_error)
+        
+        error_str = strip_html(error_str).strip()
 
-        if error:
-            error = strip_html(error).strip()
+        if not error_str:
+            error_str = self.tr("Sign in failed.")
 
         html = '<a href="https://app.qfield.cloud/accounts/password/reset/">{}?</a>'.format(
             self.tr("Forgot password")
         )
-        if error:
-            return self.tr("Sign in failed: {}. {}").format(str(error), html)
-        else:
-            return self.tr("Sign in failed. {}").format(html)
+
+        return self.tr("{}. {}").format(error_str, html)
 
     def _clear_cloud_cookies(self, url: QUrl) -> None:
         """When the CSRF_TOKEN cookie is present and the plugin is reloaded, the token has expired"""


### PR DESCRIPTION
EDIT:
Even better now.
![image](https://github.com/opengisch/qfieldsync/assets/2820439/752dfac2-1aa8-4d0c-b920-cee6aa4d9177)


---

So far it was showing "Failed to login: None"

![image](https://github.com/opengisch/qfieldsync/assets/2820439/d1695d7a-a18d-4c7e-87bd-e10cd4208a9c)


Fixes #511