### PR TITLE
Add basemap tiles min and max zoom to project's qfield settings form

### DIFF
--- a/qfieldsync/gui/project_configuration_widget.py
+++ b/qfieldsync/gui/project_configuration_widget.py
@@ -229,6 +229,14 @@ class ProjectConfigurationWidget(WidgetUi, QgsOptionsPageWidget):
 
         self.mapUnitsPerPixel.setValue(self.__project_configuration.base_map_mupp)
         self.tileSize.setValue(self.__project_configuration.base_map_tile_size)
+
+        self.baseMapTilesMinZoomLevelSpinBox.setValue(
+            self.__project_configuration.base_map_tiles_min_zoom_level
+        )
+        self.baseMapTilesMaxZoomLevelSpinBox.setValue(
+            self.__project_configuration.base_map_tiles_max_zoom_level
+        )
+
         self.onlyOfflineCopyFeaturesInAoi.setChecked(
             self.__project_configuration.offline_copy_only_aoi
         )
@@ -338,6 +346,13 @@ class ProjectConfigurationWidget(WidgetUi, QgsOptionsPageWidget):
             self.mapUnitsPerPixel.value()
         )
         self.__project_configuration.base_map_tile_size = self.tileSize.value()
+
+        self.__project_configuration.base_map_tiles_min_zoom_level = (
+            self.baseMapTilesMinZoomLevelSpinBox.value()
+        )
+        self.__project_configuration.base_map_tiles_max_zoom_level = (
+            self.baseMapTilesMaxZoomLevelSpinBox.value()
+        )
 
         self.__project_configuration.maximum_image_width_height = (
             self.maximumImageWidthHeight.value()

--- a/qfieldsync/ui/project_configuration_widget.ui
+++ b/qfieldsync/ui/project_configuration_widget.ui
@@ -142,7 +142,7 @@
                 <bool>true</bool>
                </property>
                <property name="clearValue">
-                <number>30</number>
+                <bool>true</bool>
                </property>
               </widget>
              </item>
@@ -185,14 +185,62 @@
          <property name="saveCheckedState">
           <bool>true</bool>
          </property>
-         <layout class="QGridLayout" name="gridLayout" columnstretch="1,3">
-          <item row="3" column="0">
-           <widget class="QLabel" name="mapUnitsPerPixelLabel">
+         <layout class="QGridLayout" name="gridLayout">
+          <item row="0" column="1">
+           <widget class="QRadioButton" name="mapThemeRadioButton">
             <property name="text">
-             <string>Map units per pixel</string>
+             <string>Map theme</string>
+            </property>
+            <attribute name="buttonGroup">
+             <string notr="true">buttonGroup</string>
+            </attribute>
+           </widget>
+          </item>
+          <item row="6" column="1">
+           <widget class="QgsSpinBox" name="baseMapTilesMaxZoomLevelSpinBox">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="toolTip">
+             <string>This determines the maximum zoom level of the basemap tiles (mbtiles format), generated during cable export.</string>
+            </property>
+            <property name="maximum">
+             <number>20</number>
+            </property>
+            <property name="value">
+             <number>14</number>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="tileSizeLabel">
+            <property name="text">
+             <string>Tile size</string>
             </property>
             <property name="alignment">
              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="1">
+           <widget class="QgsSpinBox" name="baseMapTilesMinZoomLevelSpinBox">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="toolTip">
+             <string>This determines the minimum zoom level of the basemap tiles (mbtiles format), generated during cable export.</string>
+            </property>
+            <property name="maximum">
+             <number>20</number>
+            </property>
+            <property name="value">
+             <number>14</number>
             </property>
            </widget>
           </item>
@@ -204,6 +252,25 @@
             <attribute name="buttonGroup">
              <string notr="true">buttonGroup</string>
             </attribute>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="QgsDoubleSpinBox" name="mapUnitsPerPixel">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="toolTip">
+             <string>This determines the spatial resolution of the resulting map image. It depends on the CRS of the map canvas. For map units in [m], a value of 1 means each pixel covers an area of 1x1 m, a value of 1000 means 1 pixel per square kilometer.</string>
+            </property>
+            <property name="suffix">
+             <string> mupp</string>
+            </property>
+            <property name="value">
+             <double>99.989999999999995</double>
+            </property>
            </widget>
           </item>
           <item row="1" column="0" colspan="2">
@@ -238,7 +305,7 @@
                <number>0</number>
               </property>
               <item row="0" column="0">
-               <widget class="QLabel" name="label">
+               <widget class="QLabel" name="baseMapMapThemeLabel">
                 <property name="text">
                  <string>Map Theme</string>
                 </property>
@@ -273,7 +340,7 @@
                <number>0</number>
               </property>
               <item row="0" column="0">
-               <widget class="QLabel" name="label_2">
+               <widget class="QLabel" name="baseMapLayerLabel">
                 <property name="text">
                  <string>Layer</string>
                 </property>
@@ -287,6 +354,16 @@
               </item>
              </layout>
             </widget>
+           </widget>
+          </item>
+          <item row="4" column="0">
+           <widget class="QLabel" name="baseMapTilesMinZoomLevelLabel">
+            <property name="text">
+             <string>Tiles min zoom level</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
            </widget>
           </item>
           <item row="2" column="1">
@@ -314,39 +391,20 @@
             </property>
            </widget>
           </item>
-          <item row="3" column="1">
-           <widget class="QgsDoubleSpinBox" name="mapUnitsPerPixel">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
+          <item row="3" column="0">
+           <widget class="QLabel" name="mapUnitsPerPixelLabel">
+            <property name="text">
+             <string>Map units per pixel</string>
             </property>
-            <property name="toolTip">
-             <string>This determines the spatial resolution of the resulting map image. It depends on the CRS of the map canvas. For map units in [m], a value of 1 means each pixel covers an area of 1x1 m, a value of 1000 means 1 pixel per square kilometer.</string>
-            </property>
-            <property name="suffix">
-             <string> mupp</string>
-            </property>
-            <property name="value">
-             <double>99.989999999999995</double>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
             </property>
            </widget>
           </item>
-          <item row="0" column="1">
-           <widget class="QRadioButton" name="mapThemeRadioButton">
+          <item row="6" column="0">
+           <widget class="QLabel" name="baseMapTilesMaxZoomLevelLabel">
             <property name="text">
-             <string>Map theme</string>
-            </property>
-            <attribute name="buttonGroup">
-             <string notr="true">buttonGroup</string>
-            </attribute>
-           </widget>
-          </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="tileSizeLabel">
-            <property name="text">
-             <string>Tile size</string>
+             <string>Tiles max zoom level</string>
             </property>
             <property name="alignment">
              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -570,6 +628,32 @@
    <header>qgsspinbox.h</header>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>scrollArea</tabstop>
+  <tabstop>exportTypeTabs</tabstop>
+  <tabstop>preferOnlineLayersRadioButton</tabstop>
+  <tabstop>preferOfflineLayersRadioButton</tabstop>
+  <tabstop>cloudAdvancedSettings</tabstop>
+  <tabstop>forceAutoPush</tabstop>
+  <tabstop>forceAutoPushInterval</tabstop>
+  <tabstop>createBaseMapGroupBox</tabstop>
+  <tabstop>singleLayerRadioButton</tabstop>
+  <tabstop>mapThemeRadioButton</tabstop>
+  <tabstop>mapThemeComboBox</tabstop>
+  <tabstop>tileSize</tabstop>
+  <tabstop>mapUnitsPerPixel</tabstop>
+  <tabstop>baseMapTilesMinZoomLevelSpinBox</tabstop>
+  <tabstop>baseMapTilesMaxZoomLevelSpinBox</tabstop>
+  <tabstop>geofencingGroupBox</tabstop>
+  <tabstop>geofencingLayerComboBox</tabstop>
+  <tabstop>geofencingBehaviorComboBox</tabstop>
+  <tabstop>geofencingShouldPreventDigitizingCheckBox</tabstop>
+  <tabstop>digitizingLogsLayerComboBox</tabstop>
+  <tabstop>onlyOfflineCopyFeaturesInAoi</tabstop>
+  <tabstop>maximumImageWidthHeight</tabstop>
+  <tabstop>attachmentDirsListWidget</tabstop>
+  <tabstop>layerComboBox</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
  <buttongroups>

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ future
 transifex-client
 
 # NOTE `libqfielsync` version should be defined in the `*.tar.gz` format, not `git+https://` to make `wheel` happy
-libqfieldsync @ https://github.com/opengisch/libqfieldsync/archive/bba00b13671b19d6d2ae2376ceedc5bb5f087a19.tar.gz
+libqfieldsync @ https://github.com/opengisch/libqfieldsync/archive/9e7dbf112d3ab6429e18e8300ccbffc875c7f871.tar.gz


### PR DESCRIPTION
This PR adds the basemap tiles min and max zoom levels, in a project's QField settings form, for generating `mbtiles` during cable export.

2 new `QgsSpinBox` widget now appear at the bottom of the `Base Map` form:

![image](https://github.com/user-attachments/assets/1623b31e-4546-463e-97a5-31f6f9f74275)

See [this `libqfieldsync` PR](https://github.com/opengisch/libqfieldsync/pull/105) for more details and steps.