### PR TITLE
Project properties' attachment directories UI revamp

### DIFF
--- a/qfieldsync/core/preferences.py
+++ b/qfieldsync/core/preferences.py
@@ -31,6 +31,7 @@ class Preferences(SettingManager):
                 "attachmentDirs", Scope.Project, ["DCIM", "audio", "video", "files"]
             )
         )
+        self.add_setting(Stringlist("dataDirs", Scope.Project, []))
         self.add_setting(Dictionary("qfieldCloudProjectLocalDirs", Scope.Global, {}))
         self.add_setting(Dictionary("qfieldCloudLastProjectFiles", Scope.Global, {}))
         self.add_setting(String("qfieldCloudServerUrl", Scope.Global, ""))

--- a/qfieldsync/gui/directories_configuration_widget.py
+++ b/qfieldsync/gui/directories_configuration_widget.py
@@ -76,45 +76,45 @@ class DirectoriesConfigurationWidget(WidgetUi, QWidget):
 
         self.directoriesTable.setRowCount(0)
         if "attachment_dirs" in configuration:
-            print(configuration["attachment_dirs"])
             for attachment_dir in configuration["attachment_dirs"]:
-                count = self.directoriesTable.rowCount()
-                self.directoriesTable.insertRow(count)
-
-                item = QTableWidgetItem(attachment_dir)
-                item.setData(Qt.EditRole, attachment_dir)
-                self.directoriesTable.setItem(count, 0, item)
-
-                cmb = QComboBox()
-                cmb.addItem(self.tr("Attachments"))
-                cmb.setCurrentIndex(0)
-                self.directoriesTable.setCellWidget(count, 1, cmb)
+                self.addDirectoryRow(attachment_dir, 0)
+        if "data_dirs" in configuration:
+            for data_dir in configuration["data_dirs"]:
+                self.addDirectoryRow(data_dir, 1)
 
     def createConfiguration(self):
-        configuration = {"attachment_dirs": []}
+        configuration = {"attachment_dirs": [], "data_dirs": []}
 
         for i in range(self.directoriesTable.rowCount()):
             item = self.directoriesTable.item(i, 0)
             cmb = self.directoriesTable.cellWidget(i, 1)
-            if cmb.currentIndex() == 0 and item.data(Qt.EditRole) != "":
-                configuration["attachment_dirs"].append(item.data(Qt.EditRole))
+            if item.data(Qt.EditRole) != "":
+                if cmb.currentIndex() == 0:
+                    configuration["attachment_dirs"].append(item.data(Qt.EditRole))
+                elif cmb.currentIndex() == 1:
+                    configuration["data_dirs"].append(item.data(Qt.EditRole))
 
         return configuration
 
-    def addDirectory(self):
-        self.directoriesTable.setFocus()
+    def addDirectoryRow(self, name="", typeIndex=0, editRow=False):
         count = self.directoriesTable.rowCount()
         self.directoriesTable.insertRow(count)
 
-        item = QTableWidgetItem("")
-        item.setData(Qt.EditRole, "")
+        item = QTableWidgetItem(name)
+        item.setData(Qt.EditRole, name)
         self.directoriesTable.setItem(count, 0, item)
 
         cmb = QComboBox()
         cmb.addItem(self.tr("Attachments"))
-        cmb.setCurrentIndex(0)
+        cmb.addItem(self.tr("Data"))
+        cmb.setCurrentIndex(typeIndex)
         self.directoriesTable.setCellWidget(count, 1, cmb)
-        self.directoriesTable.editItem(item)
+        if editRow:
+            self.directoriesTable.editItem(item)
+
+    def addDirectory(self):
+        self.directoriesTable.setFocus()
+        self.addDirectoryRow("", 0, True)
 
     def removeDirectory(self):
         if self.directoriesTable.selectedItems():

--- a/qfieldsync/gui/directories_configuration_widget.py
+++ b/qfieldsync/gui/directories_configuration_widget.py
@@ -1,0 +1,123 @@
+# -*- coding: utf-8 -*-
+"""
+/***************************************************************************
+                             -------------------
+        begin                : 2025-06-28
+        git sha              : $Format:%H$
+        copyright            : (C) 2024 by OPENGIS.ch
+        email                : info@opengis.ch
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+"""
+import os
+
+from qgis.core import QgsApplication
+from qgis.PyQt.QtCore import Qt
+from qgis.PyQt.QtWidgets import (
+    QAbstractItemView,
+    QComboBox,
+    QHeaderView,
+    QTableWidgetItem,
+    QWidget,
+)
+from qgis.PyQt.uic import loadUiType
+
+WidgetUi, _ = loadUiType(
+    os.path.join(os.path.dirname(__file__), "../ui/directories_configuration_widget.ui")
+)
+
+
+class DirectoriesConfigurationWidget(WidgetUi, QWidget):
+    def __init__(self, parent=None):
+        """Constructor."""
+        super().__init__(parent)
+        self.setupUi(self)
+
+        self.setMinimumHeight(120)
+        self.directoriesTable.setColumnCount(2)
+        self.directoriesTable.setHorizontalHeaderLabels(
+            [self.tr("Name"), self.tr("Type")]
+        )
+        self.directoriesTable.setColumnWidth(1, 160)
+        self.directoriesTable.horizontalHeader().setSectionResizeMode(
+            0, QHeaderView.Stretch
+        )
+        self.directoriesTable.verticalHeader().setVisible(False)
+        self.directoriesTable.setAlternatingRowColors(True)
+        self.directoriesTable.setSortingEnabled(False)
+        self.directoriesTable.setSelectionMode(
+            QAbstractItemView.SelectionMode.SingleSelection
+        )
+        self.directoriesTable.itemSelectionChanged.connect(
+            lambda: self.removeButton.setEnabled(
+                len(self.directoriesTable.selectedItems()) > 0
+            )
+        )
+
+        self.addButton.setIcon(QgsApplication.getThemeIcon("/symbologyAdd.svg"))
+        self.addButton.clicked.connect(self.addDirectory)
+
+        self.removeButton.setIcon(QgsApplication.getThemeIcon("/symbologyRemove.svg"))
+        self.removeButton.setEnabled(False)
+        self.removeButton.clicked.connect(self.removeDirectory)
+
+    def reload(self, configuration):
+        """
+        Load directories into table.
+        """
+
+        self.directoriesTable.setRowCount(0)
+        if "attachment_dirs" in configuration:
+            print(configuration["attachment_dirs"])
+            for attachment_dir in configuration["attachment_dirs"]:
+                count = self.directoriesTable.rowCount()
+                self.directoriesTable.insertRow(count)
+
+                item = QTableWidgetItem(attachment_dir)
+                item.setData(Qt.EditRole, attachment_dir)
+                self.directoriesTable.setItem(count, 0, item)
+
+                cmb = QComboBox()
+                cmb.addItem(self.tr("Attachments"))
+                cmb.setCurrentIndex(0)
+                self.directoriesTable.setCellWidget(count, 1, cmb)
+
+    def createConfiguration(self):
+        configuration = {"attachment_dirs": []}
+
+        for i in range(self.directoriesTable.rowCount()):
+            item = self.directoriesTable.item(i, 0)
+            cmb = self.directoriesTable.cellWidget(i, 1)
+            if cmb.currentIndex() == 0 and item.data(Qt.EditRole) != "":
+                configuration["attachment_dirs"].append(item.data(Qt.EditRole))
+
+        return configuration
+
+    def addDirectory(self):
+        self.directoriesTable.setFocus()
+        count = self.directoriesTable.rowCount()
+        self.directoriesTable.insertRow(count)
+
+        item = QTableWidgetItem("")
+        item.setData(Qt.EditRole, "")
+        self.directoriesTable.setItem(count, 0, item)
+
+        cmb = QComboBox()
+        cmb.addItem(self.tr("Attachments"))
+        cmb.setCurrentIndex(0)
+        self.directoriesTable.setCellWidget(count, 1, cmb)
+        self.directoriesTable.editItem(item)
+
+    def removeDirectory(self):
+        if self.directoriesTable.selectedItems():
+            self.directoriesTable.removeRow(
+                self.directoriesTable.selectedItems()[0].row()
+            )

--- a/qfieldsync/gui/project_configuration_widget.py
+++ b/qfieldsync/gui/project_configuration_widget.py
@@ -265,7 +265,10 @@ class ProjectConfigurationWidget(WidgetUi, QgsOptionsPageWidget):
         )
 
         self.directoriesConfigurationWidget.reload(
-            {"attachment_dirs": [*self.preferences.value("attachmentDirs")]}
+            {
+                "attachment_dirs": [*self.preferences.value("attachmentDirs")],
+                "data_dirs": [*self.preferences.value("dataDirs")],
+            }
         )
 
         if self.unsupportedLayersList:
@@ -387,6 +390,7 @@ class ProjectConfigurationWidget(WidgetUi, QgsOptionsPageWidget):
 
         configuration = self.directoriesConfigurationWidget.createConfiguration()
         self.preferences.set_value("attachmentDirs", configuration["attachment_dirs"])
+        self.preferences.set_value("dataDirs", configuration["data_dirs"])
 
         self.__project_configuration.map_themes_active_layer = (
             self.mapThemesConfigWidget.createConfiguration()

--- a/qfieldsync/ui/directories_configuration_widget.ui
+++ b/qfieldsync/ui/directories_configuration_widget.ui
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>234</width>
+    <height>146</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string/>
+  </property>
+  <layout class="QHBoxLayout" name="layout">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item>
+    <widget class="QTableWidget" name="directoriesTable"/>
+   </item>
+   <item>
+    <layout class="QVBoxLayout" name="buttonsLayout">
+     <item>
+      <widget class="QToolButton" name="addButton">
+       <property name="toolTip">
+        <string>Add directory</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="removeButton">
+       <property name="toolTip">
+        <string>Remove directory</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="buttonsSpacer">
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>10</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/qfieldsync/ui/project_configuration_widget.ui
+++ b/qfieldsync/ui/project_configuration_widget.ui
@@ -498,10 +498,10 @@
           <item row="4" column="0">
            <widget class="QLabel" name="attachmentDirsLabel">
             <property name="toolTip">
-             <string>A list of directories and files to be treated as attachments. Usually the directories that store images and/or SVG are here.</string>
+             <string>A list of directories and files to be treated as attachments or data. Usually the directories that store images and/or SVG are here.</string>
             </property>
             <property name="text">
-             <string>Attachment directories</string>
+             <string>Directories</string>
             </property>
             <property name="alignment">
              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>

--- a/qfieldsync/ui/project_configuration_widget.ui
+++ b/qfieldsync/ui/project_configuration_widget.ui
@@ -508,9 +508,6 @@
             </property>
            </widget>
           </item>
-          <item row="4" column="1">
-           <widget class="QListWidget" name="attachmentDirsListWidget"/>
-          </item>
           <item row="0" column="0">
            <widget class="QLabel" name="labelDigitizingLogsLayer">
             <property name="text">
@@ -651,7 +648,6 @@
   <tabstop>digitizingLogsLayerComboBox</tabstop>
   <tabstop>onlyOfflineCopyFeaturesInAoi</tabstop>
   <tabstop>maximumImageWidthHeight</tabstop>
-  <tabstop>attachmentDirsListWidget</tabstop>
   <tabstop>layerComboBox</tabstop>
  </tabstops>
  <resources/>


### PR DESCRIPTION
This PR revamps the attachment directories UI found in the project properties dialog, and adds a new "data" directory type. Here's how it looks:

![image](https://github.com/user-attachments/assets/a6c9f444-dcbb-4f76-b9ce-c2f28f9e818e)

Improvements include:
- A clear way to add new directories (i.e., users don't need to guess that double clicking on a blank row is the way you add a row :))
- A clear way to remove directories

The need for a new data directory type emerged since we added on-demand attachment download in QField/QFieldCloud. If attachments are downloaded on demand, our project plugin / symbology / decoration assets placed in a subfolder still needs to be downloaded. That will now happen with data directories.