### PR TITLE
Make project form on create and edit to look more similar

### DIFF
--- a/qfieldsync/gui/cloud_create_project_widget.py
+++ b/qfieldsync/gui/cloud_create_project_widget.py
@@ -99,7 +99,7 @@ class CloudCreateProjectWidget(QWidget, WidgetUi):
         self.nextButton.clicked.connect(self.on_next_button_clicked)
         self.backButton.clicked.connect(self.on_back_button_clicked)
         self.createButton.clicked.connect(self.on_create_button_clicked)
-        self.localDirButton.clicked.connect(lambda: self.on_local_dir_button_clicked())
+        self.localDirButton.clicked.connect(self.on_local_dir_button_clicked)
         self.localDirLineEdit.textChanged.connect(
             self.on_dirname_line_edit_text_changed
         )
@@ -114,9 +114,7 @@ class CloudCreateProjectWidget(QWidget, WidgetUi):
         self.localDirButton.setPopupMode(QToolButton.MenuButtonPopup)
         self.localDirButton.menu().addAction(self.use_current_project_directory_action)
 
-        self.localDirOpenButton.clicked.connect(
-            lambda: self.on_local_dir_open_button_clicked()
-        )
+        self.localDirOpenButton.clicked.connect(self.on_local_dir_open_button_clicked)
         self.localDirOpenButton.setIcon(
             QgsApplication.getThemeIcon("/mActionFileOpen.svg")
         )

--- a/qfieldsync/ui/cloud_create_project_widget.ui
+++ b/qfieldsync/ui/cloud_create_project_widget.ui
@@ -155,40 +155,22 @@
           <string>Project Details</string>
          </property>
          <layout class="QGridLayout" name="gridLayout_4">
-          <item row="1" column="0">
-           <widget class="QLabel" name="projectDescriptionLabel">
-            <property name="text">
-             <string>Project description</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="1">
-           <layout class="QGridLayout" name="localDirHBoxLayout">
-            <item row="0" column="1">
-             <widget class="QToolButton" name="dirnameButton">
-              <property name="text">
-               <string>...</string>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="0">
-             <widget class="QLineEdit" name="dirnameLineEdit"/>
-            </item>
-           </layout>
-          </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="dirnameLabel">
-            <property name="text">
-             <string>Local directory</string>
-            </property>
-           </widget>
-          </item>
           <item row="0" column="0">
            <widget class="QLabel" name="projectNameLabel">
             <property name="text">
-             <string>Project name</string>
+             <string>Name</string>
             </property>
            </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="projectDescriptionLabel">
+            <property name="text">
+             <string>Description</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QTextEdit" name="projectDescriptionTextEdit"/>
           </item>
           <item row="0" column="1">
            <widget class="QLineEdit" name="projectNameLineEdit">
@@ -203,11 +185,52 @@
             </property>
            </widget>
           </item>
-          <item row="1" column="1">
-           <widget class="QTextEdit" name="projectDescriptionTextEdit"/>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="projectsOfflineSettingsGroupBox">
+         <property name="title">
+          <string>Local Project Settings</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_2" columnstretch="1,4">
+          <item row="0" column="1">
+           <layout class="QHBoxLayout" name="localDirHBoxLayout_2">
+            <item>
+             <widget class="QLineEdit" name="localDirLineEdit"/>
+            </item>
+            <item>
+             <widget class="QToolButton" name="localDirButton">
+              <property name="text">
+               <string>...</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="localDirOpenButton">
+              <property name="toolTip">
+               <string>Open in external file browser</string>
+              </property>
+              <property name="text">
+               <string/>
+              </property>
+              <property name="icon">
+               <iconset>
+                <normaloff>../resources/launch.svg</normaloff>../resources/launch.svg</iconset>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </item>
-          <item row="3" column="1">
-           <widget class="QLabel" name="dirnameFeedbackLabel">
+          <item row="0" column="0">
+           <widget class="QLabel" name="localDirLabel">
+            <property name="text">
+             <string>Local Directory</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QLabel" name="localDirFeedbackLabel">
             <property name="text">
              <string/>
             </property>


### PR DESCRIPTION
Also renamed the elements to have the same name to reduce cognitive needs.

| before | after |
|-|-|
| ![image](https://github.com/opengisch/qfieldsync/assets/2820439/2de34ae2-5fbe-490d-b5d2-b109404b0e69) | ![image](https://github.com/opengisch/qfieldsync/assets/2820439/c137f52e-58a8-445d-8be5-e5149d788225) |
