### PR TITLE
ui(basemap): clean up basemap generation parameters

### DIFF
--- a/qfieldsync/gui/project_configuration_widget.py
+++ b/qfieldsync/gui/project_configuration_widget.py
@@ -297,7 +297,11 @@ class ProjectConfigurationWidget(WidgetUi, QgsPanelWidget):
             self.__project_configuration.maximum_image_width_height
         )
 
-        self.tileSize.setValue(self.__project_configuration.base_map_tile_size)
+        tiles_size_index = self.baseMapTileSizeComboBox.findText(
+            str(self.__project_configuration.base_map_tile_size)
+        )
+        if tiles_size_index >= 0:
+            self.baseMapTileSizeComboBox.setCurrentIndex(tiles_size_index)
 
         self.baseMapTilesMinZoomLevelSpinBox.setValue(
             self.__project_configuration.base_map_tiles_min_zoom_level
@@ -409,7 +413,9 @@ class ProjectConfigurationWidget(WidgetUi, QgsPanelWidget):
         except AttributeError:
             pass
 
-        self.__project_configuration.base_map_tile_size = self.tileSize.value()
+        self.__project_configuration.base_map_tile_size = int(
+            self.baseMapTileSizeComboBox.currentText()
+        )
 
         self.__project_configuration.base_map_tiles_min_zoom_level = (
             self.baseMapTilesMinZoomLevelSpinBox.value()

--- a/qfieldsync/ui/project_configuration_widget.ui
+++ b/qfieldsync/ui/project_configuration_widget.ui
@@ -68,16 +68,16 @@
           <attribute name="title">
            <string>QFieldCloud Packaging</string>
           </attribute>
-          <layout class="QGridLayout" name="cloudExportLayout" columnstretch="1,0">
+          <layout class="QGridLayout" name="cloudExportLayout" columnstretch="1,0,0">
            <item row="0" column="0" colspan="2">
             <widget class="QLabel" name="cloudExportLabel">
-             <property name="text">
-              <string>The map layers settings are used by QFieldCloud when packaging your project for QField. To allow editing while offline and synchronize changes to features  back to QFieldCloud, set the action to ‘offline editing’.</string>
-             </property>
              <property name="font">
               <font>
                <italic>true</italic>
               </font>
+             </property>
+             <property name="text">
+              <string>The map layers settings are used by QFieldCloud when packaging your project for QField. To allow editing while offline and synchronize changes to features  back to QFieldCloud, set the action to ‘offline editing’.</string>
              </property>
              <property name="wordWrap">
               <bool>true</bool>
@@ -185,13 +185,13 @@
           <layout class="QGridLayout" name="cableExportLayout">
            <item row="0" column="0">
             <widget class="QLabel" name="cableExportLabel">
-             <property name="text">
-              <string>The map layers settings are used when packaging your project intended for manually copying the generated project onto your devices manually via USB cable or other file sharing  mechanisms.</string>
-             </property>
              <property name="font">
               <font>
                <italic>true</italic>
               </font>
+             </property>
+             <property name="text">
+              <string>The map layers settings are used when packaging your project intended for manually copying the generated project onto your devices manually via USB cable or other file sharing  mechanisms.</string>
              </property>
              <property name="wordWrap">
               <bool>true</bool>
@@ -207,13 +207,13 @@
           <layout class="QGridLayout" name="attachmentsDirectoriesLayout" columnstretch="1,0">
            <item row="0" column="0" colspan="2">
             <widget class="QLabel" name="attachmentsDirectoriesLabel">
-             <property name="text">
-              <string>When packaging a project, attachment and data directories are copied into the QField project. &lt;b&gt;Attachment&lt;/b&gt; directories should be tied to feature form attachment editor widgets while &lt;b&gt;data&lt;/b&gt; directories are used to package assets such as print layout,decoration images or QField project plugin files.</string>
-             </property>
              <property name="font">
               <font>
                <italic>true</italic>
               </font>
+             </property>
+             <property name="text">
+              <string>When packaging a project, attachment and data directories are copied into the QField project. &lt;b&gt;Attachment&lt;/b&gt; directories should be tied to feature form attachment editor widgets while &lt;b&gt;data&lt;/b&gt; directories are used to package assets such as print layout,decoration images or QField project plugin files.</string>
              </property>
              <property name="wordWrap">
               <bool>true</bool>
@@ -284,13 +284,13 @@
          <layout class="QGridLayout" name="areaOfInterestBaseMapLayout">
           <item row="0" column="0" colspan="2">
            <widget class="QLabel" name="areaOfInterestLabel">
-            <property name="text">
-             <string>The area of interest defines the part of a project that should be made available for offline use.</string>
-            </property>
             <property name="font">
              <font>
               <italic>true</italic>
              </font>
+            </property>
+            <property name="text">
+             <string>The area of interest defines the part of a project that should be made available for offline use.</string>
             </property>
             <property name="wordWrap">
              <bool>true</bool>
@@ -310,8 +310,11 @@
           <item row="2" column="0" colspan="2">
            <widget class="QCheckBox" name="onlyOfflineCopyFeaturesInAoi">
             <property name="text">
-             <string>When offlining layers, only copy features intersecting the area of interest</string>
+             <string>Map theme</string>
             </property>
+            <attribute name="buttonGroup">
+             <string notr="true">buttonGroup</string>
+            </attribute>
            </widget>
           </item>
           <item row="3" column="0" colspan="2">
@@ -322,22 +325,22 @@
             <property name="checkable">
              <bool>true</bool>
             </property>
-            <property name="saveCollapsedState">
-             <bool>true</bool>
-            </property>
             <property name="collapsed">
+             <bool>false</bool>
+            </property>
+            <property name="saveCollapsedState">
              <bool>true</bool>
             </property>
             <layout class="QGridLayout" name="gridLayout">
              <item row="0" column="0" colspan="2">
               <widget class="QLabel" name="baseMapLabel">
-               <property name="text">
-                <string>A raster base map can be generated when triggering a cable packaging process. The generated raster will cover the project’s full extent or the customized area of interest defined above.</string>
-               </property>
                <property name="font">
                 <font>
                  <italic>true</italic>
                 </font>
+               </property>
+               <property name="text">
+                <string>A raster base map can be generated when triggering a cable packaging process. The generated raster will cover the project’s full extent or the customized area of interest defined above.</string>
                </property>
                <property name="wordWrap">
                 <bool>true</bool>
@@ -364,7 +367,7 @@
               </widget>
              </item>
              <item row="5" column="0">
-              <widget class="QLabel" name="tileSizeLabel">
+              <widget class="QLabel" name="baseMapTileSizeLabel">
                <property name="text">
                 <string>Tile size</string>
                </property>
@@ -452,31 +455,6 @@
                </property>
               </widget>
              </item>
-             <item row="5" column="1">
-              <widget class="QgsSpinBox" name="tileSize">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="toolTip">
-                <string>Rendering will happen in tiles. This number determines the width and height (in pixels) that will be rendered per tile.</string>
-               </property>
-               <property name="suffix">
-                <string> px</string>
-               </property>
-               <property name="minimum">
-                <number>1</number>
-               </property>
-               <property name="maximum">
-                <number>10240</number>
-               </property>
-               <property name="value">
-                <number>1024</number>
-               </property>
-              </widget>
-             </item>
              <item row="9" column="0">
               <widget class="QLabel" name="baseMapTilesMaxZoomLevelLabel">
                <property name="text">
@@ -485,6 +463,25 @@
                <property name="alignment">
                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                </property>
+              </widget>
+             </item>
+             <item row="5" column="1">
+              <widget class="QComboBox" name="baseMapTileSizeComboBox">
+               <item>
+                <property name="text">
+                 <string>256</string>
+                </property>
+               </item>
+               <item>
+                <property name="text">
+                 <string>512</string>
+                </property>
+               </item>
+               <item>
+                <property name="text">
+                 <string>1024</string>
+                </property>
+               </item>
               </widget>
              </item>
             </layout>
@@ -502,7 +499,7 @@
           <bool>true</bool>
          </property>
          <property name="collapsed">
-          <bool>true</bool>
+          <bool>false</bool>
          </property>
          <property name="saveCollapsedState">
           <bool>true</bool>
@@ -510,13 +507,13 @@
          <layout class="QGridLayout" name="geofencingGridLayout" columnstretch="1,3">
           <item row="0" column="0" colspan="2">
            <widget class="QLabel" name="geofencingIntroductionLabel">
-            <property name="text">
-             <string>QField provides real-time feedback to users when their device position falls within or outside of areas defined by a selected polygon layer.</string>
-            </property>
             <property name="font">
              <font>
               <italic>true</italic>
              </font>
+            </property>
+            <property name="text">
+             <string>QField provides real-time feedback to users when their device position falls within or outside of areas defined by a selected polygon layer.</string>
             </property>
             <property name="wordWrap">
              <bool>true</bool>
@@ -559,7 +556,7 @@
           <string>Advanced Settings</string>
          </property>
          <property name="collapsed">
-          <bool>true</bool>
+          <bool>false</bool>
          </property>
          <property name="saveCollapsedState">
           <bool>true</bool>
@@ -625,11 +622,6 @@
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsDoubleSpinBox</class>
-   <extends>QDoubleSpinBox</extends>
-   <header>qgsdoublespinbox.h</header>
-  </customwidget>
-  <customwidget>
    <class>QgsMapLayerComboBox</class>
    <extends>QComboBox</extends>
    <header>qgsmaplayercombobox.h</header>
@@ -656,7 +648,6 @@
   <tabstop>mapThemeRadioButton</tabstop>
   <tabstop>layerComboBox</tabstop>
   <tabstop>mapThemeComboBox</tabstop>
-  <tabstop>tileSize</tabstop>
   <tabstop>baseMapTilesMinZoomLevelSpinBox</tabstop>
   <tabstop>baseMapTilesMaxZoomLevelSpinBox</tabstop>
   <tabstop>geofencingGroupBox</tabstop>


### PR DESCRIPTION
This PR intends to make the basemap generation parameters less confusing.

| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/dce435a8-37d4-4674-a3f1-d3a1436ad85c) | ![image](https://github.com/user-attachments/assets/a1d1a1b4-48bd-43f4-a4dc-4b4fd1ceb8d9) |

3 possible values for the basemap tile size parameter, which is now picked within a ComboBox : 256, 512 and 1024.

See the sister-PR on libqfieldsync: https://github.com/opengisch/libqfieldsync/pull/117