### PR TITLE
Insure login dialog is front and center

### DIFF
--- a/qfieldsync/gui/cloud_login_dialog.py
+++ b/qfieldsync/gui/cloud_login_dialog.py
@@ -54,6 +54,8 @@ class CloudLoginDialog(QDialog, CloudLoginDialogUi):
     ):
         if CloudLoginDialog.instance:
             CloudLoginDialog.instance.show()
+            CloudLoginDialog.instance.raise_()
+            CloudLoginDialog.instance.activateWindow()
             return CloudLoginDialog.instance
 
         CloudLoginDialog.instance = CloudLoginDialog(network_manager, parent)
@@ -153,6 +155,8 @@ class CloudLoginDialog(QDialog, CloudLoginDialogUi):
 
         if not cfg.config("token") or not self.parent():
             self.show()
+            self.raise_()
+            self.activateWindow()
 
     def on_login_button_clicked(self) -> None:
         QApplication.setOverrideCursor(Qt.WaitCursor)

--- a/qfieldsync/gui/cloud_projects_dialog.py
+++ b/qfieldsync/gui/cloud_projects_dialog.py
@@ -121,20 +121,6 @@ class CloudProjectsDialog(QDialog, CloudProjectsDialogUi):
 
         self.update_welcome_label()
 
-        if self.network_manager.has_token():
-            self.show_projects()
-            self.show()
-            self.createButton.setEnabled(True)
-        else:
-            CloudLoginDialog.show_auth_dialog(
-                self.network_manager,
-                lambda: self.on_auth_accepted(),
-                lambda: self.close(),
-                parent=self,
-            )
-            self.hide()
-            self.createButton.setEnabled(False)
-
         self.use_current_project_directory_action = QAction(
             QIcon(), self.tr("Use Current Project Directory")
         )
@@ -175,6 +161,20 @@ class CloudProjectsDialog(QDialog, CloudProjectsDialogUi):
         )
         self.deleteButton.setEnabled(False)
 
+        self.show()
+
+        if self.network_manager.has_token():
+            self.show_projects()
+            self.createButton.setEnabled(True)
+        else:
+            CloudLoginDialog.show_auth_dialog(
+                self.network_manager,
+                lambda: self.on_auth_accepted(),
+                lambda: self.close(),
+                parent=self,
+            )
+            self.createButton.setEnabled(False)
+
         self.projectsStack.setCurrentWidget(self.projectsListPage)
         self.createProjectWidget = CloudCreateProjectWidget(
             iface,
@@ -182,6 +182,7 @@ class CloudProjectsDialog(QDialog, CloudProjectsDialogUi):
             QgsProject.instance(),
             self,
         )
+
         self.projectCreatePage.layout().addWidget(self.createProjectWidget)
         self.createProjectWidget.finished.connect(
             lambda project_id: self.on_create_project_finished(project_id)


### PR DESCRIPTION
Calling raise() and activateWindow() is used to insure dialogs are raised to the top, let's call this to avoid dialog stacking confusion on macos.

Also, the cloud projects dialog was mishandling its visible state (calling self.hide() prior to opening the login window only to have it re-shown after constructor (by show_cloud_overview_dialog(self)). This lead to the (disabled) projects dialog being focused instead of the login dialog. I suspect that will also alleviate whatever is going on with macos.