### PR TITLE
Fix attachment directories list widget's tiny height issue

### DIFF
--- a/qfieldsync/gui/project_configuration_widget.py
+++ b/qfieldsync/gui/project_configuration_widget.py
@@ -107,6 +107,7 @@ class ProjectConfigurationWidget(WidgetUi, QgsOptionsPageWidget):
 
         self.forceAutoPush.clicked.connect(self.onForceAutoPushClicked)
 
+        self.attachmentDirsListWidget.setMinimumHeight(140)
         self.attachmentDirsListWidget.itemChanged.connect(self.onItemChanged)
         self.event_eater = EventEater()
         self.attachmentDirsListWidget.installEventFilter(self.event_eater)


### PR DESCRIPTION
The attachment directories list widget's height can get really small - ie _too_ small - when expanding a couple of group boxes in there. 

While the whole project configuration panel deserves a re-styling, this PR provides a nice band-aid by adding a minimum height so the list remains usable.