### PR TITLE
Implement UI to control the new value map editor widget's toggle buttons interface

### DIFF
--- a/qfieldsync/gui/map_layer_config_widget.py
+++ b/qfieldsync/gui/map_layer_config_widget.py
@@ -24,7 +24,7 @@ import os
 
 from libqfieldsync.layer import LayerSource
 from qgis.core import QgsMapLayer, QgsProject, QgsProperty, QgsPropertyDefinition
-from qgis.gui import QgsMapLayerConfigWidget, QgsMapLayerConfigWidgetFactory
+from qgis.gui import QgsMapLayerConfigWidget, QgsMapLayerConfigWidgetFactory, QgsSpinBox
 from qgis.PyQt.QtWidgets import QLabel
 from qgis.PyQt.uic import loadUiType
 
@@ -82,6 +82,10 @@ class MapLayerConfigWidget(QgsMapLayerConfigWidget, WidgetUi):
         self.relationshipConfigurationTable.addLayerFields(self.layer_source)
         self.relationshipConfigurationTable.setLayerColumnHidden(True)
 
+        self.valueMapButtonInterfaceSpinBox.setClearValueMode(
+            QgsSpinBox.CustomValue, self.tr("Disabled")
+        )
+
         self.measurementTypeComboBox.addItem(
             "Elapsed time (seconds since start of tracking)"
         )
@@ -122,6 +126,11 @@ class MapLayerConfigWidget(QgsMapLayerConfigWidget, WidgetUi):
             self.isGeometryLockedCheckBox.setChecked(
                 self.layer_source.is_geometry_locked
             )
+
+            self.valueMapButtonInterfaceSpinBox.setValue(
+                self.layer_source.value_map_button_interface_threshold
+            )
+            self.valueMapButtonInterfaceSpinBox.setVisible(True)
 
             # append the attachment naming table to the layout
             self.attachmentsRelationsLayout.insertRow(
@@ -182,6 +191,7 @@ class MapLayerConfigWidget(QgsMapLayerConfigWidget, WidgetUi):
             self.isGeometryLockedDDButton.setVisible(False)
             self.isGeometryLockedCheckBox.setVisible(False)
 
+            self.valueMapButtonInterfaceSpinBox.setVisible(False)
             self.attachmentsRelationsGroupBox.setVisible(False)
             self.trackingSessionGroupBox.setVisible(False)
 
@@ -200,6 +210,11 @@ class MapLayerConfigWidget(QgsMapLayerConfigWidget, WidgetUi):
         prop = self.isGeometryLockedDDButton.toProperty()
         self.layer_source.is_geometry_locked_expression_active = prop.isActive()
         self.layer_source.geometry_locked_expression = prop.asExpression()
+        print(self.valueMapButtonInterfaceSpinBox.value())
+        print(self.valueMapButtonInterfaceSpinBox.value())
+        self.layer_source.value_map_button_interface_threshold = (
+            self.valueMapButtonInterfaceSpinBox.value()
+        )
         self.attachmentNamingTable.syncLayerSourceValues()
         self.relationshipConfigurationTable.syncLayerSourceValues()
 

--- a/qfieldsync/ui/map_layer_config_widget.ui
+++ b/qfieldsync/ui/map_layer_config_widget.ui
@@ -87,9 +87,57 @@
    <item>
     <widget class="QGroupBox" name="attachmentsRelationsGroupBox">
      <property name="title">
-      <string>Attachments and Relationships Settings</string>
+      <string>Feature Form, Attachments and Relationships Settings</string>
      </property>
      <layout class="QFormLayout" name="attachmentsRelationsLayout">
+      <item row="0" column="0" colspan="2">
+       <layout class="QHBoxLayout" name="valueMapButtonInterfaceLayout">
+        <item>
+         <widget class="QLabel" name="valueMapButtonInterfaceLabel">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+            <horstretch>1</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>Item threshold under which value map editor widgets will use a toggle buttons interface</string>
+          </property>
+          <property name="wordWrap">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QgsSpinBox" name="valueMapButtonInterfaceSpinBox">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="suffix">
+           <string> item(s)</string>
+          </property>
+          <property name="minimum">
+           <number>0</number>
+          </property>
+          <property name="maximum">
+           <number>9999999</number>
+          </property>
+          <property name="value">
+           <number>0</number>
+          </property>
+          <property name="showClearButton">
+           <bool>true</bool>
+          </property>
+           <property name="clearValue">
+            <bool>false</bool>
+           </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
      </layout>
     </widget>
    </item>

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ future
 transifex-client
 
 # NOTE `libqfielsync` version should be defined in the `*.tar.gz` format, not `git+https://` to make `wheel` happy
-libqfieldsync @ https://github.com/opengisch/libqfieldsync/archive/c20d5ef6e37e88aace073416af0f1d4f99d09545.tar.gz
+libqfieldsync @ https://github.com/opengisch/libqfieldsync/archive/c98ef2671aca31c7943d3aa4c69221dbdb157d5a.tar.gz


### PR DESCRIPTION
In the future, it'd be great to have the UX implemented in QGIS itself. But for now, let's rely on our beloved qfieldsync to implement a simple layer-level configuration:

![image](https://github.com/opengisch/qfieldsync/assets/1728657/0137312b-51d7-493d-8e41-f02ce0f45a0a)
