### PR TITLE
Do not hardcode a hyperlink color, let the system handle it

### DIFF
--- a/qfieldsync/ui/cloud_login_dialog.ui
+++ b/qfieldsync/ui/cloud_login_dialog.ui
@@ -141,7 +141,7 @@
    <item>
     <widget class="QLabel" name="registerLabel">
      <property name="text">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;New user? &lt;a href=&quot;https://app.qfield.cloud/accounts/signup/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Register an account&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;New user? &lt;a href=&quot;https://app.qfield.cloud/accounts/signup/&quot;&gt;&lt;span&gt;Register an account&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
      <property name="textFormat">
       <enum>Qt::RichText</enum>


### PR DESCRIPTION
Before:
![Screenshot from 2024-06-17 15-19-39](https://github.com/opengisch/qfieldsync/assets/1728657/29000f61-5f09-48db-9607-f698c899be42)

PR:
![Screenshot from 2024-06-17 15-19-54](https://github.com/opengisch/qfieldsync/assets/1728657/c19bf2ef-4236-4c8d-913f-2ab5fb447ae5)

And just like that, the register an account hyperlink is becoming readable! :)