### PR TITLE
Add tooltip to the QFieldCloudIcon

### DIFF
--- a/qfieldsync/ui/cloud_login_dialog.ui
+++ b/qfieldsync/ui/cloud_login_dialog.ui
@@ -22,6 +22,9 @@
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
+     <property name="toolTipQfieldCloudIcon">
+      <string>Double-click me to show or hide advanced options</string>
+     </property>
      <property name="scaledContents">
       <bool>false</bool>
      </property>


### PR DESCRIPTION
Following the suggestion in this PR
https://github.com/opengisch/qfieldsync/pull/641

![image](https://github.com/user-attachments/assets/32fab7ca-3648-4262-b1ec-3814ddb1fedd)
