### PR TITLE
Fixing missing argument files_to_upload_for_localized_datasets on the cloud transferrer

### DIFF
--- a/qfieldsync/gui/cloud_create_project_widget.py
+++ b/qfieldsync/gui/cloud_create_project_widget.py
@@ -250,7 +250,7 @@ class CloudCreateProjectWidget(QWidget, WidgetUi):
             self.cloud_transferrer.finished.connect(
                 lambda: self.on_transferrer_finished()
             )
-            self.cloud_transferrer.sync(list(cloud_project.files_to_sync), [], [])
+            self.cloud_transferrer.sync(list(cloud_project.files_to_sync), [], [], [])
 
     def after_project_creation_action(self, project_id: str):
         QApplication.restoreOverrideCursor()


### PR DESCRIPTION
This PR fix:
![image](https://github.com/user-attachments/assets/d9c6b766-ab80-4ca1-94ab-b208673563fd)
