### PR TITLE
Add additional default attachment directories to cover all default attachment expressions

### DIFF
--- a/qfieldsync/core/preferences.py
+++ b/qfieldsync/core/preferences.py
@@ -26,7 +26,11 @@ class Preferences(SettingManager):
         self.add_setting(Bool("showPackagingActions", Scope.Global, True))
         self.add_setting(String("importDirectoryProject", Scope.Project, None))
         self.add_setting(Dictionary("dirsToCopy", Scope.Project, {}))
-        self.add_setting(Stringlist("attachmentDirs", Scope.Project, ["DCIM"]))
+        self.add_setting(
+            Stringlist(
+                "attachmentDirs", Scope.Project, ["DCIM", "audio", "video", "files"]
+            )
+        )
         self.add_setting(Dictionary("qfieldCloudProjectLocalDirs", Scope.Global, {}))
         self.add_setting(Dictionary("qfieldCloudLastProjectFiles", Scope.Global, {}))
         self.add_setting(String("qfieldCloudServerUrl", Scope.Global, ""))


### PR DESCRIPTION
We should have done this a long time ago -- once upon a time, when we added audio, video, and other file attachments support, the default expression has files put in more than a single DCIM directory. If the users to not add these extra folders, they will end up not able to package attachments when downloading the project on QField devices (i.e. https://github.com/opengisch/QField/issues/6409)
