### PR TITLE
Properly name the QFieldSync toolbar

### DIFF
--- a/qfieldsync/qfield_sync.py
+++ b/qfieldsync/qfield_sync.py
@@ -113,8 +113,8 @@ class QFieldSync(object):
         self.actions = []
         self.menu = self.tr("&QFieldSync")
         # TODO: We are going to let the user set this up in a future iteration
-        self.toolbar = self.iface.addToolBar("QFieldSync")
-        self.toolbar.setObjectName("QFieldSync")
+        self.toolbar = self.iface.addToolBar(self.tr("QFieldSync Toolbar"))
+        self.toolbar.setObjectName("QFieldSync Toolbar")
 
         # instance of the map config widget factory, shown in layer properties
         self.mapLayerConfigWidgetFactory = MapLayerConfigWidgetFactory(


### PR DESCRIPTION
Fixing an issue that's been bugging me every time I right clicked on the QGIS main window toolbar area:

![image](https://github.com/opengisch/qfieldsync/assets/1728657/0a895ff2-e978-4ed0-9409-457a733d73c7)

Every single item ends with Toolbar except QFieldSync, let's fix that. The PR also makes the label translatable. Win-win.