### PR TITLE
Fix creation of basemap when feature filtering isn't enabled

### DIFF
--- a/qfieldsync/gui/package_dialog.py
+++ b/qfieldsync/gui/package_dialog.py
@@ -140,20 +140,16 @@ class PackageDialog(QDialog, DialogUi):
         self.button_box.button(QDialogButtonBox.Save).setEnabled(False)
 
         export_folder = self.get_export_folder_from_dialog()
-        if self.__project_configuration.offline_copy_only_aoi:
-            area_of_interest = (
-                self.__project_configuration.area_of_interest
-                if self.__project_configuration.area_of_interest
-                else self.iface.mapCanvas().extent().asWktPolygon()
-            )
-            area_of_interest_crs = (
-                self.__project_configuration.area_of_interest_crs
-                if self.__project_configuration.area_of_interest_crs
-                else QgsProject.instance().crs().authid()
-            )
-        else:
-            area_of_interest = ""
-            area_of_interest_crs = QgsProject.instance().crs().authid()
+        area_of_interest = (
+            self.__project_configuration.area_of_interest
+            if self.__project_configuration.area_of_interest
+            else self.iface.mapCanvas().extent().asWktPolygon()
+        )
+        area_of_interest_crs = (
+            self.__project_configuration.area_of_interest_crs
+            if self.__project_configuration.area_of_interest_crs
+            else QgsProject.instance().crs().authid()
+        )
 
         self.qfield_preferences.set_value("exportDirectoryProject", export_folder)
         self.dirsToCopyWidget.save_settings()

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ future
 transifex-client
 
 # NOTE `libqfielsync` version should be defined in the `*.tar.gz` format, not `git+https://` to make `wheel` happy
-libqfieldsync @ https://github.com/opengisch/libqfieldsync/archive/7936c96967f2e9b350b7039ea7bb88f3947ee588.tar.gz
+libqfieldsync @ https://github.com/opengisch/libqfieldsync/archive/12df4955427a663b9eecb3b5481ff5dde3bdba89.tar.gz


### PR DESCRIPTION
A regression slipped into 4.8.0 with regards to basemap creation during cable export.

Long story short, the UI is a bit deceptive and makes it look like the area of interest is only tied to filtering of feature when in fact it's also tied to basemap creation.

Requires https://github.com/opengisch/libqfieldsync/pull/73