### PR TITLE
Explode geometry locked into 4 distinct locked states

### DIFF
--- a/qfieldsync/gui/map_layer_config_widget.py
+++ b/qfieldsync/gui/map_layer_config_widget.py
@@ -55,7 +55,10 @@ class MapLayerConfigWidgetFactory(QgsMapLayerConfigWidgetFactory):
 
 
 class MapLayerConfigWidget(QgsMapLayerConfigWidget, WidgetUi):
-    PROPERTY_GEOMETRY_LOCKED = 1
+    PROPERTY_FEATURE_ADDITION_LOCKED = 1
+    PROPERTY_GEOMETRY_EDITING_LOCKED = 2
+    PROPERTY_ATTRIBUTE_EDITING_LOCKED = 3
+    PROPERTY_FEATURE_DELETION_LOCKED = 4
 
     def __init__(self, layer, canvas, parent):
         super(MapLayerConfigWidget, self).__init__(layer, canvas, parent)
@@ -102,29 +105,99 @@ class MapLayerConfigWidget(QgsMapLayerConfigWidget, WidgetUi):
 
         if layer.type() == QgsMapLayer.VectorLayer:
             prop = QgsProperty.fromExpression(
-                self.layer_source.geometry_locked_expression
+                self.layer_source.feature_addition_locked_expression
             )
-            prop.setActive(self.layer_source.is_geometry_locked_expression_active)
+            prop.setActive(
+                self.layer_source.is_feature_addition_locked_expression_active
+            )
             prop_definition = QgsPropertyDefinition(
-                "is_geometry_locked",
+                "is_feature_addition_locked",
                 QgsPropertyDefinition.DataType.DataTypeBoolean,
-                "Geometry Locked",
+                "Feature Addition Locked",
                 "",
             )
-            self.isGeometryLockedDDButton.init(
-                MapLayerConfigWidget.PROPERTY_GEOMETRY_LOCKED,
+            self.isFeatureAdditionLockedDDButton.init(
+                MapLayerConfigWidget.PROPERTY_FEATURE_ADDITION_LOCKED,
                 prop,
                 prop_definition,
                 None,
                 False,
             )
-            self.isGeometryLockedDDButton.setVectorLayer(layer)
-
-            self.isGeometryLockedCheckBox.setEnabled(
-                self.layer_source.can_lock_geometry
+            self.isFeatureAdditionLockedDDButton.setVectorLayer(layer)
+            self.isFeatureAdditionLockedCheckBox.setChecked(
+                self.layer_source.is_feature_addition_locked
             )
-            self.isGeometryLockedCheckBox.setChecked(
-                self.layer_source.is_geometry_locked
+
+            prop = QgsProperty.fromExpression(
+                self.layer_source.attribute_editing_locked_expression
+            )
+            prop.setActive(
+                self.layer_source.is_attribute_editing_locked_expression_active
+            )
+            prop_definition = QgsPropertyDefinition(
+                "is_attribute_editing_locked",
+                QgsPropertyDefinition.DataType.DataTypeBoolean,
+                "Attribute Editing Locked",
+                "",
+            )
+            self.isAttributeEditingLockedDDButton.init(
+                MapLayerConfigWidget.PROPERTY_ATTRIBUTE_EDITING_LOCKED,
+                prop,
+                prop_definition,
+                None,
+                False,
+            )
+            self.isAttributeEditingLockedDDButton.setVectorLayer(layer)
+            self.isAttributeEditingLockedCheckBox.setChecked(
+                self.layer_source.is_attribute_editing_locked
+            )
+
+            prop = QgsProperty.fromExpression(
+                self.layer_source.geometry_editing_locked_expression
+            )
+            prop.setActive(
+                self.layer_source.is_geometry_editing_locked_expression_active
+            )
+            prop_definition = QgsPropertyDefinition(
+                "is_geometry_editing_locked",
+                QgsPropertyDefinition.DataType.DataTypeBoolean,
+                "Geometry Editing Locked",
+                "",
+            )
+            self.isGeometryEditingLockedDDButton.init(
+                MapLayerConfigWidget.PROPERTY_GEOMETRY_EDITING_LOCKED,
+                prop,
+                prop_definition,
+                None,
+                False,
+            )
+            self.isGeometryEditingLockedDDButton.setVectorLayer(layer)
+            self.isGeometryEditingLockedCheckBox.setChecked(
+                self.layer_source.is_geometry_editing_locked
+            )
+
+            prop = QgsProperty.fromExpression(
+                self.layer_source.feature_deletion_locked_expression
+            )
+            prop.setActive(
+                self.layer_source.is_feature_deletion_locked_expression_active
+            )
+            prop_definition = QgsPropertyDefinition(
+                "is_feature_deletion_locked",
+                QgsPropertyDefinition.DataType.DataTypeBoolean,
+                "Feature Deletion Locked",
+                "",
+            )
+            self.isFeatureDeletionLockedDDButton.init(
+                MapLayerConfigWidget.PROPERTY_FEATURE_DELETION_LOCKED,
+                prop,
+                prop_definition,
+                None,
+                False,
+            )
+            self.isFeatureDeletionLockedDDButton.setVectorLayer(layer)
+            self.isFeatureDeletionLockedCheckBox.setChecked(
+                self.layer_source.is_feature_deletion_locked
             )
 
             self.valueMapButtonInterfaceSpinBox.setValue(
@@ -196,22 +269,40 @@ class MapLayerConfigWidget(QgsMapLayerConfigWidget, WidgetUi):
             self.trackingSessionGroupBox.setVisible(False)
 
     def apply(self):
-        self.layer_source.action
-        self.layer_source.cloud_action
-        self.layer_source.is_geometry_locked
-
         self.layer_source.cloud_action = self.cloudLayerActionComboBox.itemData(
             self.cloudLayerActionComboBox.currentIndex()
         )
         self.layer_source.action = self.cableLayerActionComboBox.itemData(
             self.cableLayerActionComboBox.currentIndex()
         )
-        self.layer_source.is_geometry_locked = self.isGeometryLockedCheckBox.isChecked()
-        prop = self.isGeometryLockedDDButton.toProperty()
-        self.layer_source.is_geometry_locked_expression_active = prop.isActive()
-        self.layer_source.geometry_locked_expression = prop.asExpression()
-        print(self.valueMapButtonInterfaceSpinBox.value())
-        print(self.valueMapButtonInterfaceSpinBox.value())
+
+        self.layer_source.is_feature_addition_locked = (
+            self.isFeatureAdditionLockedCheckBox.isChecked()
+        )
+        prop = self.isFeatureAdditionLockedDDButton.toProperty()
+        self.layer_source.is_feature_addition_locked_expression_active = prop.isActive()
+        self.layer_source.feature_addition_locked_expression = prop.asExpression()
+        self.layer_source.is_attribute_editing_locked = (
+            self.isAttributeEditingLockedCheckBox.isChecked()
+        )
+        prop = self.isAttributeEditingLockedDDButton.toProperty()
+        self.layer_source.is_attribute_editing_locked_expression_active = (
+            prop.isActive()
+        )
+        self.layer_source.attribute_editing_locked_expression = prop.asExpression()
+        self.layer_source.is_geometry_editing_locked = (
+            self.isGeometryEditingLockedCheckBox.isChecked()
+        )
+        prop = self.isGeometryEditingLockedDDButton.toProperty()
+        self.layer_source.is_geometry_editing_locked_expression_active = prop.isActive()
+        self.layer_source.geometry_editing_locked_expression = prop.asExpression()
+        self.layer_source.is_feature_deletion_locked = (
+            self.isFeatureDeletionLockedCheckBox.isChecked()
+        )
+        prop = self.isFeatureDeletionLockedDDButton.toProperty()
+        self.layer_source.is_feature_deletion_locked_expression_active = prop.isActive()
+        self.layer_source.feature_deletion_locked_expression = prop.asExpression()
+
         self.layer_source.value_map_button_interface_threshold = (
             self.valueMapButtonInterfaceSpinBox.value()
         )

--- a/qfieldsync/ui/map_layer_config_widget.ui
+++ b/qfieldsync/ui/map_layer_config_widget.ui
@@ -52,8 +52,8 @@
        </widget>
       </item>
       <item row="2" column="1">
-       <layout class="QHBoxLayout" name="horizontalLayout">
-        <item>
+       <layout class="QGridLayout" name="lockGridLayout">
+        <item row="0" column="0">
          <widget class="QCheckBox" name="isFeatureAdditionLockedCheckBox">
           <property name="toolTip">
            <string>When enabled, this option disables adding features onto the layer.</string>
@@ -63,14 +63,14 @@
           </property>
          </widget>
         </item>
-        <item>
+        <item row="0" column="1">
          <widget class="QgsPropertyOverrideButton" name="isFeatureAdditionLockedDDButton">
           <property name="text">
            <string>…</string>
           </property>
          </widget>
         </item>
-        <item>
+        <item row="0" column="2">
          <widget class="QCheckBox" name="isFeatureDeletionLockedCheckBox">
           <property name="toolTip">
            <string>When enabled, this option disables the deletion of features.</string>
@@ -80,14 +80,14 @@
           </property>
          </widget>
         </item>
-        <item>
+        <item row="0" column="3">
          <widget class="QgsPropertyOverrideButton" name="isFeatureDeletionLockedDDButton">
           <property name="text">
            <string>…</string>
           </property>
          </widget>
         </item>
-        <item>
+        <item row="0" column="4">
          <spacer name="horizontalSpacer">
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
@@ -100,11 +100,7 @@
           </property>
          </spacer>
         </item>
-       </layout>
-      </item>
-      <item row="3" column="1">
-       <layout class="QHBoxLayout" name="horizontalLayout2">
-        <item>
+        <item row="1" column="0">
          <widget class="QCheckBox" name="isAttributeEditingLockedCheckBox">
           <property name="toolTip">
            <string>When enabled, this option disables modifying attributes of existing features.</string>
@@ -114,14 +110,14 @@
           </property>
          </widget>
         </item>
-        <item>
+        <item row="1" column="1">
          <widget class="QgsPropertyOverrideButton" name="isAttributeEditingLockedDDButton">
           <property name="text">
            <string>…</string>
           </property>
          </widget>
         </item>
-        <item>
+        <item row="1" column="2">
          <widget class="QCheckBox" name="isGeometryEditingLockedCheckBox">
           <property name="toolTip">
            <string>When enabled, this option disables modifying geometries of existing features.</string>
@@ -131,25 +127,12 @@
           </property>
          </widget>
         </item>
-        <item>
+        <item row="1" column="3">
          <widget class="QgsPropertyOverrideButton" name="isGeometryEditingLockedDDButton">
           <property name="text">
            <string>…</string>
           </property>
          </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer2">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>20</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
         </item>
        </layout>
       </item>

--- a/qfieldsync/ui/map_layer_config_widget.ui
+++ b/qfieldsync/ui/map_layer_config_widget.ui
@@ -44,20 +44,44 @@
         </property>
        </widget>
       </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="lockLabel">
+        <property name="text">
+         <string>Permission lock</string>
+        </property>
+       </widget>
+      </item>
       <item row="2" column="1">
        <layout class="QHBoxLayout" name="horizontalLayout">
         <item>
-         <widget class="QCheckBox" name="isGeometryLockedCheckBox">
+         <widget class="QCheckBox" name="isFeatureAdditionLockedCheckBox">
           <property name="toolTip">
-           <string>When enabled, this option disables adding and deleting features, as well as modifying the geometries of existing features.</string>
+           <string>When enabled, this option disables adding features onto the layer.</string>
           </property>
           <property name="text">
-           <string>Lock geometries</string>
+           <string>Feature addition</string>
           </property>
          </widget>
         </item>
         <item>
-         <widget class="QgsPropertyOverrideButton" name="isGeometryLockedDDButton">
+         <widget class="QgsPropertyOverrideButton" name="isFeatureAdditionLockedDDButton">
+          <property name="text">
+           <string>…</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="isFeatureDeletionLockedCheckBox">
+          <property name="toolTip">
+           <string>When enabled, this option disables the deletion of features.</string>
+          </property>
+          <property name="text">
+           <string>Feature deletion</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QgsPropertyOverrideButton" name="isFeatureDeletionLockedDDButton">
           <property name="text">
            <string>…</string>
           </property>
@@ -65,6 +89,57 @@
         </item>
         <item>
          <spacer name="horizontalSpacer">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </item>
+      <item row="3" column="1">
+       <layout class="QHBoxLayout" name="horizontalLayout2">
+        <item>
+         <widget class="QCheckBox" name="isAttributeEditingLockedCheckBox">
+          <property name="toolTip">
+           <string>When enabled, this option disables modifying attributes of existing features.</string>
+          </property>
+          <property name="text">
+           <string>Attribute editing</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QgsPropertyOverrideButton" name="isAttributeEditingLockedDDButton">
+          <property name="text">
+           <string>…</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="isGeometryEditingLockedCheckBox">
+          <property name="toolTip">
+           <string>When enabled, this option disables modifying geometries of existing features.</string>
+          </property>
+          <property name="text">
+           <string>Geometry editing</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QgsPropertyOverrideButton" name="isGeometryEditingLockedDDButton">
+          <property name="text">
+           <string>…</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer2">
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
           </property>

--- a/qfieldsync/ui/map_layer_config_widget.ui
+++ b/qfieldsync/ui/map_layer_config_widget.ui
@@ -47,7 +47,7 @@
       <item row="2" column="0">
        <widget class="QLabel" name="lockLabel">
         <property name="text">
-         <string>Permission lock</string>
+         <string>Permissions</string>
         </property>
        </widget>
       </item>
@@ -56,10 +56,10 @@
         <item row="0" column="0">
          <widget class="QCheckBox" name="isFeatureAdditionLockedCheckBox">
           <property name="toolTip">
-           <string>When enabled, this option disables adding features onto the layer.</string>
+           <string>When enabled, this option prevents the addition of new features into the layer.</string>
           </property>
           <property name="text">
-           <string>Feature addition</string>
+           <string>Disable feature addition</string>
           </property>
          </widget>
         </item>
@@ -73,10 +73,10 @@
         <item row="0" column="2">
          <widget class="QCheckBox" name="isFeatureDeletionLockedCheckBox">
           <property name="toolTip">
-           <string>When enabled, this option disables the deletion of features.</string>
+           <string>When enabled, this option prevents the deletion of features from the layer.</string>
           </property>
           <property name="text">
-           <string>Feature deletion</string>
+           <string>Disable feature deletion</string>
           </property>
          </widget>
         </item>
@@ -103,10 +103,10 @@
         <item row="1" column="0">
          <widget class="QCheckBox" name="isAttributeEditingLockedCheckBox">
           <property name="toolTip">
-           <string>When enabled, this option disables modifying attributes of existing features.</string>
+           <string>When enabled, this option disables editing of attributes of existing features.</string>
           </property>
           <property name="text">
-           <string>Attribute editing</string>
+           <string>Disable attribute editing</string>
           </property>
          </widget>
         </item>
@@ -120,10 +120,10 @@
         <item row="1" column="2">
          <widget class="QCheckBox" name="isGeometryEditingLockedCheckBox">
           <property name="toolTip">
-           <string>When enabled, this option disables modifying geometries of existing features.</string>
+           <string>When enabled, this option disables editing of geometries of existing features.</string>
           </property>
           <property name="text">
-           <string>Geometry editing</string>
+           <string>Disable geometry editing</string>
           </property>
          </widget>
         </item>

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ future
 transifex-client
 
 # NOTE `libqfielsync` version should be defined in the `*.tar.gz` format, not `git+https://` to make `wheel` happy
-libqfieldsync @ https://github.com/opengisch/libqfieldsync/archive/cd0140d6feca1deacf7e21ea37ae3eef7152bcaa.tar.gz
+libqfieldsync @ https://github.com/opengisch/libqfieldsync/archive/3e580428196af61a68f902d8b8927ed062f389f9.tar.gz


### PR DESCRIPTION
Until now, our [x] lock geometry toggle was locking quite a lot. It was locking:
- feature addition
- feature deletion
- geometry modification

Users have requested a finer grained set of locks. This PR implements that by adding 4 distinct locked states:
- feature addition
- feature deletion
- geometry modification
- attribute editing (a nice 4th lock here that was not possible before)

Each of these locks come with a data-defined property that allows for the locks to be turned on/off based on expressions evaluated against a given feature and/or various scopes.

Here's how it looks UI-wise:

![image](https://github.com/user-attachments/assets/82cb5149-57ed-44b8-8315-7798cebe7227)

Note that on the UI side, we're letting go of the word "lock" in favor of a wording that aims at being easier to understand.
