### PR TITLE
Update requirements.txt to use the latest libqfieldsync

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ future
 transifex-client
 
 # NOTE `libqfielsync` version should be defined in the `*.tar.gz` format, not `git+https://` to make `wheel` happy
-libqfieldsync @ https://github.com/opengisch/libqfieldsync/archive/1b923ba27ecfc8def5adcd255e94a226ae92b3eb.tar.gz
+libqfieldsync @ https://github.com/opengisch/libqfieldsync/archive/03530d49798c278eb84c0d726f2fca3d2b3c7b56.tar.gz


### PR DESCRIPTION
The PR involves the changes from:
https://github.com/opengisch/libqfieldsync/pull/96 
https://github.com/opengisch/libqfieldsync/pull/97