### PR TITLE
Implement support for uploading localized dataset files to `localized…

### DIFF
--- a/qfieldsync/core/cloud_api.py
+++ b/qfieldsync/core/cloud_api.py
@@ -735,7 +735,7 @@ class CloudNetworkAccessManager(QObject):
             self._nam.cookieJar().deleteCookie(cookie)
 
 
-    def ensure_localized_dataset_project(self) -> Optional[str]:
+    def get_localized_datasets_project(self) -> Optional[str]:
         """
         Ensures that the 'localized_datasets' project exists under the user's organization.
 
@@ -745,33 +745,22 @@ class CloudNetworkAccessManager(QObject):
         try:
          
           
-            org_username = self.user_details.get("username")
+            username = self.user_details.get("username")
 
-            if not org_username:
-                QgsMessageLog.logMessage("User not authenticated", "QFieldSync", Qgis.Warning)
-                return None
-            
             existing_projects = self.get_projects_not_async()
 
             for project in existing_projects:
-                if project.get("name") == "localized_datasets":
-                    QgsMessageLog.logMessage(
-                        "'localized_datasets' project already exists."+project.get("id"),
-                        "QFieldSync",
-                        Qgis.Info,
-                    )
+                if project.get("name") == "localized_datasets" and project.get("owner") == username:
                     return project
 
             reply = self.create_project(
                 name="localized_datasets",
-                owner=org_username,
+                owner=username,
                 description="Localized datasets for QField",
                 private=True,
             )
             
             project_data = self.json_object(reply)
-
-            QgsMessageLog.logMessage("Project ID:"+project_data.id, "QFieldSync", Qgis.Warning)
 
             return project_data
 

--- a/qfieldsync/core/cloud_api.py
+++ b/qfieldsync/core/cloud_api.py
@@ -735,28 +735,33 @@ class CloudNetworkAccessManager(QObject):
             self._nam.cookieJar().deleteCookie(cookie)
 
 
-    def get_localized_datasets_project(self) -> Optional[str]:
+    def get_localized_datasets_project(self, owner: str) -> Optional[str]:
         """
-        Ensures that the 'localized_datasets' project exists under the user's organization.
+        Retrieve the 'localized_datasets' project ID for a given owner.
+
+        This ensures that the 'localized_datasets' project is retrieved for the specified owner,
+        typically an organization or user that owns the main project. If such a project does not exist,
+        None is returned.
+
+        Args:
+            owner (str): The username of the project owner (person or organization).
 
         Returns:
-            str | None: The project ID of the 'localized_datasets' project, or None if creation failed.
+            Optional[str]: The ID of the 'localized_datasets' project if found, otherwise None.
         """
         try:
          
           
-            username = self.user_details.get("username")
-
             existing_projects = self.get_projects_not_async()
 
             for project in existing_projects:
-                if project.get("name") == "localized_datasets" and project.get("owner") == username:
+                if project.get("name") == "localized_datasets" and project.get("owner") == owner:
                     return project
 
             reply = self.create_project(
                 name="localized_datasets",
-                owner=username,
-                description="Localized datasets for QField",
+                owner=owner,
+                description="Localized datasets for QField(Sync)",
                 private=True,
             )
             


### PR DESCRIPTION
**Summary**
This PR introduces full support for handling localized datasets in QFieldSync. It ensures that any files stored under a user-specified `Localized Data Path` are properly detected and uploaded to a dedicated `localized_datasets` project on QFieldCloud.

**Implementation**
- Identification of all layers that reference files under the user-defined localized data path.
- Extraction of the relative dir and the filename of these files
- Automatically checks for the existence of the localized_datasets project under the user's organization.
- Creation of the project if it doesn't exist (only if the user is the owner of the organization).
- Localized files are uploaded to a separate `localized_datasets project.
- Files maintain relative paths under a localized: prefix (e.g., localized:Rasters/orthophoto_sevilla.tif).
- Integration with existing cloud sync workflows.

**Testing**
- Login in QFieldSync as the owner of an org
- Create/pull project
- Define a Localized Data Path under QFieldSync settings in QGIS
- Add layers referencing files inside that path
- Proceed to a cloud upload from the QFieldSync plugin
- Check that the project localized_datasets exists under the org (if it was not there before) and the files are uploaded to the localized_datasets project with correct relative paths