### PR TITLE
Implement geofencing settings in the project properties' QField panel

### DIFF
--- a/qfieldsync/gui/project_configuration_widget.py
+++ b/qfieldsync/gui/project_configuration_widget.py
@@ -110,6 +110,19 @@ class ProjectConfigurationWidget(WidgetUi, QgsOptionsPageWidget):
         self.event_eater = EventEater()
         self.attachmentDirsListWidget.installEventFilter(self.event_eater)
 
+        self.geofencingBehaviorComboBox.addItem(
+            self.tr("Alert users when inside an area"),
+            ProjectProperties.GeofencingBehavior.ALERT_INSIDE_AREAS,
+        )
+        self.geofencingBehaviorComboBox.addItem(
+            self.tr("Alert users when outside all areas"),
+            ProjectProperties.GeofencingBehavior.ALERT_OUTSIDE_AREAS,
+        )
+        self.geofencingBehaviorComboBox.addItem(
+            self.tr("Inform users when entering and leaving an area"),
+            ProjectProperties.GeofencingBehavior.INFORM_ENTER_LEAVE_AREAS,
+        )
+
         self.reloadProject()
 
     def reloadProject(self):
@@ -185,8 +198,10 @@ class ProjectConfigurationWidget(WidgetUi, QgsOptionsPageWidget):
         )
         self.geofencingLayerComboBox.setLayer(geofencingLayer)
 
-        self.geofencingInvertLogicCheckBox.setChecked(
-            self.__project_configuration.geofencing_invert_logic
+        self.geofencingBehaviorComboBox.setCurrentIndex(
+            self.geofencingBehaviorComboBox.findData(
+                self.__project_configuration.geofencing_behavior
+            )
         )
 
         # Advanced settings
@@ -291,8 +306,8 @@ class ProjectConfigurationWidget(WidgetUi, QgsOptionsPageWidget):
         except AttributeError:
             pass
 
-        self.__project_configuration.geofencing_invert_logic = (
-            self.geofencingInvertLogicCheckBox.isChecked()
+        self.__project_configuration.geofencing_behavior = (
+            self.geofencingBehaviorComboBox.currentData()
         )
 
         # Advanced settings

--- a/qfieldsync/gui/project_configuration_widget.py
+++ b/qfieldsync/gui/project_configuration_widget.py
@@ -204,6 +204,10 @@ class ProjectConfigurationWidget(WidgetUi, QgsOptionsPageWidget):
             )
         )
 
+        self.geofencingPreventDigitizingCheckBox.setChecked(
+            self.__project_configuration.geofencing_prevent_digitizing
+        )
+
         # Advanced settings
         digitizingLogsLayer = QgsProject.instance().mapLayer(
             self.__project_configuration.digitizing_logs_layer
@@ -308,6 +312,10 @@ class ProjectConfigurationWidget(WidgetUi, QgsOptionsPageWidget):
 
         self.__project_configuration.geofencing_behavior = (
             self.geofencingBehaviorComboBox.currentData()
+        )
+
+        self.__project_configuration.geofencing_prevent_digitizing = (
+            self.geofencingPreventDigitizingCheckBox.isChecked()
         )
 
         # Advanced settings

--- a/qfieldsync/gui/project_configuration_widget.py
+++ b/qfieldsync/gui/project_configuration_widget.py
@@ -190,7 +190,7 @@ class ProjectConfigurationWidget(WidgetUi, QgsOptionsPageWidget):
 
         # Geofencing settings
         self.geofencingGroupBox.setChecked(
-            self.__project_configuration.geofencing_active
+            self.__project_configuration.geofencing_is_active
         )
 
         geofencingLayer = QgsProject.instance().mapLayer(
@@ -204,8 +204,8 @@ class ProjectConfigurationWidget(WidgetUi, QgsOptionsPageWidget):
             )
         )
 
-        self.geofencingPreventDigitizingCheckBox.setChecked(
-            self.__project_configuration.geofencing_prevent_digitizing
+        self.geofencingShouldPreventDigitizingCheckBox.setChecked(
+            self.__project_configuration.geofencing_should_prevent_digitizing
         )
 
         # Advanced settings
@@ -297,7 +297,7 @@ class ProjectConfigurationWidget(WidgetUi, QgsOptionsPageWidget):
             pass
 
         # Geofencing settings
-        self.__project_configuration.geofencing_active = (
+        self.__project_configuration.geofencing_is_active = (
             self.geofencingGroupBox.isChecked()
         )
 
@@ -314,8 +314,8 @@ class ProjectConfigurationWidget(WidgetUi, QgsOptionsPageWidget):
             self.geofencingBehaviorComboBox.currentData()
         )
 
-        self.__project_configuration.geofencing_prevent_digitizing = (
-            self.geofencingPreventDigitizingCheckBox.isChecked()
+        self.__project_configuration.geofencing_should_prevent_digitizing = (
+            self.geofencingShouldPreventDigitizingCheckBox.isChecked()
         )
 
         # Advanced settings

--- a/qfieldsync/gui/project_configuration_widget.py
+++ b/qfieldsync/gui/project_configuration_widget.py
@@ -144,10 +144,16 @@ class ProjectConfigurationWidget(WidgetUi, QgsOptionsPageWidget):
             self.mapThemeComboBox.addItem(theme)
 
         self.layerComboBox.setFilters(QgsMapLayerProxyModel.RasterLayer)
+
+        self.geofencingLayerComboBox.setFilters(QgsMapLayerProxyModel.PolygonLayer)
+        self.geofencingLayerComboBox.setAllowEmptyLayer(True)
+
         self.digitizingLogsLayerComboBox.setFilters(QgsMapLayerProxyModel.PointLayer)
         self.digitizingLogsLayerComboBox.setAllowEmptyLayer(True)
 
         self.__project_configuration = ProjectConfiguration(self.project)
+
+        # Base map settings
         self.createBaseMapGroupBox.setChecked(
             self.__project_configuration.create_base_map
         )
@@ -169,6 +175,21 @@ class ProjectConfigurationWidget(WidgetUi, QgsOptionsPageWidget):
         )
         self.layerComboBox.setLayer(layer)
 
+        # Geofencing settings
+        self.geofencingGroupBox.setChecked(
+            self.__project_configuration.geofencing_active
+        )
+
+        geofencingLayer = QgsProject.instance().mapLayer(
+            self.__project_configuration.geofencing_layer
+        )
+        self.geofencingLayerComboBox.setLayer(geofencingLayer)
+
+        self.geofencingInvertLogicCheckBox.setChecked(
+            self.__project_configuration.geofencing_invert_logic
+        )
+
+        # Advanced settings
         digitizingLogsLayer = QgsProject.instance().mapLayer(
             self.__project_configuration.digitizing_logs_layer
         )
@@ -229,29 +250,10 @@ class ProjectConfigurationWidget(WidgetUi, QgsOptionsPageWidget):
         self.cloudLayersConfigWidget.apply()
         self.cableLayersConfigWidget.apply()
 
+        # Base map settings
         self.__project_configuration.create_base_map = (
             self.createBaseMapGroupBox.isChecked()
         )
-        self.__project_configuration.base_map_theme = (
-            self.mapThemeComboBox.currentText()
-        )
-
-        # try/pass these because the save button is global for all
-        # project settings, not only QField
-        try:
-            self.__project_configuration.base_map_layer = (
-                self.layerComboBox.currentLayer().id()
-            )
-        except AttributeError:
-            pass
-        try:
-            self.__project_configuration.digitizing_logs_layer = (
-                self.digitizingLogsLayerComboBox.currentLayer().id()
-                if self.digitizingLogsLayerComboBox.currentLayer()
-                else ""
-            )
-        except AttributeError:
-            pass
 
         if self.singleLayerRadioButton.isChecked():
             self.__project_configuration.base_map_type = (
@@ -261,6 +263,47 @@ class ProjectConfigurationWidget(WidgetUi, QgsOptionsPageWidget):
             self.__project_configuration.base_map_type = (
                 ProjectProperties.BaseMapType.MAP_THEME
             )
+
+        self.__project_configuration.base_map_theme = (
+            self.mapThemeComboBox.currentText()
+        )
+
+        # try/pass layer ID fetching because the save button is global for all
+        # project settings, not only QField
+        try:
+            self.__project_configuration.base_map_layer = (
+                self.layerComboBox.currentLayer().id()
+            )
+        except AttributeError:
+            pass
+
+        # Geofencing settings
+        self.__project_configuration.geofencing_active = (
+            self.geofencingGroupBox.isChecked()
+        )
+
+        try:
+            self.__project_configuration.geofencing_layer = (
+                self.geofencingLayerComboBox.currentLayer().id()
+                if self.geofencingLayerComboBox.currentLayer()
+                else ""
+            )
+        except AttributeError:
+            pass
+
+        self.__project_configuration.geofencing_invert_logic = (
+            self.geofencingInvertLogicCheckBox.isChecked()
+        )
+
+        # Advanced settings
+        try:
+            self.__project_configuration.digitizing_logs_layer = (
+                self.digitizingLogsLayerComboBox.currentLayer().id()
+                if self.digitizingLogsLayerComboBox.currentLayer()
+                else ""
+            )
+        except AttributeError:
+            pass
 
         self.__project_configuration.base_map_mupp = float(
             self.mapUnitsPerPixel.value()

--- a/qfieldsync/ui/project_configuration_widget.ui
+++ b/qfieldsync/ui/project_configuration_widget.ui
@@ -364,14 +364,11 @@
          <property name="checkable">
           <bool>true</bool>
          </property>
-         <property name="saveCheckedState">
-          <bool>true</bool>
-         </property>
          <layout class="QGridLayout" name="geofencingGridLayout" columnstretch="1,3">
           <item row="0" column="0" colspan="2">
            <widget class="QLabel" name="geofencingIntroductionLabel">
             <property name="text">
-             <string>When geofencing is activated, QField will alert users when the device position falls within areas from the selected polygon layer.</string>
+             <string>When geofencing is activated, QField will provider feedback to users when the device position falls within or outside of areas defined by a selected polygon layer.</string>
             </property>
             <property name="wordWrap">
              <bool>true</bool>
@@ -388,15 +385,15 @@
           <item row="1" column="1">
            <widget class="QgsMapLayerComboBox" name="geofencingLayerComboBox"/>
           </item>
-          <item row="2" column="0" colspan="2">
-           <widget class="QCheckBox" name="geofencingInvertLogicCheckBox">
+          <item row="2" column="0">
+           <widget class="QLabel" name="geofencingBehaviorLabel">
             <property name="text">
-             <string>Revert geofencing logic</string>
-            </property>
-            <property name="toolTip">
-             <string>When the geofencing logic is reverted, the user alert will occur when the position is located outside the geofencing areas.</string>
+             <string>Geofencing behavior</string>
             </property>
            </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QComboBox" name="geofencingBehaviorComboBox"/>
           </item>
          </layout>
         </widget>

--- a/qfieldsync/ui/project_configuration_widget.ui
+++ b/qfieldsync/ui/project_configuration_widget.ui
@@ -368,7 +368,7 @@
           <item row="0" column="0" colspan="2">
            <widget class="QLabel" name="geofencingIntroductionLabel">
             <property name="text">
-             <string>When geofencing is activated, QField will provider feedback to users when the device position falls within or outside of areas defined by a selected polygon layer.</string>
+             <string>QField provides real-time feedback to users when their device position falls within or outside of areas defined by a selected polygon layer.</string>
             </property>
             <property name="wordWrap">
              <bool>true</bool>

--- a/qfieldsync/ui/project_configuration_widget.ui
+++ b/qfieldsync/ui/project_configuration_widget.ui
@@ -357,6 +357,48 @@
         </widget>
        </item>
        <item>
+        <widget class="QgsCollapsibleGroupBox" name="geofencingGroupBox">
+         <property name="title">
+          <string>Geofencing</string>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+         <property name="saveCheckedState">
+          <bool>true</bool>
+         </property>
+         <layout class="QGridLayout" name="geofencingGridLayout" columnstretch="1,3">
+          <item row="0" column="0">
+           <widget class="QLabel" name="geofencingLayerLabel">
+            <property name="text">
+             <string>Geofencing areas layer</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QgsMapLayerComboBox" name="geofencingLayerComboBox"/>
+          </item>
+          <item row="1" column="0" colspan="2">
+           <widget class="QCheckBox" name="geofencingInvertLogicCheckBox">
+            <property name="text">
+             <string>Revert geofencing logic</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0" colspan="2">
+           <widget class="QLabel" name="geofencingInvertedLogicLabel">
+            <property name="text">
+             <string>When the geofencing logic is reverted, the user alert will occur when the position is located outside the geofencing areas.</string>
+            </property>
+            <property name="wordWrap">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
         <widget class="QgsCollapsibleGroupBox" name="advancedSettingsGroupBox">
          <property name="title">
           <string>Advanced Settings</string>

--- a/qfieldsync/ui/project_configuration_widget.ui
+++ b/qfieldsync/ui/project_configuration_widget.ui
@@ -383,15 +383,8 @@
             <property name="text">
              <string>Revert geofencing logic</string>
             </property>
-           </widget>
-          </item>
-          <item row="2" column="0" colspan="2">
-           <widget class="QLabel" name="geofencingInvertedLogicLabel">
-            <property name="text">
+            <property name="toolTip">
              <string>When the geofencing logic is reverted, the user alert will occur when the position is located outside the geofencing areas.</string>
-            </property>
-            <property name="wordWrap">
-             <bool>true</bool>
             </property>
            </widget>
           </item>

--- a/qfieldsync/ui/project_configuration_widget.ui
+++ b/qfieldsync/ui/project_configuration_widget.ui
@@ -395,6 +395,13 @@
           <item row="2" column="1">
            <widget class="QComboBox" name="geofencingBehaviorComboBox"/>
           </item>
+          <item row="3" column="0" colspan="2">
+           <widget class="QCheckBox" name="geofencingPreventDigitizingCheckBox">
+            <property name="text">
+             <string>Prevent digitizing when alerting</string>
+            </property>
+           </widget>
+          </item>
          </layout>
         </widget>
        </item>

--- a/qfieldsync/ui/project_configuration_widget.ui
+++ b/qfieldsync/ui/project_configuration_widget.ui
@@ -396,7 +396,7 @@
            <widget class="QComboBox" name="geofencingBehaviorComboBox"/>
           </item>
           <item row="3" column="0" colspan="2">
-           <widget class="QCheckBox" name="geofencingPreventDigitizingCheckBox">
+           <widget class="QCheckBox" name="geofencingShouldPreventDigitizingCheckBox">
             <property name="text">
              <string>Prevent digitizing when alerting</string>
             </property>

--- a/qfieldsync/ui/project_configuration_widget.ui
+++ b/qfieldsync/ui/project_configuration_widget.ui
@@ -368,17 +368,27 @@
           <bool>true</bool>
          </property>
          <layout class="QGridLayout" name="geofencingGridLayout" columnstretch="1,3">
-          <item row="0" column="0">
+          <item row="0" column="0" colspan="2">
+           <widget class="QLabel" name="geofencingIntroductionLabel">
+            <property name="text">
+             <string>When geofencing is activated, QField will alert users when the device position falls within areas from the selected polygon layer.</string>
+            </property>
+            <property name="wordWrap">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
            <widget class="QLabel" name="geofencingLayerLabel">
             <property name="text">
              <string>Geofencing areas layer</string>
             </property>
            </widget>
           </item>
-          <item row="0" column="1">
+          <item row="1" column="1">
            <widget class="QgsMapLayerComboBox" name="geofencingLayerComboBox"/>
           </item>
-          <item row="1" column="0" colspan="2">
+          <item row="2" column="0" colspan="2">
            <widget class="QCheckBox" name="geofencingInvertLogicCheckBox">
             <property name="text">
              <string>Revert geofencing logic</string>

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ future
 transifex-client
 
 # NOTE `libqfielsync` version should be defined in the `*.tar.gz` format, not `git+https://` to make `wheel` happy
-libqfieldsync @ https://github.com/opengisch/libqfieldsync/archive/b17f17b2ac14b01ca2b690da7624a4b95d1adcf2.tar.gz
+libqfieldsync @ https://github.com/opengisch/libqfieldsync/archive/1fa9ec4a49fe92b67d9dbc69babb1a821e8b3484.tar.gz

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ future
 transifex-client
 
 # NOTE `libqfielsync` version should be defined in the `*.tar.gz` format, not `git+https://` to make `wheel` happy
-libqfieldsync @ https://github.com/opengisch/libqfieldsync/archive/1fa9ec4a49fe92b67d9dbc69babb1a821e8b3484.tar.gz
+libqfieldsync @ https://github.com/opengisch/libqfieldsync/archive/61523b5775dd1bccc25abcf4b9c7a266af18c214.tar.gz

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ future
 transifex-client
 
 # NOTE `libqfielsync` version should be defined in the `*.tar.gz` format, not `git+https://` to make `wheel` happy
-libqfieldsync @ https://github.com/opengisch/libqfieldsync/archive/c98ef2671aca31c7943d3aa4c69221dbdb157d5a.tar.gz
+libqfieldsync @ https://github.com/opengisch/libqfieldsync/archive/b17f17b2ac14b01ca2b690da7624a4b95d1adcf2.tar.gz


### PR DESCRIPTION
This PR adds a couple of widgets to setup geofencing in QField. Looks:

![image](https://github.com/opengisch/qfieldsync/assets/1728657/ef670b60-feed-41d0-9396-9c8b912f3f6e)

The libqfieldsync counterpart is here: https://github.com/opengisch/libqfieldsync/pull/86