### PR TITLE
New setting to toggle visibility of non-cloud packaging toolbar buttons, hide by default

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -110,16 +110,16 @@ jobs:
               --osgeo-password ${OSGEO_PASSWORD} \
               --asset-path qfieldsync/libqfieldsync.whl
 
-      - name: Release
+      - name: Package
         if: ${{ github.event_name == 'pull_request' }}
         run: |
-          qgis-plugin-ci package dev \
+          qgis-plugin-ci package 0.1 \
               --asset-path qfieldsync/libqfieldsync.whl
 
       - uses: actions/upload-artifact@v3
         with:
           name: qfieldsync-plugin
-          path: qfieldsync.dev.zip
+          path: qfieldsync.0.1.zip
   package:
     runs-on: ubuntu-22.04
     env:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,0 +1,27 @@
+---
+name: 📜 Documentation
+on:
+  pull_request_target:
+    types:
+      - closed
+      - labeled
+jobs:
+  backport:
+    runs-on: ubuntu-latest
+    name: Create documentation task
+    if: contains(github.event.pull_request.labels.*.name, 'needs documentation')
+    steps:
+      - name: Create task
+        run: |
+          curl -i -X POST \
+            'https://api.clickup.com/api/v2/list/900400532890/task' \
+            -H 'Authorization: ${{ secrets.CLICKUP_TOKEN}}' \
+            -H 'Content-Type: application/json' \
+            -d '{
+              "name": "${{ github.context.payload.pull_request.title }}",
+              "description": "Coming from pull request ${{ github.context.payload.pull_request.url }}",
+              "tags": [
+                "qfield"
+              ],
+              "status": "Open"
+            }'

--- a/qfieldsync/core/preferences.py
+++ b/qfieldsync/core/preferences.py
@@ -23,6 +23,7 @@ class Preferences(SettingManager):
         self.add_setting(
             String("importDirectory", Scope.Global, str(home.joinpath("QField/import")))
         )
+        self.add_setting(Bool("showPackagingActions", Scope.Global, False))
         self.add_setting(String("importDirectoryProject", Scope.Project, None))
         self.add_setting(Dictionary("dirsToCopy", Scope.Project, {}))
         self.add_setting(Stringlist("attachmentDirs", Scope.Project, ["DCIM"]))

--- a/qfieldsync/gui/preferences_widget.py
+++ b/qfieldsync/gui/preferences_widget.py
@@ -35,7 +35,8 @@ WidgetUi, _ = loadUiType(
 
 
 class PreferencesWidget(WidgetUi, QgsOptionsPageWidget, SettingDialog):
-    def __init__(self, parent=None):
+    def __init__(self, qfieldSync, parent=None):
+        self.qfieldSync = qfieldSync
         preferences = Preferences()
         SettingDialog.__init__(self, setting_manager=preferences)
         super().__init__(parent, setting_manager=preferences)
@@ -54,3 +55,4 @@ class PreferencesWidget(WidgetUi, QgsOptionsPageWidget, SettingDialog):
 
     def apply(self):
         self.set_values_from_widgets()
+        self.qfieldSync.update_button_visibility()

--- a/qfieldsync/ui/preferences_widget.ui
+++ b/qfieldsync/ui/preferences_widget.ui
@@ -95,6 +95,16 @@
       <item row="2" column="1">
        <widget class="QgsFileWidget" name="exportDirectory"/>
       </item>
+      <item row="3" column="0" colspan="2">
+       <widget class="QCheckBox" name="showPackagingActions">
+        <property name="text">
+         <string>Show packaging actions in the toolbar</string>
+        </property>
+        <property name="toolTip">
+         <string>Store QFieldCloud credentials and automatically sign in on QGIS startup.</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>


### PR DESCRIPTION
This will need a bit of documentation tweaked. In an attempt to streamline the QField experience for newcomers, we are now hiding cable export/import toolbar buttons so the cloud path becomes "clearer". The cable actions are still available in the plugins -> QFieldSync sub menu, and _can be made visible in the toolbar_ view a new setting checkbox.

UI:
![image](https://github.com/opengisch/qfieldsync/assets/1728657/45fdec8b-8cf8-4533-bd61-0a70dec05524)

Looks:
![image](https://github.com/opengisch/qfieldsync/assets/1728657/d134dadf-4ff3-49f3-a8a6-e36b0b693d7a)

![image](https://github.com/opengisch/qfieldsync/assets/1728657/751afa08-9641-4e96-bb1d-1bfdab942e49)
