### PR TITLE
Fix runtime error after plugin update when `libqfieldsync` changed API

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -96,7 +96,8 @@ jobs:
       - name: Package libqfieldsync
         run: |
           pip wheel $(grep -o -P '(https://.*.tar.gz)' requirements.txt)
-          mv libqfieldsync-*.whl qfieldsync/libqfieldsync.whl
+          LIBQFIELDSYNC_COMMIT_SHA=$(echo $(grep -o -P '(https://.*.tar.gz)' requirements.txt) | grep -Eo '[0-9a-f]{40}')
+          mv libqfieldsync-*.whl qfieldsync/libqfieldsyncq_${LIBQFIELDSYNC_COMMIT_SHA}.whl
 
       - name: Release
         run: |

--- a/qfieldsync/__init__.py
+++ b/qfieldsync/__init__.py
@@ -24,14 +24,27 @@
 
 from __future__ import absolute_import
 
+import importlib
 import pathlib
+import re
 import sys
 
 src_dir = pathlib.Path(__file__).parent.resolve()
 
-libqfieldsync_whl = src_dir / "libqfieldsync.whl"
-if libqfieldsync_whl.exists():
+# remove previously loaded `libqfieldsync.whl` from the python import path
+for python_path in sys.path:
+    if re.search(r"libqfieldsync.*\.whl$", python_path):
+        sys.path.remove(python_path)
+
+# add the new `libqfieldsync.whl` file to the python import path
+for libqfieldsync_whl in src_dir.glob("libqfieldsync*.whl"):
     sys.path.append(str(libqfieldsync_whl))
+
+# force reload all the `libqfieldsync` modules from the new path
+module_names = list(sys.modules.keys())
+for module_name in module_names:
+    if module_name.startswith("libqfieldsync"):
+        importlib.reload(sys.modules[module_name])
 
 
 # noinspection PyPep8Naming


### PR DESCRIPTION
When we add a new class/method/API change in `libqfieldsync` and we use it within QFieldSync plugin, we get a runtime error, such as:

```
ImportError: cannot import name 'PackagingCanceledException' from 'libqfieldsync.offline_converter' (C:\Users\paul.bennett\AppData\Roaming\QGIS\QGIS3\profiles\default\python\plugins\qfieldsync\libqfieldsync.whl\libqfieldsync\offline_converter.py)
```

The reason is that `libqfieldsync` is loaded from a `.whl` file, which is cached by the Python runtime and we need to introduce this magic to force reload this.

The magic consists of two parts:
1) ensure the new version .whl file has a different name 2) ensure we use `importlib.reload` to force reload from the new .whl

Tested on Windows 11 with QGIIS 3.34. Failed to reproduce on Ubuntu, but also did not try hard.

I wish I have time to do more fun stuff like this...

Fix #643 #646