### PR TITLE
Allow users to force auto-push and manage time interval via project configuration

### DIFF
--- a/qfieldsync/gui/project_configuration_widget.py
+++ b/qfieldsync/gui/project_configuration_widget.py
@@ -104,6 +104,8 @@ class ProjectConfigurationWidget(WidgetUi, QgsOptionsPageWidget):
         )
         self.singleLayerRadioButton.toggled.connect(self.baseMapTypeChanged)
 
+        self.forceAutoPush.clicked.connect(self.onForceAutoPushClicked)
+
         self.attachmentDirsListWidget.itemChanged.connect(self.onItemChanged)
         self.event_eater = EventEater()
         self.attachmentDirsListWidget.installEventFilter(self.event_eater)
@@ -189,6 +191,14 @@ class ProjectConfigurationWidget(WidgetUi, QgsOptionsPageWidget):
         )
         self.preferOfflineLayersRadioButton.setChecked(
             self.__project_configuration.layer_action_preference == "offline"
+        )
+
+        self.forceAutoPush.setChecked(self.__project_configuration.force_auto_push)
+        self.forceAutoPushInterval.setEnabled(
+            self.__project_configuration.force_auto_push
+        )
+        self.forceAutoPushInterval.setValue(
+            self.__project_configuration.force_auto_push_interval_mins
         )
 
         attachment_dirs = [*self.preferences.value("attachmentDirs")]
@@ -279,6 +289,11 @@ class ProjectConfigurationWidget(WidgetUi, QgsOptionsPageWidget):
             "online" if self.preferOnlineLayersRadioButton.isChecked() else "offline"
         )
 
+        self.__project_configuration.force_auto_push = self.forceAutoPush.isChecked()
+        self.__project_configuration.force_auto_push_interval_mins = (
+            self.forceAutoPushInterval.value()
+        )
+
         v = QLibraryInfo.version()
         match_flag = (
             Qt.MatchRegularExpression
@@ -289,6 +304,9 @@ class ProjectConfigurationWidget(WidgetUi, QgsOptionsPageWidget):
         for item in self.attachmentDirsListWidget.findItems("^\\S+$", match_flag):
             keys[item.text()] = 1
         self.preferences.set_value("attachmentDirs", list(keys.keys()))
+
+    def onForceAutoPushClicked(self, checked):
+        self.forceAutoPushInterval.setEnabled(checked)
 
     def onLayerActionPreferenceChanged(self):
         """Triggered when prefer online or offline radio buttons have been changed"""

--- a/qfieldsync/ui/project_configuration_widget.ui
+++ b/qfieldsync/ui/project_configuration_widget.ui
@@ -104,6 +104,51 @@
             </widget>
            </item>
            <item row="4" column="0" colspan="3">
+            <layout class="QHBoxLayout" name="horizontalLayout">
+             <item>
+              <widget class="QCheckBox" name="forceAutoPush">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="text">
+                <string>Automatically push pending changes on the following interval</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QgsSpinBox" name="forceAutoPushInterval">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                 <horstretch>1</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="suffix">
+                <string> minutes</string>
+               </property>
+               <property name="minimum">
+                <number>1</number>
+               </property>
+               <property name="maximum">
+                <number>2880</number>
+               </property>
+               <property name="value">
+                <number>30</number>
+               </property>
+               <property name="showClearButton">
+                <bool>true</bool>
+               </property>
+               <property name="clearValue">
+                <number>30</number>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+           <item row="5" column="0" colspan="3">
             <spacer name="verticalSpacer_2">
              <property name="orientation">
               <enum>Qt::Vertical</enum>

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ future
 transifex-client
 
 # NOTE `libqfielsync` version should be defined in the `*.tar.gz` format, not `git+https://` to make `wheel` happy
-libqfieldsync @ https://github.com/opengisch/libqfieldsync/archive/e3647e9b0fcbaf74cbb4c3f72bc8f34d99cb44e0.tar.gz
+libqfieldsync @ https://github.com/opengisch/libqfieldsync/archive/3c0b0c4903d0a5e6944779d4d43a64e29542bd87.tar.gz


### PR DESCRIPTION
This PR implements a mechanism through which users/managers of cloud projects can force enable auto-push on QField devices in the field as well as dictating the interval in minutes:

![image](https://github.com/opengisch/qfieldsync/assets/1728657/735b3caa-b370-4bcf-8e31-8396056ca08c)
