### PR TITLE
Add map themes's default active layer configuration

### DIFF
--- a/qfieldsync/gui/mapthemes_config_widget.py
+++ b/qfieldsync/gui/mapthemes_config_widget.py
@@ -5,9 +5,9 @@
                                  A QGIS plugin
  Sync your projects to QField
                              -------------------
-        begin                : 2020-10-10
+        begin                : 2024-07-22
         git sha              : $Format:%H$
-        copyright            : (C) 2020 by OPENGIS.ch
+        copyright            : (C) 2024 by OPENGIS.ch
         email                : info@opengis.ch
  ***************************************************************************/
 

--- a/qfieldsync/gui/mapthemes_config_widget.py
+++ b/qfieldsync/gui/mapthemes_config_widget.py
@@ -1,0 +1,83 @@
+# -*- coding: utf-8 -*-
+"""
+/***************************************************************************
+ MapThemesConfigWidget
+                                 A QGIS plugin
+ Sync your projects to QField
+                             -------------------
+        begin                : 2020-10-10
+        git sha              : $Format:%H$
+        copyright            : (C) 2020 by OPENGIS.ch
+        email                : info@opengis.ch
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+"""
+
+from qgis.core import Qgis
+from qgis.gui import QgsMapLayerComboBox
+
+from qgis.PyQt.QtCore import Qt
+from qgis.PyQt.QtWidgets import QTableWidgetItem, QTableWidget
+
+
+class MapThemesConfigWidget(QTableWidget):
+    def __init__(self, project, configuration, parent=None):
+        """Constructor."""
+        super(QTableWidget, self).__init__(parent=parent)
+
+        self.project = project
+
+        self.setMinimumHeight(200)
+        self.setColumnCount(2)
+        self.setHorizontalHeaderLabels(
+            [self.tr("Map Theme"), self.tr("Default Active Layer")]
+        )
+
+        self.reload(configuration)
+
+    def reload(self, configuration):
+        """
+        Load map themes into table.
+        """
+
+        self.setRowCount(0)
+        self.setSortingEnabled(False)
+        map_themes = self.project.mapThemeCollection().mapThemes()
+        for map_theme in map_themes:
+            count = self.rowCount()
+            self.insertRow(count)
+            item = QTableWidgetItem(map_theme)
+            item.setData(Qt.EditRole, map_theme)
+            self.setItem(count, 0, item)
+
+            cmb = QgsMapLayerComboBox()
+            cmb.setAllowEmptyLayer(True)
+            cmb.setProject(self.project)
+            cmb.setFilters(Qgis.LayerFilter.VectorLayer)
+            if map_theme in configuration:
+                cmb.setLayer(self.project.mapLayer(configuration[map_theme]))
+            self.setCellWidget(count, 1, cmb)
+
+        self.setColumnWidth(0, int(self.width() * 0.2))
+        self.setColumnWidth(1, int(self.width() * 0.75))
+        self.sortByColumn(0, Qt.AscendingOrder)
+        self.setSortingEnabled(True)
+
+    def createConfiguration(self):
+        configuration = {}
+        for i in range(self.rowCount()):
+            item = self.item(i, 0)
+            map_theme = item.data(Qt.EditRole)
+            cmb = self.cellWidget(i, 1)
+            layer_id = cmb.currentLayer().id() if cmb.currentLayer() else ""
+            configuration[map_theme] = layer_id
+
+        return configuration

--- a/qfieldsync/gui/project_configuration_widget.py
+++ b/qfieldsync/gui/project_configuration_widget.py
@@ -36,6 +36,7 @@ from qgis.utils import iface
 
 from qfieldsync.core.preferences import Preferences
 from qfieldsync.gui.layers_config_widget import LayersConfigWidget
+from qfieldsync.gui.mapthemes_config_widget import MapThemesConfigWidget
 
 WidgetUi, _ = loadUiType(
     os.path.join(os.path.dirname(__file__), "../ui/project_configuration_widget.ui"),
@@ -152,7 +153,7 @@ class ProjectConfigurationWidget(WidgetUi, QgsOptionsPageWidget):
         self.cloudExportTab.layout().addWidget(infoLabel, 0, 2)
         self.cableExportTab.layout().addWidget(self.cableLayersConfigWidget)
 
-        # Load Map Themes
+        # Map Themes configuration widgets
         for theme in self.project.mapThemeCollection().mapThemes():
             self.mapThemeComboBox.addItem(theme)
 
@@ -165,6 +166,11 @@ class ProjectConfigurationWidget(WidgetUi, QgsOptionsPageWidget):
         self.digitizingLogsLayerComboBox.setAllowEmptyLayer(True)
 
         self.__project_configuration = ProjectConfiguration(self.project)
+
+        self.mapThemesConfigWidget = MapThemesConfigWidget(
+            self.project, self.__project_configuration.map_themes_active_layer
+        )
+        self.mapThemesGroupBox.layout().addWidget(self.mapThemesConfigWidget)
 
         # Base map settings
         self.createBaseMapGroupBox.setChecked(
@@ -370,6 +376,10 @@ class ProjectConfigurationWidget(WidgetUi, QgsOptionsPageWidget):
         for item in self.attachmentDirsListWidget.findItems("^\\S+$", match_flag):
             keys[item.text()] = 1
         self.preferences.set_value("attachmentDirs", list(keys.keys()))
+
+        self.__project_configuration.map_themes_active_layer = (
+            self.mapThemesConfigWidget.createConfiguration()
+        )
 
     def onForceAutoPushClicked(self, checked):
         self.forceAutoPushInterval.setEnabled(checked)

--- a/qfieldsync/ui/project_configuration_widget.ui
+++ b/qfieldsync/ui/project_configuration_widget.ui
@@ -420,6 +420,23 @@
           <bool>true</bool>
          </property>
          <layout class="QGridLayout" name="gridLayout_8" columnstretch="1,3">
+          <item row="5" column="0" colspan="2">
+           <widget class="QgsCollapsibleGroupBox" name="mapThemesGroupBox">
+            <property name="title">
+             <string>Map Themes Configuration</string>
+            </property>
+            <property name="checkable">
+             <bool>false</bool>
+            </property>
+            <property name="collapsed">
+             <bool>false</bool>
+            </property>
+            <property name="saveCollapsedState">
+             <bool>true</bool>
+            </property>
+            <layout class="QVBoxLayout" name="verticalLayout_8"/>
+           </widget>
+          </item>
           <item row="4" column="0">
            <widget class="QLabel" name="attachmentDirsLabel">
             <property name="toolTip">

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ future
 transifex-client
 
 # NOTE `libqfielsync` version should be defined in the `*.tar.gz` format, not `git+https://` to make `wheel` happy
-libqfieldsync @ https://github.com/opengisch/libqfieldsync/archive/61523b5775dd1bccc25abcf4b9c7a266af18c214.tar.gz
+libqfieldsync @ https://github.com/opengisch/libqfieldsync/archive/c670dcffb9aada9a7066591a7588188f024102a0.tar.gz


### PR DESCRIPTION
This PR implements the project configuration UI to setup the default active layer QField will pick when users select a map theme in QField. The functionality allows for project managers to help out field workers by auto-picking the right active layer to digitize entries based on map themes.

Screenshot:

![image](https://github.com/user-attachments/assets/614e52a5-37c8-450e-afe0-3525975085b3)
