### PR TITLE
Fixing QFieldSync:: Invalid value for setting exportDirectoryProject …

### DIFF
--- a/qfieldsync/gui/package_dialog.py
+++ b/qfieldsync/gui/package_dialog.py
@@ -206,7 +206,7 @@ class PackageDialog(QDialog, DialogUi):
         )
 
         self.qfield_preferences.set_value(
-            "exportDirectoryProject", packaged_project_file.parent
+            "exportDirectoryProject", str(packaged_project_file.parent)
         )
         self.dirsToCopyWidget.save_settings()
 


### PR DESCRIPTION
Fixing the WARNING `String QFieldSync:: Invalid value for setting exportDirectoryProject: project_name It must be a string`.

![image](https://github.com/user-attachments/assets/c4da084c-4a90-43c4-b824-d6602b748e18)
