### PR TITLE
Cloud project transfer dialog bug hunting and improvements, part 2

### DIFF
--- a/qfieldsync/gui/cloud_transfer_dialog.py
+++ b/qfieldsync/gui/cloud_transfer_dialog.py
@@ -30,7 +30,7 @@ from libqfieldsync.offline_converter import ExportType
 from libqfieldsync.project_checker import ProjectChecker
 from libqfieldsync.utils.file_utils import get_unique_empty_dirname
 from libqfieldsync.utils.qgis import get_qgis_files_within_dir
-from qgis.core import QgsProject
+from qgis.core import QgsApplication, QgsProject
 from qgis.PyQt.QtCore import QDir, Qt, QUrl, pyqtSignal
 from qgis.PyQt.QtGui import QDesktopServices, QShowEvent
 from qgis.PyQt.QtWidgets import (
@@ -161,6 +161,13 @@ class CloudTransferDialog(QDialog, CloudTransferDialogUi):
         self.preferNoneButton.clicked.connect(self._on_prefer_none_button_clicked)
         self.preferLocalButton.clicked.connect(self._on_prefer_local_button_clicked)
         self.preferCloudButton.clicked.connect(self._on_prefer_cloud_button_clicked)
+
+        self.localDirOpenButton.clicked.connect(
+            lambda: self.on_local_dir_open_button_clicked()
+        )
+        self.localDirOpenButton.setIcon(
+            QgsApplication.getThemeIcon("/mActionFileOpen.svg")
+        )
 
     def showEvent(self, event: QShowEvent) -> None:
         self.buttonBox.button(QDialogButtonBox.Cancel).setVisible(True)
@@ -366,8 +373,9 @@ class CloudTransferDialog(QDialog, CloudTransferDialogUi):
             self.buttonBox.button(QDialogButtonBox.Apply).setVisible(True)
             self.explanationLabel.setVisible(True)
 
+            self.cloudProjectNameValueLabel.setOpenExternalLinks(True)
             self.cloudProjectNameValueLabel.setText(
-                '<a href="{}{}">{}</a>'.format(
+                '<a href="{}{}"><b>{}</b></a>'.format(
                     self.network_manager.url,
                     self.cloud_project.url,
                     self.cloud_project.name_with_owner,
@@ -476,6 +484,11 @@ class CloudTransferDialog(QDialog, CloudTransferDialogUi):
             self._start_synchronization()
         else:
             raise NotImplementedError()
+
+    def on_local_dir_open_button_clicked(self) -> None:
+        dirname = self.projectLocalDirValueLineEdit.text()
+        if dirname and Path(dirname).exists():
+            QDesktopServices.openUrl(QUrl.fromLocalFile(dirname))
 
     def _start_synchronization(self):
         assert self.cloud_project

--- a/qfieldsync/ui/cloud_transfer_dialog.ui
+++ b/qfieldsync/ui/cloud_transfer_dialog.ui
@@ -377,57 +377,6 @@
         <number>0</number>
        </property>
        <item>
-        <layout class="QVBoxLayout" name="verticalLayout_7">
-         <item>
-          <layout class="QFormLayout" name="formLayout">
-           <item row="0" column="0">
-            <widget class="QLabel" name="cloudProjectNameLabel">
-             <property name="font">
-              <font>
-               <weight>75</weight>
-               <bold>true</bold>
-              </font>
-             </property>
-             <property name="text">
-              <string>QFieldCloud project name</string>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="1">
-            <widget class="QLabel" name="cloudProjectNameValueLabel">
-             <property name="text">
-              <string/>
-             </property>
-            </widget>
-           </item>
-           <item row="1" column="0">
-            <widget class="QLabel" name="projectLocalDirLabel">
-             <property name="font">
-              <font>
-               <weight>75</weight>
-               <bold>true</bold>
-              </font>
-             </property>
-             <property name="text">
-              <string>Local project directory</string>
-             </property>
-            </widget>
-           </item>
-           <item row="1" column="1">
-            <widget class="QLineEdit" name="projectLocalDirValueLineEdit">
-             <property name="styleSheet">
-              <string notr="true">[readOnly=&quot;true&quot;] {color: #808080; background-color: #F0F0F0;}</string>
-             </property>
-             <property name="readOnly">
-              <bool>true</bool>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </item>
-        </layout>
-       </item>
-       <item>
         <widget class="QLabel" name="explanationLabel">
          <property name="text">
           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
@@ -528,6 +477,74 @@
           </widget>
          </item>
         </layout>
+       </item>
+       <item>
+        <widget class="QgsCollapsibleGroupBox" name="projectDetailsGroupBox">
+         <property name="title">
+          <string>Project Details</string>
+         </property>
+         <property name="saveCollapsedState" stdset="0">
+          <bool>true</bool>
+         </property>
+         <property name="collapsed" stdset="0">
+          <bool>false</bool>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_7">
+          <item>
+           <layout class="QFormLayout" name="formLayout">
+            <item row="0" column="0">
+             <widget class="QLabel" name="cloudProjectNameLabel">
+              <property name="text">
+               <string>Web page</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <widget class="QLabel" name="cloudProjectNameValueLabel">
+              <property name="text">
+               <string/>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="0">
+             <widget class="QLabel" name="projectLocalDirLabel">
+              <property name="text">
+               <string>Local directory</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="1">
+             <layout class="QHBoxLayout" name="localDirHBoxLayout">
+              <item>
+               <widget class="QLineEdit" name="projectLocalDirValueLineEdit">
+                <property name="styleSheet">
+                 <string notr="true">[readOnly=&quot;true&quot;] {color: palette(shadow );}</string>
+                </property>
+                <property name="readOnly">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QPushButton" name="localDirOpenButton">
+                <property name="toolTip">
+                 <string>Open in external file browser</string>
+                </property>
+                <property name="text">
+                 <string/>
+                </property>
+                <property name="icon">
+                 <iconset>
+                  <normaloff>../resources/launch.svg</normaloff>../resources/launch.svg</iconset>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
        </item>
       </layout>
      </widget>


### PR DESCRIPTION
More polishing and improvements to the cloud project transfer dialog, this time on the panel that has users pick which files are uploaded/download to/from the cloud:

- on dark themes, the local project directory text edit widget was looking bad, the PR fixes that by avoiding hardcoded stylesheet colors
- the project hyperlink that's meant to bring users to the project page on the web did not work, fixed
- the local project directory didn't offer much at all in terms of UI/UX, a button has been added so users can open it directly

Beyond that, I've re-ordered the widgets a bit so the panel focuses on the job at hand, i.e. to transfer files. The project's hyperlink to the web app (the project name being already int the dialog title bar) and the local directory text edit widgets are secondary details/actions that should hit the eye first. As such, I've moved these to sit below the transfer widgets section, and into a collapsible groupbox (expanded by default, until users decide to save space :) ).

Before:
![Screenshot From 2025-04-13 13-31-44](https://github.com/user-attachments/assets/e949d935-b22d-4d2f-8d85-970522bc3e9b)

PR, with project details expanded:
![Screenshot From 2025-04-13 13-28-08](https://github.com/user-attachments/assets/1b02f12b-b867-4a73-ae23-57b8cfcb6310)

PR, with project details collapsed:
![Screenshot From 2025-04-13 13-28-23](https://github.com/user-attachments/assets/1735fa9e-49ef-4df5-8909-4da097ad1874)
