### PR TITLE
Adding the option for specify the project title on packaged project

### DIFF
--- a/qfieldsync/gui/package_dialog.py
+++ b/qfieldsync/gui/package_dialog.py
@@ -74,7 +74,7 @@ class PackageDialog(QDialog, DialogUi):
         self.__project_configuration = ProjectConfiguration(self.project)
         self.button_box.button(QDialogButtonBox.Save).setText(self.tr("Create"))
         self.button_box.button(QDialogButtonBox.Save).clicked.connect(
-            self.package_project
+            self.run_package_project
         )
         self.button_box.button(QDialogButtonBox.Reset).setText(
             self.tr("Configure current project...")
@@ -162,6 +162,20 @@ class PackageDialog(QDialog, DialogUi):
         self.nextButton.setVisible(False)
         self.button_box.setVisible(True)
         self.stackedWidget.setCurrentWidget(self.packagePage)
+
+    def run_package_project(self):
+        export_packaged_project = Path(self.packagedProjectFileWidget.filePath())
+
+        if export_packaged_project.suffix != ".qgs":
+            QMessageBox.critical(
+                self,
+                self.tr("Invalid File"),
+                self.tr('The filename must have a ".qgs" extension.'),
+            )
+            return
+
+        else:
+            self.package_project()
 
     def package_project(self):
         self.button_box.button(QDialogButtonBox.Save).setEnabled(False)

--- a/qfieldsync/gui/package_dialog.py
+++ b/qfieldsync/gui/package_dialog.py
@@ -136,7 +136,7 @@ class PackageDialog(QDialog, DialogUi):
         else:
             self.show_package_page()
 
-    def get_export_folder(self):
+    def get_export_folder(self) -> str:
         """Get the export folder according to the inputs in the selected"""
         export_dirname = self.qfield_preferences.value("exportDirectoryProject")
         if not export_dirname:
@@ -146,14 +146,14 @@ class PackageDialog(QDialog, DialogUi):
             )
         return QDir.toNativeSeparators(str(export_dirname))
 
-    def get_export_filename_suggestion(self):
+    def get_export_filename_suggestion(self) -> str:
         export_folder = Path(self.get_export_folder())
         full_project_name_suggestion = export_folder.joinpath(
             f"{self.project.baseName()}_qfield.qgs"
         )
         return str(full_project_name_suggestion)
 
-    def set_export_filename_suggested(self):
+    def set_export_filename_suggested(self) -> None:
         self.packagedProjectFileWidget.setFilePath(
             self.get_export_filename_suggestion()
         )
@@ -163,13 +163,13 @@ class PackageDialog(QDialog, DialogUi):
         self.button_box.setVisible(True)
         self.stackedWidget.setCurrentWidget(self.packagePage)
 
-    def run_package_project(self):
+    def run_package_project(self) -> None:
         export_packaged_project = Path(self.packagedProjectFileWidget.filePath())
 
         if export_packaged_project.suffix != ".qgs":
             QMessageBox.critical(
                 self,
-                self.tr("Invalid File"),
+                self.tr("Invalid Filename"),
                 self.tr('The filename must have a ".qgs" extension.'),
             )
             return

--- a/qfieldsync/gui/package_dialog.py
+++ b/qfieldsync/gui/package_dialog.py
@@ -136,27 +136,19 @@ class PackageDialog(QDialog, DialogUi):
         else:
             self.show_package_page()
 
-    def get_export_folder(self) -> str:
-        """Get the export folder according to the inputs in the selected"""
+    def get_export_filename_suggestion(self) -> str:
+        """Get the suggested export filename"""
         export_dirname = self.qfield_preferences.value("exportDirectoryProject")
         if not export_dirname:
             export_dirname = os.path.join(
                 self.qfield_preferences.value("exportDirectory"),
                 fileparts(QgsProject.instance().fileName())[1],
             )
-        return QDir.toNativeSeparators(str(export_dirname))
-
-    def get_export_filename_suggestion(self) -> str:
-        export_folder = Path(self.get_export_folder())
+        export_folder = Path(QDir.toNativeSeparators(str(export_dirname)))
         full_project_name_suggestion = export_folder.joinpath(
             f"{self.project.baseName()}_qfield.qgs"
         )
         return str(full_project_name_suggestion)
-
-    def set_export_filename_suggested(self) -> None:
-        self.packagedProjectFileWidget.setFilePath(
-            self.get_export_filename_suggestion()
-        )
 
     def show_package_page(self):
         self.nextButton.setVisible(False)

--- a/qfieldsync/tests/test_export.py
+++ b/qfieldsync/tests/test_export.py
@@ -70,7 +70,7 @@ class OfflineConverterTest(unittest.TestCase):
         offline_editing = QgsOfflineEditing()
         offline_converter = OfflineConverter(
             project,
-            str(self.target_dir),
+            self.target_dir.joinpath("project_qfield.qgs"),
             "POLYGON((1 1, 5 0, 5 5, 0 5, 1 1))",
             QgsProject.instance().crs().authid(),
             ["DCIM"],
@@ -110,7 +110,7 @@ class OfflineConverterTest(unittest.TestCase):
         offline_editing = QgsOfflineEditing()
         offline_converter = OfflineConverter(
             project,
-            str(self.target_dir),
+            self.target_dir.joinpath("project_qfield.qgs"),
             "POLYGON((1 1, 5 0, 5 5, 0 5, 1 1))",
             QgsProject.instance().crs().authid(),
             ["DCIM"],

--- a/qfieldsync/ui/package_dialog.ui
+++ b/qfieldsync/ui/package_dialog.ui
@@ -7,43 +7,13 @@
     <x>0</x>
     <y>0</y>
     <width>599</width>
-    <height>570</height>
+    <height>700</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Package Project for QField</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_3">
-   <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_2">
-     <property name="topMargin">
-      <number>0</number>
-     </property>
-     <item>
-      <widget class="QLabel" name="label_2">
-       <property name="text">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Project:&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-       </property>
-       <property name="textFormat">
-        <enum>Qt::RichText</enum>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="project_lbl">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
    <item>
     <widget class="QStackedWidget" name="stackedWidget">
      <property name="currentIndex">
@@ -111,16 +81,25 @@
        <item>
         <widget class="QGroupBox" name="groupBox">
          <property name="title">
-          <string>Export Directory</string>
+          <string>Packaged Project Title</string>
          </property>
          <layout class="QGridLayout" name="gridLayout">
           <item row="0" column="0">
-           <widget class="QLineEdit" name="manualDir"/>
+           <widget class="QLineEdit" name="packagedProjectTitleLineEdit"/>
           </item>
-          <item row="0" column="1">
-           <widget class="QToolButton" name="manualDir_btn">
-            <property name="text">
-             <string>...</string>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="groupBox">
+         <property name="title">
+          <string>Packaged Project Filename</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout">
+          <item row="0" column="0" colspan="2">
+           <widget class="QgsFileWidget" name="packagedProjectFileWidget">
+            <property name="storageMode">
+             <enum>QgsFileWidget::SaveFile</enum>
             </property>
            </widget>
           </item>
@@ -278,6 +257,11 @@
    <extends>QGroupBox</extends>
    <header>qgscollapsiblegroupbox.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsFileWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsfilewidget.h</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ future
 transifex-client
 
 # NOTE `libqfielsync` version should be defined in the `*.tar.gz` format, not `git+https://` to make `wheel` happy
-libqfieldsync @ https://github.com/opengisch/libqfieldsync/archive/7901b65225caa2fb8788639f1e21b1050c87a6f3.tar.gz
+libqfieldsync @ https://github.com/opengisch/libqfieldsync/archive/1b923ba27ecfc8def5adcd255e94a226ae92b3eb.tar.gz


### PR DESCRIPTION
This adds the option to specify a new project name and title in the exported project when packaging.

| Before | After |
|--------|-------|
| ![Before Image](https://github.com/user-attachments/assets/543f0fc9-4034-463e-a638-1a0b453281fc) | ![After Image](https://github.com/user-attachments/assets/9ad7c145-a6b8-454a-98a3-496c6ae21ef9) |

Related PR: https://github.com/opengisch/libqfieldsync/pull/94