### PR TITLE
Do not show `master password` when using QFieldSync for the first time

### DIFF
--- a/qfieldsync/core/preferences.py
+++ b/qfieldsync/core/preferences.py
@@ -31,7 +31,7 @@ class Preferences(SettingManager):
         self.add_setting(Dictionary("qfieldCloudLastProjectFiles", Scope.Global, {}))
         self.add_setting(String("qfieldCloudServerUrl", Scope.Global, ""))
         self.add_setting(String("qfieldCloudAuthcfg", Scope.Global, ""))
-        self.add_setting(Bool("qfieldCloudRememberMe", Scope.Global, True))
+        self.add_setting(Bool("qfieldCloudRememberMe", Scope.Global, False))
         self.add_setting(
             String("cloudDirectory", Scope.Global, str(home.joinpath("QField/cloud")))
         )


### PR DESCRIPTION
Probably not the best way to solve it, but the easiest with no serious consequences.

If the user install QFieldSync and the default value of `qfieldCloudRememberMe=True`, it will call the `cloud_api.auto_login_attempt`, which calls the `QgsApplication.authManager()`.

As a UI this is asking for the master password, but the users have no idea what is this and what is the context of it. 

Fix https://github.com/opengisch/qfieldsync/issues/580