### PR TITLE
Implement a feature-based geometry lock mechanism

### DIFF
--- a/qfieldsync/ui/map_layer_config_widget.ui
+++ b/qfieldsync/ui/map_layer_config_widget.ui
@@ -39,20 +39,51 @@
     </widget>
    </item>
    <item row="2" column="1">
-    <widget class="QCheckBox" name="isGeometryLockedCheckBox">
-     <property name="toolTip">
-      <string>When enabled, this option disables adding and deleting features, as well as modifying the geometries of existing features.</string>
-     </property>
-     <property name="text">
-      <string>Lock geometries</string>
-     </property>
-    </widget>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QCheckBox" name="isGeometryLockedCheckBox">
+       <property name="toolTip">
+        <string>When enabled, this option disables adding and deleting features, as well as modifying the geometries of existing features.</string>
+       </property>
+       <property name="text">
+        <string>Lock geometries</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QgsPropertyOverrideButton" name="isGeometryLockedDDButton">
+       <property name="text">
+        <string>…</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>20</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
    </item>
    <item row="1" column="1">
     <widget class="QComboBox" name="cableLayerActionComboBox"/>
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsPropertyOverrideButton</class>
+   <extends>QToolButton</extends>
+   <header>qgspropertyoverridebutton.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>


### PR DESCRIPTION
This PR implements a functionality in qfieldsync allowing users to determine the locked geometry state of individual features within a vector layer.

First, here's a screenshot of the UI:

![image](https://github.com/opengisch/qfieldsync/assets/1728657/888750b8-dd83-473d-b9e3-fd3cfdcb875c)

A brand new data-defined property button sits next to the [x] lock geometry checkbox. From there, users can select a feature attribute or build a more complex expression that will change the locked geometry status of individual features.

_(Requires https://github.com/opengisch/libqfieldsync/pull/58 on the libqfieldsync side of things)_