### PR TITLE
Layers configuration widget cleanup + map themes table widget harmonization

### DIFF
--- a/qfieldsync/gui/layers_config_widget.py
+++ b/qfieldsync/gui/layers_config_widget.py
@@ -24,14 +24,14 @@ import os
 from typing import Callable
 
 from libqfieldsync.layer import LayerSource, SyncAction
-from qgis.core import Qgis, QgsMapLayerModel, QgsProject
+from qgis.core import Qgis, QgsApplication, QgsMapLayerModel, QgsProject
 from qgis.PyQt.QtCore import Qt
 from qgis.PyQt.QtGui import QIcon
 from qgis.PyQt.QtWidgets import (
     QAction,
     QComboBox,
+    QHeaderView,
     QMenu,
-    QPushButton,
     QTableWidgetItem,
     QToolButton,
     QWidget,
@@ -56,6 +56,14 @@ class LayersConfigWidget(QWidget, LayersConfigWidgetUi):
         self.project = project
         self.use_cloud_actions = use_cloud_actions
         self.layer_sources = layer_sources
+
+        self.layersTable.setAlternatingRowColors(True)
+        self.layersTable.verticalHeader().setVisible(False)
+        self.layersTable.setColumnCount(3)
+        self.layersTable.setHorizontalHeaderLabels(
+            [self.tr("Layer"), self.tr("Action"), ""]
+        )
+        self.layersTable.horizontalHeader().setSectionResizeMode(0, QHeaderView.Stretch)
 
         self.multipleToggleButton.setIcon(
             QIcon(
@@ -169,8 +177,11 @@ class LayersConfigWidget(QWidget, LayersConfigWidgetUi):
                 cmb, available_actions, self.get_layer_action(layer_source)
             )
 
-            properties_btn = QPushButton()
-            properties_btn.setText(self.tr("Properties"))
+            properties_btn = QToolButton()
+            properties_btn.setIcon(
+                QgsApplication.getThemeIcon("/propertyicons/settings.svg")
+            )
+            properties_btn.setAutoRaise(True)
             properties_btn.clicked.connect(self.propertiesBtn_clicked(layer_source))
 
             self.layersTable.setCellWidget(count, 1, cmb)

--- a/qfieldsync/gui/mapthemes_config_widget.py
+++ b/qfieldsync/gui/mapthemes_config_widget.py
@@ -34,6 +34,8 @@ class MapThemesConfigWidget(QTableWidget):
 
         self.project = project
 
+        self.setAlternatingRowColors(True)
+        self.verticalHeader().setVisible(False)
         self.setMinimumHeight(200)
         self.setColumnCount(2)
         self.setHorizontalHeaderLabels(

--- a/qfieldsync/ui/layers_config_widget.ui
+++ b/qfieldsync/ui/layers_config_widget.ui
@@ -43,26 +43,7 @@
     </widget>
    </item>
    <item row="1" column="0" colspan="2">
-    <widget class="QTableWidget" name="layersTable">
-     <attribute name="horizontalHeaderStretchLastSection">
-      <bool>true</bool>
-     </attribute>
-     <column>
-      <property name="text">
-       <string>Layer</string>
-      </property>
-     </column>
-     <column>
-      <property name="text">
-       <string>Action</string>
-      </property>
-     </column>
-     <column>
-      <property name="text">
-       <string/>
-      </property>
-     </column>
-    </widget>
+    <widget class="QTableWidget" name="layersTable"/>
    </item>
    <item row="0" column="0" colspan="2">
     <layout class="QHBoxLayout" name="horizontalLayout">


### PR DESCRIPTION
The PR attempts at cleaning up the layers configuration widget to make it less intimidating and feel less crowded.

Before:
![Screenshot From 2025-06-29 09-42-24](https://github.com/user-attachments/assets/f613b267-e0af-41e3-8e74-981f9cee5bc9)

PR:
![Screenshot From 2025-06-29 09-40-29](https://github.com/user-attachments/assets/0363f54e-3b4e-4358-b3be-16e1037038bd)

Improvements include:
- Removing the vertical header (i.e. 1,2,3,4,5,etc.), it just takes up space for no reason since the numbers are not used here
- Getting rid of the repeated [ Properties ] push button in favor of a much smaller tool button with a simple settings gear icon which results in more space for the layer label and a less intimidating view IMHO
- Alternating row colors, because it's a nice, subtle guide

The map themes table widget got the same visual tweaks (no vertical header, alt. row color)