### PR TITLE
Seamless localized datasets upload support

### DIFF
--- a/qfieldsync/core/cloud_api.py
+++ b/qfieldsync/core/cloud_api.py
@@ -735,7 +735,7 @@ class CloudNetworkAccessManager(QObject):
             self._nam.cookieJar().deleteCookie(cookie)
 
 
-    def ensure_localized_dataset_project(self) -> Optional[str]:
+    def get_localized_datasets_project(self) -> Optional[str]:
         """
         Ensures that the 'localized_datasets' project exists under the user's organization.
 
@@ -745,33 +745,22 @@ class CloudNetworkAccessManager(QObject):
         try:
          
           
-            org_username = self.user_details.get("username")
+            username = self.user_details.get("username")
 
-            if not org_username:
-                QgsMessageLog.logMessage("User not authenticated", "QFieldSync", Qgis.Warning)
-                return None
-            
             existing_projects = self.get_projects_not_async()
 
             for project in existing_projects:
-                if project.get("name") == "localized_datasets":
-                    QgsMessageLog.logMessage(
-                        "'localized_datasets' project already exists."+project.get("id"),
-                        "QFieldSync",
-                        Qgis.Info,
-                    )
+                if project.get("name") == "localized_datasets" and project.get("owner") == username:
                     return project
 
             reply = self.create_project(
                 name="localized_datasets",
-                owner=org_username,
+                owner=username,
                 description="Localized datasets for QField",
                 private=True,
             )
             
             project_data = self.json_object(reply)
-
-            QgsMessageLog.logMessage("Project ID:"+project_data.id, "QFieldSync", Qgis.Warning)
 
             return project_data
 

--- a/qfieldsync/core/cloud_api.py
+++ b/qfieldsync/core/cloud_api.py
@@ -735,28 +735,33 @@ class CloudNetworkAccessManager(QObject):
             self._nam.cookieJar().deleteCookie(cookie)
 
 
-    def get_localized_datasets_project(self) -> Optional[str]:
+    def get_localized_datasets_project(self, owner: str) -> Optional[str]:
         """
-        Ensures that the 'localized_datasets' project exists under the user's organization.
+        Retrieve the 'localized_datasets' project ID for a given owner.
+
+        This ensures that the 'localized_datasets' project is retrieved for the specified owner,
+        typically an organization or user that owns the main project. If such a project does not exist,
+        None is returned.
+
+        Args:
+            owner (str): The username of the project owner (person or organization).
 
         Returns:
-            str | None: The project ID of the 'localized_datasets' project, or None if creation failed.
+            Optional[str]: The ID of the 'localized_datasets' project if found, otherwise None.
         """
         try:
          
           
-            username = self.user_details.get("username")
-
             existing_projects = self.get_projects_not_async()
 
             for project in existing_projects:
-                if project.get("name") == "localized_datasets" and project.get("owner") == username:
+                if project.get("name") == "localized_datasets" and project.get("owner") == owner:
                     return project
 
             reply = self.create_project(
                 name="localized_datasets",
-                owner=username,
-                description="Localized datasets for QField",
+                owner=owner,
+                description="Localized datasets for QField(Sync)",
                 private=True,
             )
             

--- a/qfieldsync/core/cloud_api.py
+++ b/qfieldsync/core/cloud_api.py
@@ -33,11 +33,18 @@ from qgis.core import (
     Qgis,
     QgsApplication,
     QgsAuthMethodConfig,
+    QgsMessageLog,
     QgsNetworkAccessManager,
     QgsProject,
-    QgsMessageLog
 )
-from qgis.PyQt.QtCore import QEventLoop, QFileSystemWatcher, QObject, QUrl, QUrlQuery, pyqtSignal
+from qgis.PyQt.QtCore import (
+    QEventLoop,
+    QFileSystemWatcher,
+    QObject,
+    QUrl,
+    QUrlQuery,
+    pyqtSignal,
+)
 from qgis.PyQt.QtNetwork import (
     QHttpMultiPart,
     QHttpPart,
@@ -748,7 +755,7 @@ class CloudNetworkAccessManager(QObject):
             for project in self.projects_cache.projects:
                 if project.name == "localized_datasets" and project.owner == owner:
                     return project
-            
+
             # If not, refresh the projects cache and check again
             self.projects_cache.refresh_not_async()
             for project in self.projects_cache.projects:
@@ -765,7 +772,7 @@ class CloudNetworkAccessManager(QObject):
             loop = QEventLoop()
             reply.finished.connect(loop.quit)
             loop.exec()
-            
+
             self.projects_cache.refresh_not_async()
             for project in self.projects_cache.projects:
                 if project.name == "localized_datasets" and project.owner == owner:
@@ -773,7 +780,7 @@ class CloudNetworkAccessManager(QObject):
 
         except Exception as err:
             QgsMessageLog.logMessage(
-                "Error:"+str(err),
+                "Error:" + str(err),
                 "QFieldSync",
                 Qgis.Critical,
             )
@@ -1037,4 +1044,3 @@ class CloudProjectsCache(QObject):
         for project in self._projects:
             if dirpath == project.local_dir:
                 project.refresh_files()
-

--- a/qfieldsync/core/cloud_api.py
+++ b/qfieldsync/core/cloud_api.py
@@ -736,7 +736,7 @@ class CloudNetworkAccessManager(QObject):
 
         return error_str
 
-    def get_localized_datasets_project(self, owner: str) -> Optional[str]:
+    def get_or_create_localized_datasets_project(self, owner: str) -> Optional[str]:
         """
         Retrieve the 'localized_datasets' project ID for a given owner.
 
@@ -748,7 +748,7 @@ class CloudNetworkAccessManager(QObject):
             owner: The username of the project owner (person or organization).
 
         Returns:
-            The 'localized_datasets' project data if found, otherwise None.
+            The 'localized_datasets' project data if found or successfully created, otherwise None.
         """
         try:
             # Check if the project is already in the projects cache

--- a/qfieldsync/core/cloud_project.py
+++ b/qfieldsync/core/cloud_project.py
@@ -28,7 +28,7 @@ from pathlib import Path
 from typing import Any, Dict, Iterator, List, Optional, Union
 
 from libqfieldsync.utils.qgis import get_qgis_files_within_dir
-from qgis.core import Qgis, QgsProject, QgsProviderRegistry, QgsProviderMetadata
+from qgis.core import Qgis, QgsProject, QgsProviderRegistry
 from qgis.PyQt.QtCore import QDir
 
 from qfieldsync.core.preferences import Preferences
@@ -361,7 +361,7 @@ class CloudProject:
                 continue
 
             yield project_file
-    
+
     @property
     def is_current_qgis_project(self) -> bool:
         project_home_path = QgsProject.instance().homePath()
@@ -395,7 +395,11 @@ class CloudProject:
         return None
 
     def get_localized_dataset_files(self, localized_data_paths) -> List[Path]:
-        if len(localized_data_paths) > 0 and self.local_project_file and self.local_project_file.local_path_exists:
+        if (
+            len(localized_data_paths) > 0
+            and self.local_project_file
+            and self.local_project_file.local_path_exists
+        ):
             read_flags = QgsProject.ReadFlags()
             read_flags |= QgsProject.FlagDontLoadLayouts
             read_flags |= QgsProject.FlagTrustLayerMetadata
@@ -405,9 +409,11 @@ class CloudProject:
             temporary_project.read(str(self.local_project_file.local_path), read_flags)
             layers = temporary_project.mapLayers()
             localized_datasets_files = []
-            for (layer_id, layer) in layers.items():
-                if layer.dataProvider():                    
-                    metadata = QgsProviderRegistry.instance().providerMetadata(layer.dataProvider().name())
+            for layer_id, layer in layers.items():
+                if layer.dataProvider():
+                    metadata = QgsProviderRegistry.instance().providerMetadata(
+                        layer.dataProvider().name()
+                    )
                     metadata.decodeUri(layer.source())
                     filename = metadata.decodeUri(layer.source()).get("path", "")
                     if filename:

--- a/qfieldsync/core/cloud_project.py
+++ b/qfieldsync/core/cloud_project.py
@@ -28,6 +28,7 @@ from pathlib import Path
 from typing import Any, Dict, Iterator, List, Optional, Union
 
 from libqfieldsync.utils.qgis import get_qgis_files_within_dir
+from libqfieldsync.utils.bad_layer_handler import bad_layer_handler
 from qgis.core import QgsProject
 from qgis.PyQt.QtCore import QDir
 
@@ -357,6 +358,10 @@ class CloudProject:
                 continue
 
             yield project_file
+    
+    @property
+    def localized_dataset_files(self) -> Optional[List]:
+        print(self.local_project_file)
 
     @property
     def is_current_qgis_project(self) -> bool:

--- a/qfieldsync/core/cloud_transferrer.py
+++ b/qfieldsync/core/cloud_transferrer.py
@@ -456,7 +456,7 @@ class CloudTransferrer(QObject):
         if len(self._files_to_upload_for_localized_datasets) == 0:
             self.localized_datasets_upload_progress.emit(1)
             self.localized_datasets_upload_finished.emit()
-            # NOTE check _on_localized_datasets_upload_finished
+            # NOTE the execution logic here continues in the `_on_localized_datasets_upload_finished`, as now we have to upload the regular project files.
             return
 
         self.is_localized_datasets_upload_active = True
@@ -689,7 +689,10 @@ class ThrottledFileTransferrer(QObject):
         self.filenames = [f.name for f in files]
         self.max_parallel_requests = max_parallel_requests
         self.finished_count = 0
-        self.temp_dir = Path(cloud_project.local_dir).joinpath(".qfieldsync")
+        if cloud_project.local_dir:
+            self.temp_dir = Path(cloud_project.local_dir).joinpath(".qfieldsync")
+        else:
+            self.temp_dir = None
         self.transfer_type = transfer_type
 
         for file in self.files:
@@ -699,6 +702,8 @@ class ThrottledFileTransferrer(QObject):
                 destination = self.temp_dir.joinpath(
                     str(self.transfer_type.value), file.name
                 )
+            else:
+                assert False
 
             transfer = FileTransfer(
                 self.network_manager,

--- a/qfieldsync/core/cloud_transferrer.py
+++ b/qfieldsync/core/cloud_transferrer.py
@@ -190,14 +190,15 @@ class CloudTransferrer(QObject):
             for localized_data_path in localized_data_paths:
                 for localized_datasets_file in localized_datasets_files:
                     if localized_datasets_file.startswith(localized_data_path):
+                        localized_datasets_name = (
+                            Path(localized_datasets_file)
+                            .relative_to(localized_data_path)
+                            .as_posix()
+                        )
                         self._localized_datasets_files_to_upload.append(
                             ProjectFile(
-                                {
-                                    "name": localized_datasets_file[
-                                        len(localized_data_path) + 1 :
-                                    ]
-                                },
-                                local_dir=localized_datasets_file,
+                                {"name": localized_datasets_name},
+                                local_dir=localized_data_path,
                             )
                         )
 
@@ -716,7 +717,7 @@ class ThrottledFileTransferrer(QObject):
                 self.cloud_project,
                 self.transfer_type,
                 file,
-                Path(file.local_dir)
+                Path(file.local_dir).joinpath(file.name)
                 if use_file_local_dir
                 else self.temp_dir.joinpath(str(self.transfer_type.value), file.name),
             )

--- a/qfieldsync/gui/cloud_transfer_dialog.py
+++ b/qfieldsync/gui/cloud_transfer_dialog.py
@@ -30,7 +30,7 @@ from libqfieldsync.offline_converter import ExportType
 from libqfieldsync.project_checker import ProjectChecker
 from libqfieldsync.utils.file_utils import get_unique_empty_dirname
 from libqfieldsync.utils.qgis import get_qgis_files_within_dir
-from qgis.core import QgsApplication, QgsProject, QgsLocalizedDataPathRegistry
+from qgis.core import QgsApplication, QgsProject
 from qgis.PyQt.QtCore import QDir, Qt, QUrl, pyqtSignal
 from qgis.PyQt.QtGui import QDesktopServices, QShowEvent
 from qgis.PyQt.QtWidgets import (
@@ -49,7 +49,7 @@ from qgis.utils import iface
 
 from qfieldsync.core.cloud_api import CloudNetworkAccessManager
 from qfieldsync.core.cloud_project import CloudProject, ProjectFile, ProjectFileCheckout
-from qfieldsync.core.cloud_transferrer import CloudTransferrer, FileTransfer, TransferFileLogsModel
+from qfieldsync.core.cloud_transferrer import CloudTransferrer, TransferFileLogsModel
 from qfieldsync.core.preferences import Preferences
 from qfieldsync.gui.checker_feedback_table import CheckerFeedbackTable
 
@@ -261,7 +261,6 @@ class CloudTransferDialog(QDialog, CloudTransferDialogUi):
                 self.cloud_project.id
             )
             reply.finished.connect(lambda: self.check_localized_datasets())
-            
 
     def show_end_page(
         self, feedback: str = "", logs_model: TransferFileLogsModel = None
@@ -314,19 +313,29 @@ class CloudTransferDialog(QDialog, CloudTransferDialogUi):
             self.detailedLogEndPageListView.setModel(logs_model)
             self.detailedLogEndPageListView.setModelColumn(0)
 
-            
     def check_localized_datasets(self):
-        localized_data_paths = QgsApplication.instance().localizedDataPathRegistry().paths()
+        localized_data_paths = (
+            QgsApplication.instance().localizedDataPathRegistry().paths()
+        )
         if localized_data_paths:
-            self.localized_datasets_files = self.cloud_project.get_localized_dataset_files(localized_data_paths)
+            self.localized_datasets_files = (
+                self.cloud_project.get_localized_dataset_files(localized_data_paths)
+            )
             if self.localized_datasets_files:
-                self.localized_datasets_project = self.network_manager.get_localized_datasets_project(self.cloud_project.owner)
-                if self.localized_datasets_project and self.localized_datasets_project.id != self.cloud_project.id:
-                   reply = self.network_manager.projects_cache.get_project_files(
-                       self.localized_datasets_project.id
-                   )
-                   reply.finished.connect(lambda: self.prepare_project_transfer())
-                   return
+                self.localized_datasets_project = (
+                    self.network_manager.get_localized_datasets_project(
+                        self.cloud_project.owner
+                    )
+                )
+                if (
+                    self.localized_datasets_project
+                    and self.localized_datasets_project.id != self.cloud_project.id
+                ):
+                    reply = self.network_manager.projects_cache.get_project_files(
+                        self.localized_datasets_project.id
+                    )
+                    reply.finished.connect(lambda: self.prepare_project_transfer())
+                    return
 
         self.prepare_project_transfer()
 
@@ -345,17 +354,29 @@ class CloudTransferDialog(QDialog, CloudTransferDialogUi):
 
         # Remove files that are already present remotely, override should be done manually
         if self.localized_datasets_project and self.localized_datasets_files:
-            localized_data_paths = QgsApplication.instance().localizedDataPathRegistry().paths()
-            localized_datasets_project_files = self.localized_datasets_project.get_files()
+            localized_data_paths = (
+                QgsApplication.instance().localizedDataPathRegistry().paths()
+            )
+            localized_datasets_project_files = (
+                self.localized_datasets_project.get_files()
+            )
             localized_datasets_project_names = []
             for localized_datasets_project_file in localized_datasets_project_files:
-                localized_datasets_project_names.append(localized_datasets_project_file.name)
+                localized_datasets_project_names.append(
+                    localized_datasets_project_file.name
+                )
             for localized_data_path in localized_data_paths:
                 for localized_datasets_file in self.localized_datasets_files[:]:
-                    if localized_datasets_file[len(localized_data_path)+1:] in localized_datasets_project_names:
+                    if (
+                        localized_datasets_file[len(localized_data_path) + 1 :]
+                        in localized_datasets_project_names
+                    ):
                         self.localized_datasets_files.remove(localized_datasets_file)
 
-        if len(list(self.cloud_project.files_to_sync)) == 0 and len(self.localized_datasets_files) == 0:
+        if (
+            len(list(self.cloud_project.files_to_sync)) == 0
+            and len(self.localized_datasets_files) == 0
+        ):
             files_total = len(self.cloud_project.get_files())
             if files_total > 0:
                 self.show_end_page(
@@ -380,7 +401,9 @@ class CloudTransferDialog(QDialog, CloudTransferDialogUi):
             return
 
         print(self.localized_datasets_files)
-        self.uploadLocalizedDatasetsCheck.setVisible(len(self.localized_datasets_files) != 0)
+        self.uploadLocalizedDatasetsCheck.setVisible(
+            len(self.localized_datasets_files) != 0
+        )
         self.project_transfer = CloudTransferrer(
             self.network_manager,
             self.cloud_project,
@@ -582,8 +605,12 @@ class CloudTransferDialog(QDialog, CloudTransferDialogUi):
 
             hasLocalizedDatasetsUploads = len(self.localized_datasets_files) > 0
             self.localizedDatasetsUploadLabel.setVisible(hasLocalizedDatasetsUploads)
-            self.localizedDatasetsUploadProgressBar.setVisible(hasLocalizedDatasetsUploads)
-            self.localizedDatasetsUploadProgressFeedbackLabel.setVisible(hasLocalizedDatasetsUploads)
+            self.localizedDatasetsUploadProgressBar.setVisible(
+                hasLocalizedDatasetsUploads
+            )
+            self.localizedDatasetsUploadProgressFeedbackLabel.setVisible(
+                hasLocalizedDatasetsUploads
+            )
 
             hasUploads = len(files["to_upload"]) > 0
             self.uploadLabel.setVisible(hasUploads)
@@ -610,7 +637,10 @@ class CloudTransferDialog(QDialog, CloudTransferDialogUi):
             assert self.project_transfer
 
             self.project_transfer.sync(
-                files["to_upload"], files["to_download"], files["to_delete"], self.localized_datasets_files
+                files["to_upload"],
+                files["to_download"],
+                files["to_delete"],
+                self.localized_datasets_files,
             )
 
             assert self.project_transfer.transfers_model
@@ -925,18 +955,24 @@ class CloudTransferDialog(QDialog, CloudTransferDialogUi):
         if localized_datasets_upload_count:
             if localized_datasets_upload_count > 1:
                 localized_datasets_upload_message += self.tr(
-                    "{} localized datasets to copy to QFieldCloud.".format(localized_datasets_upload_count)
+                    "{} localized datasets to copy to QFieldCloud.".format(
+                        localized_datasets_upload_count
+                    )
                 )
             elif localized_datasets_upload_count == 1:
-                localized_datasets_upload_message += self.tr("1 localized dataset to copy to QFieldCloud.")
-            
+                localized_datasets_upload_message += self.tr(
+                    "1 localized dataset to copy to QFieldCloud."
+                )
+
             self.localizedDatasetsUploadProgressBar.setValue(0)
             self.localizedDatasetsUploadProgressBar.setEnabled(True)
         else:
             self.localizedDatasetsUploadProgressBar.setValue(100)
             self.localizedDatasetsUploadProgressBar.setEnabled(False)
             localized_datasets_upload_message = self.tr("Nothing to do on QFieldCloud.")
-        self.localizedDatasetsUploadProgressFeedbackLabel.setText(localized_datasets_upload_message)
+        self.localizedDatasetsUploadProgressFeedbackLabel.setText(
+            localized_datasets_upload_message
+        )
 
         upload_message = ""
         if upload_count or cloud_delete_count:

--- a/qfieldsync/gui/cloud_transfer_dialog.py
+++ b/qfieldsync/gui/cloud_transfer_dialog.py
@@ -257,7 +257,12 @@ class CloudTransferDialog(QDialog, CloudTransferDialogUi):
             reply = self.network_manager.projects_cache.get_project_files(
                 self.cloud_project.id
             )
+            
+            print(self.cloud_project.local_project_file)
+            #localized_project = self.network_manager.get_localized_datasets_project(self.cloud_project.owner)
+            #if not localized_project:                
             reply.finished.connect(lambda: self.prepare_project_transfer())
+            
 
     def show_end_page(
         self, feedback: str = "", logs_model: TransferFileLogsModel = None

--- a/qfieldsync/gui/cloud_transfer_dialog.py
+++ b/qfieldsync/gui/cloud_transfer_dialog.py
@@ -368,7 +368,10 @@ class CloudTransferDialog(QDialog, CloudTransferDialogUi):
             for localized_data_path in localized_data_paths:
                 for localized_datasets_file in self.localized_datasets_files[:]:
                     if (
-                        localized_datasets_file[len(localized_data_path) + 1 :]
+                        localized_datasets_file.startswith(localized_data_path)
+                        and Path(localized_datasets_file)
+                        .relative_to(localized_data_path)
+                        .as_posix()
                         in localized_datasets_project_names
                     ):
                         self.localized_datasets_files.remove(localized_datasets_file)
@@ -400,7 +403,6 @@ class CloudTransferDialog(QDialog, CloudTransferDialogUi):
                 self.openProjectCheck.setVisible(False)
             return
 
-        print(self.localized_datasets_files)
         self.uploadLocalizedDatasetsCheck.setVisible(
             len(self.localized_datasets_files) != 0
         )
@@ -603,7 +605,10 @@ class CloudTransferDialog(QDialog, CloudTransferDialogUi):
 
                 self.traverse_tree_item(item, files)
 
-            hasLocalizedDatasetsUploads = len(self.localized_datasets_files) > 0
+            hasLocalizedDatasetsUploads = (
+                len(self.localized_datasets_files) > 0
+                and self.uploadLocalizedDatasetsCheck.isChecked()
+            )
             self.localizedDatasetsUploadLabel.setVisible(hasLocalizedDatasetsUploads)
             self.localizedDatasetsUploadProgressBar.setVisible(
                 hasLocalizedDatasetsUploads
@@ -640,7 +645,9 @@ class CloudTransferDialog(QDialog, CloudTransferDialogUi):
                 files["to_upload"],
                 files["to_download"],
                 files["to_delete"],
-                self.localized_datasets_files,
+                self.localized_datasets_files
+                if self.uploadLocalizedDatasetsCheck.isChecked()
+                else [],
             )
 
             assert self.project_transfer.transfers_model
@@ -941,7 +948,11 @@ class CloudTransferDialog(QDialog, CloudTransferDialogUi):
         cloud_delete_count = 0
         download_count = len(files["to_download"])
         upload_count = len(files["to_upload"])
-        localized_datasets_upload_count = len(self.localized_datasets_files)
+        localized_datasets_upload_count = (
+            len(self.localized_datasets_files)
+            if self.uploadLocalizedDatasetsCheck.isChecked()
+            else 0
+        )
 
         for f in files["to_delete"]:
             total_delete_count += 1

--- a/qfieldsync/gui/cloud_transfer_dialog.py
+++ b/qfieldsync/gui/cloud_transfer_dialog.py
@@ -362,9 +362,13 @@ class CloudTransferDialog(QDialog, CloudTransferDialogUi):
             )
             localized_datasets_project_names = []
             for localized_datasets_project_file in localized_datasets_project_files:
-                localized_datasets_project_names.append(
-                    localized_datasets_project_file.name
-                )
+                # If the file is already on the cloud, add to names to exclude
+                if bool(
+                    localized_datasets_project_file.checkout & ProjectFileCheckout.Cloud
+                ):
+                    localized_datasets_project_names.append(
+                        localized_datasets_project_file.name
+                    )
             for localized_data_path in localized_data_paths:
                 for localized_datasets_file in self.localized_datasets_files[:]:
                     if (

--- a/qfieldsync/ui/cloud_transfer_dialog.ui
+++ b/qfieldsync/ui/cloud_transfer_dialog.ui
@@ -278,6 +278,30 @@
           </widget>
          </item>
          <item>
+          <widget class="QLabel" name="localizedDatasetsUploadLabel">
+           <property name="text">
+            <string>Uploading localized datasets</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QProgressBar" name="localizedDatasetsUploadProgressBar">
+           <property name="value">
+            <number>0</number>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="localizedDatasetsUploadProgressFeedbackLabel">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item>
           <widget class="QLabel" name="downloadLabel">
            <property name="text">
             <string>Downloading</string>
@@ -441,6 +465,16 @@
            <string>Action</string>
           </property>
          </column>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="uploadLocalizedDatasetsCheck">
+         <property name="text">
+          <string>Upload missing localized dataset(s)</string>
+         </property>
+         <property name="checked">
+          <bool>true</bool>
+         </property>
         </widget>
        </item>
        <item>

--- a/qfieldsync/ui/cloud_transfer_dialog.ui
+++ b/qfieldsync/ui/cloud_transfer_dialog.ui
@@ -473,7 +473,7 @@
           <string>Upload missing localized dataset(s)</string>
          </property>
          <property name="checked">
-          <bool>true</bool>
+          <bool>false</bool>
          </property>
         </widget>
        </item>


### PR DESCRIPTION
This PR takes on the work done by @tdrivas and finishes the handling of localized datasets upload when synchronizing a cloud project.

The following additions are in the PR:
- we do not rely on QgsProject.instance() to get localized datasets but instead we do it by temporarily opening a locally stored cloud project file to fetch them
- the upload relies on the ThrottledFileTransfer class, which gives us UI feedback and control over how many files we upload at the same time
- we rely on project cache to avoid hard-coded project fetch
- a minimal UI was added to allow for users to skip localized dataset upload (see the screenshot below):

![image](https://github.com/user-attachments/assets/856c4281-475d-4fb2-91e9-09656f70f559)

I've been re-thinking about this, and IMHO, we should actually avoid uploading a localized dataset when it's present remotely but has a different checksums. That should be handled when someone manually synchronize the localized_dataset project itself.

Thinks that could be improved in a follow up PR (but really not that required for an initial drop):
- adding a warning message for checksum mismatch