### PR TITLE
Project properties restructuring and UX improvements

### DIFF
--- a/qfieldsync/gui/map_layer_config_widget.py
+++ b/qfieldsync/gui/map_layer_config_widget.py
@@ -25,7 +25,6 @@ import os
 from libqfieldsync.layer import LayerSource
 from qgis.core import QgsMapLayer, QgsProject, QgsProperty, QgsPropertyDefinition
 from qgis.gui import QgsMapLayerConfigWidget, QgsMapLayerConfigWidgetFactory, QgsSpinBox
-from qgis.PyQt.QtWidgets import QLabel
 from qgis.PyQt.uic import loadUiType
 
 from qfieldsync.core.message_bus import message_bus
@@ -206,25 +205,16 @@ class MapLayerConfigWidget(QgsMapLayerConfigWidget, WidgetUi):
             self.valueMapButtonInterfaceSpinBox.setVisible(True)
 
             # append the attachment naming table to the layout
-            self.attachmentsRelationsLayout.insertRow(
-                -1, self.tr("Attachment\nnaming"), self.attachmentNamingTable
+            self.attachmentsRelationsLayout.addWidget(
+                self.attachmentNamingTable, 2, 0, 1, 2
             )
-            tip = QLabel(
-                self.tr(
-                    "In your expressions, use {filename} and {extension} tags to refer to attachment filenames and extensions."
-                )
-            )
-            tip.setWordWrap(True)
-            self.attachmentsRelationsLayout.insertRow(-1, "", tip)
             self.attachmentNamingTable.setEnabled(
                 self.attachmentNamingTable.rowCount() > 0
             )
 
             # append the relationship configuration table to the layout
-            self.attachmentsRelationsLayout.insertRow(
-                -1,
-                self.tr("Relationship\nconfiguration"),
-                self.relationshipConfigurationTable,
+            self.attachmentsRelationsLayout.addWidget(
+                self.relationshipConfigurationTable, 4, 0, 1, 2
             )
             self.relationshipConfigurationTable.setEnabled(
                 self.relationshipConfigurationTable.rowCount() > 0

--- a/qfieldsync/gui/map_layer_config_widget.py
+++ b/qfieldsync/gui/map_layer_config_widget.py
@@ -205,23 +205,32 @@ class MapLayerConfigWidget(QgsMapLayerConfigWidget, WidgetUi):
             self.valueMapButtonInterfaceSpinBox.setVisible(True)
 
             # append the attachment naming table to the layout
-            self.attachmentsRelationsLayout.addWidget(
-                self.attachmentNamingTable, 2, 0, 1, 2
+            self.attachmentsGroupBox.layout().addWidget(
+                self.attachmentNamingTable, 1, 0
             )
             self.attachmentNamingTable.setEnabled(
                 self.attachmentNamingTable.rowCount() > 0
             )
+            self.attachmentsGroupBox.setCollapsed(
+                self.attachmentNamingTable.rowCount() == 0
+            )
 
             # append the relationship configuration table to the layout
-            self.attachmentsRelationsLayout.addWidget(
-                self.relationshipConfigurationTable, 4, 0, 1, 2
+            self.relationsGroupBox.layout().addWidget(
+                self.relationshipConfigurationTable, 1, 0
             )
             self.relationshipConfigurationTable.setEnabled(
                 self.relationshipConfigurationTable.rowCount() > 0
             )
+            self.relationsGroupBox.setCollapsed(
+                self.relationshipConfigurationTable.rowCount() == 0
+            )
 
             self.trackingSessionGroupBox.setChecked(
                 self.layer_source.tracking_session_active
+            )
+            self.trackingSessionGroupBox.setCollapsed(
+                not self.layer_source.tracking_session_active
             )
             self.timeRequirementCheckBox.setChecked(
                 self.layer_source.tracking_time_requirement_active

--- a/qfieldsync/gui/project_configuration_widget.py
+++ b/qfieldsync/gui/project_configuration_widget.py
@@ -184,6 +184,13 @@ class ProjectConfigurationWidget(WidgetUi, QgsOptionsPageWidget):
         else:
             self.mapThemeRadioButton.setChecked(True)
 
+        self.baseMapLayerLabel.setVisible(self.singleLayerRadioButton.isChecked())
+        self.layerComboBox.setVisible(self.singleLayerRadioButton.isChecked())
+        self.baseMapMapThemeLabel.setVisible(
+            not self.singleLayerRadioButton.isChecked()
+        )
+        self.mapThemeComboBox.setVisible(not self.singleLayerRadioButton.isChecked())
+
         self.mapThemeComboBox.setCurrentIndex(
             self.mapThemeComboBox.findText(self.__project_configuration.base_map_theme)
         )
@@ -407,7 +414,9 @@ class ProjectConfigurationWidget(WidgetUi, QgsOptionsPageWidget):
             layer_source.cloud_action = cmb.itemData(cmb.currentIndex())
 
     def baseMapTypeChanged(self):
-        if self.singleLayerRadioButton.isChecked():
-            self.baseMapTypeStack.setCurrentWidget(self.singleLayerPage)
-        else:
-            self.baseMapTypeStack.setCurrentWidget(self.mapThemePage)
+        self.baseMapLayerLabel.setVisible(self.singleLayerRadioButton.isChecked())
+        self.layerComboBox.setVisible(self.singleLayerRadioButton.isChecked())
+        self.baseMapMapThemeLabel.setVisible(
+            not self.singleLayerRadioButton.isChecked()
+        )
+        self.mapThemeComboBox.setVisible(not self.singleLayerRadioButton.isChecked())

--- a/qfieldsync/gui/project_configuration_widget.py
+++ b/qfieldsync/gui/project_configuration_widget.py
@@ -30,8 +30,7 @@ from qgis.core import (
 )
 from qgis.gui import QgsExtentWidget, QgsOptionsPageWidget, QgsSpinBox
 from qgis.PyQt.QtCore import QEvent, QObject, Qt
-from qgis.PyQt.QtGui import QIcon, QKeySequence
-from qgis.PyQt.QtWidgets import QLabel
+from qgis.PyQt.QtGui import QKeySequence
 from qgis.PyQt.uic import loadUiType
 from qgis.utils import iface
 
@@ -136,14 +135,6 @@ class ProjectConfigurationWidget(WidgetUi, QgsOptionsPageWidget):
         """
         self.unsupportedLayersList = list()
 
-        infoLabel = QLabel()
-        infoLabel.setPixmap(QIcon.fromTheme("info").pixmap(16, 16))
-        infoLabel.setToolTip(
-            self.tr(
-                "To improve the overall user experience with QFieldCloud, it is recommended that all vector layers use UUID as primary key."
-            )
-        )
-
         layer_sources = [
             LayerSource(layer) for layer in QgsProject.instance().mapLayers().values()
         ]
@@ -154,7 +145,6 @@ class ProjectConfigurationWidget(WidgetUi, QgsOptionsPageWidget):
             self.project, False, layer_sources
         )
         self.cloudAdvancedSettings.layout().addWidget(self.cloudLayersConfigWidget)
-        self.cloudExportTab.layout().addWidget(infoLabel, 0, 2)
         self.cableExportTab.layout().addWidget(self.cableLayersConfigWidget)
 
         # Map Themes configuration widgets

--- a/qfieldsync/gui/project_configuration_widget.py
+++ b/qfieldsync/gui/project_configuration_widget.py
@@ -31,6 +31,7 @@ from qgis.core import (
 from qgis.gui import QgsExtentWidget, QgsOptionsPageWidget, QgsSpinBox
 from qgis.PyQt.QtCore import QEvent, QObject, Qt
 from qgis.PyQt.QtGui import QKeySequence
+from qgis.PyQt.QtWidgets import QLineEdit
 from qgis.PyQt.uic import loadUiType
 from qgis.utils import iface
 
@@ -70,10 +71,17 @@ class ProjectConfigurationWidget(WidgetUi, QgsOptionsPageWidget):
         self.project = QgsProject.instance()
         self.preferences = Preferences()
         self.__project_configuration = ProjectConfiguration(self.project)
+
         self.areaOfInterestExtentWidget = QgsExtentWidget(self)
         self.areaOfInterestExtentWidget.setToolTip(
-            self.tr("Leave null to use the current project zoom extent.")
+            self.tr("Leave empty to use the full project extent")
         )
+        # A bit of a hack to deliver a nice instructive placeholder text to users
+        line_edits = self.areaOfInterestExtentWidget.findChildren(QLineEdit)
+        for line_edit in line_edits:
+            line_edit.setPlaceholderText(
+                self.tr("Leave empty to use the full project extent")
+            )
         self.areaOfInterestExtentWidget.setNullValueAllowed(True)
 
         if iface:

--- a/qfieldsync/gui/project_configuration_widget.py
+++ b/qfieldsync/gui/project_configuration_widget.py
@@ -96,7 +96,7 @@ class ProjectConfigurationWidget(WidgetUi, QgsOptionsPageWidget):
                 self.areaOfInterestExtentWidget.outputCrs(),
             )
 
-        self.advancedSettingsGroupBox.layout().addWidget(
+        self.areaOfInterestBaseMapLayout.layout().addWidget(
             self.areaOfInterestExtentWidget, 1, 1
         )
 
@@ -111,8 +111,8 @@ class ProjectConfigurationWidget(WidgetUi, QgsOptionsPageWidget):
         self.forceAutoPush.clicked.connect(self.onForceAutoPushClicked)
 
         self.directoriesConfigurationWidget = DirectoriesConfigurationWidget(self)
-        self.advancedSettingsGroupBox.layout().addWidget(
-            self.directoriesConfigurationWidget, 4, 1
+        self.attachmentsDirectoriesTab.layout().addWidget(
+            self.directoriesConfigurationWidget, 1, 0, 1, 2
         )
 
         self.geofencingBehaviorComboBox.addItem(

--- a/qfieldsync/ui/map_layer_config_widget.ui
+++ b/qfieldsync/ui/map_layer_config_widget.ui
@@ -214,7 +214,7 @@
       <item row="3" column ="0" colspan="2">
        <widget class="QLabel" name="relationsTipLabel">
         <property name="text">
-         <string>Use the table below to configure relation editor widgets behavior. Note that to improve the overall user experience with QFieldCloud, it is recommended that all vector layers use UUID as primary keys.</string>
+         <string>Use the table below to configure relation editor widgets behavior. Note that to improve the overall user experience with QFieldCloud, it is recommended that all vector layers use expression-generated default UUID values as primary keys.</string>
         </property>
         <property name="wordWrap">
          <bool>true</bool>

--- a/qfieldsync/ui/map_layer_config_widget.ui
+++ b/qfieldsync/ui/map_layer_config_widget.ui
@@ -31,16 +31,16 @@
        </widget>
       </item>
       <item row="0" column="0">
-       <widget class="QLabel" name="cloudLayerActionLabel">
+       <widget class="QLabel" name="cloudPackagingActionLabel">
         <property name="text">
-         <string>Cloud layer action</string>
+         <string>QFieldCloud packaging action</string>
         </property>
        </widget>
       </item>
       <item row="1" column="0">
-       <widget class="QLabel" name="cableLayerActionLabel">
+       <widget class="QLabel" name="cablePackagingActionLabel">
         <property name="text">
-         <string>Cable layer action</string>
+         <string>Cable packaging action</string>
         </property>
        </widget>
       </item>
@@ -147,7 +147,7 @@
      <property name="title">
       <string>Feature Form, Attachments and Relationships Settings</string>
      </property>
-     <layout class="QFormLayout" name="attachmentsRelationsLayout">
+     <layout class="QGridLayout" name="attachmentsRelationsLayout">
       <item row="0" column="0" colspan="2">
        <layout class="QHBoxLayout" name="valueMapButtonInterfaceLayout">
         <item>
@@ -196,6 +196,36 @@
         </item>
        </layout>
       </item>
+      <item row="1" column ="0" colspan="2">
+       <widget class="QLabel" name="attachmentsTipLabel">
+        <property name="text">
+         <string>Use the table below to configure the relative filename of your attachments editor widgets. In your expressions, use {filename} and {extension} tags to refer to the default filenames and extensions.</string>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+        <property name="font">
+         <font>
+          <italic>true</italic>
+         </font>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column ="0" colspan="2">
+       <widget class="QLabel" name="relationsTipLabel">
+        <property name="text">
+         <string>Use the table below to configure relation editor widgets behavior. Note that to improve the overall user experience with QFieldCloud, it is recommended that all vector layers use UUID as primary keys.</string>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+        <property name="font">
+         <font>
+          <italic>true</italic>
+         </font>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>
@@ -217,10 +247,15 @@
        <item>
         <widget class="QLabel" name="trackingSessionLabel">
          <property name="text">
-          <string>When enabled, QField will automatically start a tracking session upon successfully loading the project.</string>
+          <string>When enabled, QField will automatically start a tracking session upon successfully loading the project using the settings provided below.</string>
          </property>
          <property name="wordWrap">
           <bool>true</bool>
+         </property>
+         <property name="font">
+          <font>
+           <italic>true</italic>
+          </font>
          </property>
         </widget>
        </item>

--- a/qfieldsync/ui/map_layer_config_widget.ui
+++ b/qfieldsync/ui/map_layer_config_widget.ui
@@ -143,12 +143,12 @@
     </widget>
    </item>
    <item>
-    <widget class="QGroupBox" name="attachmentsRelationsGroupBox">
+    <widget class="QGroupBox" name="featureFormGroupBox">
      <property name="title">
-      <string>Feature Form, Attachments and Relationships Settings</string>
+      <string>Feature Form Settings</string>
      </property>
-     <layout class="QGridLayout" name="attachmentsRelationsLayout">
-      <item row="0" column="0" colspan="2">
+     <layout class="QGridLayout" name="featureFormLayout">
+      <item row="0" column="0">
        <layout class="QHBoxLayout" name="valueMapButtonInterfaceLayout">
         <item>
          <widget class="QLabel" name="valueMapButtonInterfaceLabel">
@@ -196,7 +196,19 @@
         </item>
        </layout>
       </item>
-      <item row="1" column ="0" colspan="2">
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QgsCollapsibleGroupBox" name="attachmentsGroupBox">
+     <property name="title">
+      <string>Attachments Settings</string>
+     </property>
+     <property name="saveCollapsedState">
+      <bool>false</bool>
+     </property>
+     <layout class="QGridLayout" name="attachmentsLayout">
+      <item row="0" column ="0">
        <widget class="QLabel" name="attachmentsTipLabel">
         <property name="text">
          <string>Use the table below to configure the relative filename of your attachments editor widgets. In your expressions, use {filename} and {extension} tags to refer to the default filenames and extensions.</string>
@@ -211,10 +223,22 @@
         </property>
        </widget>
       </item>
-      <item row="3" column ="0" colspan="2">
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QgsCollapsibleGroupBox" name="relationsGroupBox">
+     <property name="title">
+      <string>Relationships Settings</string>
+     </property>
+     <property name="saveCollapsedState">
+      <bool>false</bool>
+     </property>
+     <layout class="QGridLayout" name="relationsLayout">
+      <item row="0" column ="0">
        <widget class="QLabel" name="relationsTipLabel">
         <property name="text">
-         <string>Use the table below to configure relation editor widgets behavior. Note that to improve the overall user experience with QFieldCloud, it is recommended that all vector layers use expression-generated default UUID values as primary keys.</string>
+         <string>Use the table below to configure relation editor widgets behavior. To improve the overall user experience with QFieldCloud, it is recommended that all vector layers use expression-generated default UUID values as primary keys.</string>
         </property>
         <property name="wordWrap">
          <bool>true</bool>
@@ -240,8 +264,8 @@
      <property name="checked">
       <bool>false</bool>
      </property>
-     <property name="collapsed" stdset="0">
-      <bool>true</bool>
+     <property name="saveCollapsedState">
+      <bool>false</bool>
      </property>
      <layout class="QVBoxLayout" name="trackingSessionLayout">
        <item>
@@ -421,6 +445,22 @@
        </item>
      </layout>
     </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::MinimumExpanding</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>0</height>
+      </size>
+     </property>
+    </spacer>
    </item>
   </layout>
  </widget>

--- a/qfieldsync/ui/map_layer_config_widget.ui
+++ b/qfieldsync/ui/map_layer_config_widget.ui
@@ -211,7 +211,7 @@
       <item row="0" column ="0">
        <widget class="QLabel" name="attachmentsTipLabel">
         <property name="text">
-         <string>Use the table below to configure the relative filename of your attachments editor widgets. In your expressions, use {filename} and {extension} tags to refer to the default filenames and extensions.</string>
+         <string>Configure the relative filename of your attachments editor widgets. In your expressions, use {filename} and {extension} tags to refer to the default filenames and extensions.</string>
         </property>
         <property name="wordWrap">
          <bool>true</bool>
@@ -238,7 +238,7 @@
       <item row="0" column ="0">
        <widget class="QLabel" name="relationsTipLabel">
         <property name="text">
-         <string>Use the table below to configure relation editor widgets behavior. To improve the overall user experience with QFieldCloud, it is recommended that all vector layers use expression-generated default UUID values as primary keys.</string>
+         <string>Configure relation editor widgets behavior. To improve the overall user experience with QFieldCloud, it is recommended that all vector layers use expression-generated &lt;b&gt;UUIDs for primary keys&lt;/b&gt;.</string>
         </property>
         <property name="wordWrap">
          <bool>true</bool>

--- a/qfieldsync/ui/project_configuration_widget.ui
+++ b/qfieldsync/ui/project_configuration_widget.ui
@@ -105,7 +105,7 @@
              <property name="collapsed">
               <bool>true</bool>
              </property>
-             <property name="saveCheckedState">
+             <property name="saveCollapsedState">
               <bool>true</bool>
              </property>
              <layout class="QVBoxLayout" name="verticalLayout_4"/>
@@ -266,6 +266,9 @@
         <widget class="QgsCollapsibleGroupBox" name="areaOfInterestBaseMapGroupBox">
          <property name="title">
           <string>Area of Interest and Base Map</string>
+         </property>
+         <property name="collapsed">
+          <bool>true</bool>
          </property>
          <layout class="QGridLayout" name="areaOfInterestBaseMapLayout">
           <item row="0" column="0" colspan="2">
@@ -569,6 +572,12 @@
          <property name="checkable">
           <bool>true</bool>
          </property>
+         <property name="collapsed">
+          <bool>true</bool>
+         </property>
+         <property name="saveCollapsedState">
+          <bool>true</bool>
+         </property>
          <layout class="QGridLayout" name="geofencingGridLayout" columnstretch="1,3">
           <item row="0" column="0" colspan="2">
            <widget class="QLabel" name="geofencingIntroductionLabel">
@@ -620,11 +629,8 @@
          <property name="title">
           <string>Advanced Settings</string>
          </property>
-         <property name="checkable">
-          <bool>false</bool>
-         </property>
          <property name="collapsed">
-          <bool>false</bool>
+          <bool>true</bool>
          </property>
          <property name="saveCollapsedState">
           <bool>true</bool>

--- a/qfieldsync/ui/project_configuration_widget.ui
+++ b/qfieldsync/ui/project_configuration_widget.ui
@@ -227,7 +227,7 @@
             <widget class="QgsSpinBox" name="maximumImageWidthHeight">
              <property name="sizePolicy">
               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-               <horstretch>0</horstretch>
+               <horstretch>1</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>

--- a/qfieldsync/ui/project_configuration_widget.ui
+++ b/qfieldsync/ui/project_configuration_widget.ui
@@ -318,7 +318,7 @@
           <item row="4" column="0" colspan="2">
            <widget class="QgsCollapsibleGroupBox" name="createBaseMapGroupBox">
             <property name="title">
-             <string>Generate base map</string>
+             <string>Base Map</string>
             </property>
             <property name="checkable">
              <bool>true</bool>

--- a/qfieldsync/ui/project_configuration_widget.ui
+++ b/qfieldsync/ui/project_configuration_widget.ui
@@ -75,7 +75,7 @@
            <item row="0" column="0" colspan="2">
             <widget class="QLabel" name="cloudExportLabel">
              <property name="text">
-              <string>The map layers settings below are used by QFieldCloud when packaging your project for QField to download and synchronize. To push feature editing and addition changes of vector layers back to QFieldCloud, insure that their action is set to ‘offline editing’.</string>
+              <string>The map layers settings are used by QFieldCloud when packaging your project for QField. To allow editing while offline and synchronize changes to features  back to QFieldCloud, set the action to ‘offline editing’.</string>
              </property>
              <property name="font">
               <font>
@@ -189,7 +189,7 @@
            <item row="0" column="0">
             <widget class="QLabel" name="cableExportLabel">
              <property name="text">
-              <string>The map layers settings below are used when packaging your project intented for manually copying the generated project onto your devices manually via USB cable of other import mechanisms supported by devices' operating system.</string>
+              <string>The map layers settings are used when packaging your project intended for manually copying the generated project onto your devices manually via USB cable or other file sharing  mechanisms.</string>
              </property>
              <property name="font">
               <font>
@@ -211,7 +211,7 @@
            <item row="0" column="0" colspan="2">
             <widget class="QLabel" name="attachmentsDirectoriesLabel">
              <property name="text">
-              <string>When packaging a project, attachment and data directories are used to recursively copy files into the generated output. Attachment diretories should be tied to feature forms' attachment editor widgets while data directories are used to package assets such as print layout and decoration images and QField project plugin files.</string>
+              <string>When packaging a project, attachment and data directories are copied into the QField project. &lt;b&gt;Attachment&lt;/b&gt; directories should be tied to feature form attachment editor widgets while &lt;b&gt;data&lt;/b&gt; directories are used to package assets such as print layout,decoration images or QField project plugin files.</string>
              </property>
              <property name="font">
               <font>
@@ -274,7 +274,7 @@
           <item row="0" column="0" colspan="2">
            <widget class="QLabel" name="areaOfInterestLabel">
             <property name="text">
-             <string>By default, the project’s full extent will be treated as the area of interest and can be customized using the extent widget below. The area of interest can be used to filter features from vector layers above where their packaging action is set to ‘offline editing’.</string>
+             <string>The area of interest defines the part of a project that should be made available for offline use. By default the full project extent is used unless a custom area of interest extent is provided.</string>
             </property>
             <property name="font">
              <font>
@@ -304,21 +304,6 @@
            </widget>
           </item>
           <item row="3" column="0" colspan="2">
-           <widget class="QLabel" name="baseMapLabel">
-            <property name="text">
-             <string>A raster base map can be generated upon triggering a cable packaging process. The generated raster will cover the project’s full extent or the customized area of interest defined above.</string>
-            </property>
-            <property name="font">
-             <font>
-              <italic>true</italic>
-             </font>
-            </property>
-            <property name="wordWrap">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="0" colspan="2">
            <widget class="QgsCollapsibleGroupBox" name="createBaseMapGroupBox">
             <property name="title">
              <string>Base Map</string>
@@ -333,17 +318,22 @@
              <bool>true</bool>
             </property>
             <layout class="QGridLayout" name="gridLayout">
-             <item row="0" column="1">
-              <widget class="QRadioButton" name="mapThemeRadioButton">
+             <item row="0" column="0" colspan="2">
+              <widget class="QLabel" name="baseMapLabel">
                <property name="text">
-                <string>Map theme</string>
+                <string>A raster base map can be generated when triggering a cable packaging process. The generated raster will cover the project’s full extent or the customized area of interest defined above.</string>
                </property>
-               <attribute name="buttonGroup">
-                <string notr="true">buttonGroup</string>
-               </attribute>
+               <property name="font">
+                <font>
+                 <italic>true</italic>
+                </font>
+               </property>
+               <property name="wordWrap">
+                <bool>true</bool>
+               </property>
               </widget>
              </item>
-             <item row="6" column="1">
+             <item row="9" column="1">
               <widget class="QgsSpinBox" name="baseMapTilesMaxZoomLevelSpinBox">
                <property name="sizePolicy">
                 <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -362,7 +352,7 @@
                </property>
               </widget>
              </item>
-             <item row="2" column="0">
+             <item row="5" column="0">
               <widget class="QLabel" name="tileSizeLabel">
                <property name="text">
                 <string>Tile size</string>
@@ -372,7 +362,7 @@
                </property>
               </widget>
              </item>
-             <item row="4" column="1">
+             <item row="7" column="1">
               <widget class="QgsSpinBox" name="baseMapTilesMinZoomLevelSpinBox">
                <property name="sizePolicy">
                 <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -391,119 +381,57 @@
                </property>
               </widget>
              </item>
-             <item row="0" column="0">
-              <widget class="QRadioButton" name="singleLayerRadioButton">
+             <item row="1" column="1">
+              <layout class="QHBoxLayout" name="horizontalLayout_1">
+               <item>
+                <widget class="QRadioButton" name="singleLayerRadioButton">
+                 <property name="text">
+                  <string>Single layer</string>
+                 </property>
+                 <attribute name="buttonGroup">
+                  <string notr="true">buttonGroup</string>
+                 </attribute>
+                </widget>
+               </item>
+               <item>
+                <widget class="QRadioButton" name="mapThemeRadioButton">
+                 <property name="text">
+                  <string>Map theme</string>
+                 </property>
+                 <attribute name="buttonGroup">
+                  <string notr="true">buttonGroup</string>
+                 </attribute>
+                </widget>
+               </item>
+              </layout>
+             </item>
+             <item row="2" column="0">
+              <widget class="QLabel" name="baseMapMapThemeLabel">
                <property name="text">
-                <string>Single layer</string>
+                <string>Map Theme</string>
                </property>
-               <attribute name="buttonGroup">
-                <string notr="true">buttonGroup</string>
-               </attribute>
+               <property name="alignment">
+                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+               </property>
+              </widget>
+             </item>
+             <item row="2" column="1">
+              <widget class="QComboBox" name="mapThemeComboBox"/>
+             </item>
+             <item row="3" column="0">
+              <widget class="QLabel" name="baseMapLayerLabel">
+               <property name="text">
+                <string>Layer</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+               </property>
               </widget>
              </item>
              <item row="3" column="1">
-              <widget class="QgsDoubleSpinBox" name="mapUnitsPerPixel">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="toolTip">
-                <string>This determines the spatial resolution of the resulting map image. It depends on the CRS of the map canvas. For map units in [m], a value of 1 means each pixel covers an area of 1x1 m, a value of 1000 means 1 pixel per square kilometer.</string>
-               </property>
-               <property name="suffix">
-                <string> mupp</string>
-               </property>
-               <property name="value">
-                <double>99.989999999999995</double>
-               </property>
-              </widget>
+              <widget class="QgsMapLayerComboBox" name="layerComboBox"/>
              </item>
-             <item row="1" column="0" colspan="2">
-              <widget class="QStackedWidget" name="baseMapTypeStack">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="inputMethodHints">
-                <set>Qt::ImhDialableCharactersOnly</set>
-               </property>
-               <widget class="QWidget" name="mapThemePage">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <layout class="QGridLayout" name="gridLayout_4" columnstretch="1,3">
-                 <property name="leftMargin">
-                  <number>0</number>
-                 </property>
-                 <property name="topMargin">
-                  <number>0</number>
-                 </property>
-                 <property name="rightMargin">
-                  <number>0</number>
-                 </property>
-                 <property name="bottomMargin">
-                  <number>0</number>
-                 </property>
-                 <item row="0" column="0">
-                  <widget class="QLabel" name="baseMapMapThemeLabel">
-                   <property name="text">
-                    <string>Map Theme</string>
-                   </property>
-                   <property name="alignment">
-                    <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="0" column="1">
-                  <widget class="QComboBox" name="mapThemeComboBox"/>
-                 </item>
-                </layout>
-               </widget>
-               <widget class="QWidget" name="singleLayerPage">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <layout class="QGridLayout" name="gridLayout_5" columnstretch="1,3">
-                 <property name="leftMargin">
-                  <number>0</number>
-                 </property>
-                 <property name="topMargin">
-                  <number>0</number>
-                 </property>
-                 <property name="rightMargin">
-                  <number>0</number>
-                 </property>
-                 <property name="bottomMargin">
-                  <number>0</number>
-                 </property>
-                 <item row="0" column="0">
-                  <widget class="QLabel" name="baseMapLayerLabel">
-                   <property name="text">
-                    <string>Layer</string>
-                   </property>
-                   <property name="alignment">
-                    <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="0" column="1">
-                  <widget class="QgsMapLayerComboBox" name="layerComboBox"/>
-                 </item>
-                </layout>
-               </widget>
-              </widget>
-             </item>
-             <item row="4" column="0">
+             <item row="7" column="0">
               <widget class="QLabel" name="baseMapTilesMinZoomLevelLabel">
                <property name="text">
                 <string>Tiles min zoom level</string>
@@ -513,7 +441,7 @@
                </property>
               </widget>
              </item>
-             <item row="2" column="1">
+             <item row="5" column="1">
               <widget class="QgsSpinBox" name="tileSize">
                <property name="sizePolicy">
                 <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -538,7 +466,7 @@
                </property>
               </widget>
              </item>
-             <item row="3" column="0">
+             <item row="6" column="0">
               <widget class="QLabel" name="mapUnitsPerPixelLabel">
                <property name="text">
                 <string>Map units per pixel</string>
@@ -548,7 +476,26 @@
                </property>
               </widget>
              </item>
-             <item row="6" column="0">
+             <item row="6" column="1">
+              <widget class="QgsDoubleSpinBox" name="mapUnitsPerPixel">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="toolTip">
+                <string>This determines the spatial resolution of the resulting map image. It depends on the CRS of the map canvas. For map units in [m], a value of 1 means each pixel covers an area of 1x1 m, a value of 1000 means 1 pixel per square kilometer.</string>
+               </property>
+               <property name="suffix">
+                <string> mupp</string>
+               </property>
+               <property name="value">
+                <double>99.989999999999995</double>
+               </property>
+              </widget>
+             </item>
+             <item row="9" column="0">
               <widget class="QLabel" name="baseMapTilesMaxZoomLevelLabel">
                <property name="text">
                 <string>Tiles max zoom level</string>

--- a/qfieldsync/ui/project_configuration_widget.ui
+++ b/qfieldsync/ui/project_configuration_widget.ui
@@ -274,7 +274,7 @@
           <item row="0" column="0" colspan="2">
            <widget class="QLabel" name="areaOfInterestLabel">
             <property name="text">
-             <string>The area of interest defines the part of a project that should be made available for offline use. By default the full project extent is used unless a custom area of interest extent is provided.</string>
+             <string>The area of interest defines the part of a project that should be made available for offline use.</string>
             </property>
             <property name="font">
              <font>
@@ -289,7 +289,7 @@
           <item row="1" column="0">
            <widget class="QLabel" name="customAreaOfInterestLabel">
             <property name="text">
-             <string>Custom area of interest</string>
+             <string>Area of interest</string>
             </property>
             <property name="alignment">
              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>

--- a/qfieldsync/ui/project_configuration_widget.ui
+++ b/qfieldsync/ui/project_configuration_widget.ui
@@ -71,11 +71,11 @@
           <attribute name="title">
            <string>QFieldCloud Packaging</string>
           </attribute>
-          <layout class="QGridLayout" name="cloudExportLayout" columnstretch="1,0,0">
+          <layout class="QGridLayout" name="cloudExportLayout" columnstretch="1,0">
            <item row="0" column="0" colspan="2">
             <widget class="QLabel" name="cloudExportLabel">
              <property name="text">
-              <string>The map layers settings below are used by QFieldCloud when packaging your project for QField to download and synchronize.</string>
+              <string>The map layers settings below are used by QFieldCloud when packaging your project for QField to download and synchronize. To push feature editing and addition changes of vector layers back to QFieldCloud, insure that their action is set to ‘offline editing’.</string>
              </property>
              <property name="font">
               <font>
@@ -97,7 +97,7 @@
              </property>
             </widget>
            </item>
-           <item row="3" column="0" colspan="3">
+           <item row="3" column="0" colspan="2">
             <widget class="QgsCollapsibleGroupBox" name="cloudAdvancedSettings">
              <property name="title">
               <string>Individual Layers Settings</string>

--- a/qfieldsync/ui/project_configuration_widget.ui
+++ b/qfieldsync/ui/project_configuration_widget.ui
@@ -69,10 +69,25 @@
            </sizepolicy>
           </property>
           <attribute name="title">
-           <string>QFieldCloud</string>
+           <string>QFieldCloud Packaging</string>
           </attribute>
-          <layout class="QGridLayout" name="gridLayout_2" columnstretch="1,0,0">
-           <item row="0" column="0">
+          <layout class="QGridLayout" name="cloudExportLayout" columnstretch="1,0,0">
+           <item row="0" column="0" colspan="2">
+            <widget class="QLabel" name="cloudExportLabel">
+             <property name="text">
+              <string>The map layers settings below are used by QFieldCloud when packaging your project for QField to download and synchronize.</string>
+             </property>
+             <property name="font">
+              <font>
+               <italic>true</italic>
+              </font>
+             </property>
+             <property name="wordWrap">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="0">
             <widget class="QRadioButton" name="preferOnlineLayersRadioButton">
              <property name="text">
               <string>Prefer online layers</string>
@@ -96,7 +111,7 @@
              <layout class="QVBoxLayout" name="verticalLayout_4"/>
             </widget>
            </item>
-           <item row="0" column="1">
+           <item row="1" column="1">
             <widget class="QRadioButton" name="preferOfflineLayersRadioButton">
              <property name="text">
               <string>Prefer offline layers</string>
@@ -168,247 +183,379 @@
          </widget>
          <widget class="QWidget" name="cableExportTab">
           <attribute name="title">
-           <string>Cable Export</string>
+           <string>Cable Packaging</string>
           </attribute>
-          <layout class="QGridLayout" name="gridLayout_6"/>
+          <layout class="QGridLayout" name="cableExportLayout">
+           <item row="0" column="0">
+            <widget class="QLabel" name="cableExportLabel">
+             <property name="text">
+              <string>The map layers settings below are used when packaging your project intented for manually copying the generated project onto your devices manually via USB cable of other import mechanisms supported by devices' operating system.</string>
+             </property>
+             <property name="font">
+              <font>
+               <italic>true</italic>
+              </font>
+             </property>
+             <property name="wordWrap">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+         <widget class="QWidget" name="attachmentsDirectoriesTab">
+          <attribute name="title">
+           <string>Attachments and Directories</string>
+          </attribute>
+          <layout class="QGridLayout" name="attachmentsDirectoriesLayout" columnstretch="1,0">
+           <item row="0" column="0" colspan="2">
+            <widget class="QLabel" name="attachmentsDirectoriesLabel">
+             <property name="text">
+              <string>When packaging a project, attachment and data directories are used to recursively copy files into the generated output. Attachment diretories should be tied to feature forms' attachment editor widgets while data directories are used to package assets such as print layout and decoration images and QField project plugin files.</string>
+             </property>
+             <property name="font">
+              <font>
+               <italic>true</italic>
+              </font>
+             </property>
+             <property name="wordWrap">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="1">
+            <widget class="QgsSpinBox" name="maximumImageWidthHeight">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="suffix">
+              <string> px</string>
+             </property>
+             <property name="minimum">
+              <number>0</number>
+             </property>
+             <property name="maximum">
+              <number>99999999</number>
+             </property>
+             <property name="value">
+              <number>0</number>
+             </property>
+             <property name="showClearButton">
+              <bool>true</bool>
+             </property>
+             <property name="clearValue">
+              <bool>false</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="0">
+            <widget class="QLabel" name="maximumImageWidthHeightLabel">
+             <property name="text">
+              <string>Maximum allowed width or height (in pixels) of image attachments</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
          </widget>
         </widget>
        </item>
        <item>
-        <widget class="QgsCollapsibleGroupBox" name="createBaseMapGroupBox">
+        <widget class="QgsCollapsibleGroupBox" name="areaOfInterestBaseMapGroupBox">
          <property name="title">
-          <string>Base Map</string>
+          <string>Area of Interest and Base Map</string>
          </property>
-         <property name="checkable">
-          <bool>true</bool>
-         </property>
-         <property name="saveCheckedState">
-          <bool>true</bool>
-         </property>
-         <layout class="QGridLayout" name="gridLayout">
-          <item row="0" column="1">
-           <widget class="QRadioButton" name="mapThemeRadioButton">
+         <layout class="QGridLayout" name="areaOfInterestBaseMapLayout">
+          <item row="0" column="0" colspan="2">
+           <widget class="QLabel" name="areaOfInterestLabel">
             <property name="text">
-             <string>Map theme</string>
+             <string>By default, the project’s full extent will be treated as the area of interest and can be customized using the extent widget below. The area of interest can be used to filter features from vector layers above where their packaging action is set to ‘offline editing’.</string>
             </property>
-            <attribute name="buttonGroup">
-             <string notr="true">buttonGroup</string>
-            </attribute>
-           </widget>
-          </item>
-          <item row="6" column="1">
-           <widget class="QgsSpinBox" name="baseMapTilesMaxZoomLevelSpinBox">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
+            <property name="font">
+             <font>
+              <italic>true</italic>
+             </font>
             </property>
-            <property name="toolTip">
-             <string>This determines the maximum zoom level of the basemap tiles (mbtiles format), generated during cable export.</string>
-            </property>
-            <property name="maximum">
-             <number>20</number>
-            </property>
-            <property name="value">
-             <number>14</number>
+            <property name="wordWrap">
+             <bool>true</bool>
             </property>
            </widget>
           </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="tileSizeLabel">
+          <item row="1" column="0">
+           <widget class="QLabel" name="customAreaOfInterestLabel">
             <property name="text">
-             <string>Tile size</string>
+             <string>Custom area of interest</string>
             </property>
             <property name="alignment">
              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
             </property>
            </widget>
           </item>
-          <item row="4" column="1">
-           <widget class="QgsSpinBox" name="baseMapTilesMinZoomLevelSpinBox">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="toolTip">
-             <string>This determines the minimum zoom level of the basemap tiles (mbtiles format), generated during cable export.</string>
-            </property>
-            <property name="maximum">
-             <number>20</number>
-            </property>
-            <property name="value">
-             <number>14</number>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="0">
-           <widget class="QRadioButton" name="singleLayerRadioButton">
+          <item row="2" column="0" colspan="2">
+           <widget class="QCheckBox" name="onlyOfflineCopyFeaturesInAoi">
             <property name="text">
-             <string>Single layer</string>
-            </property>
-            <attribute name="buttonGroup">
-             <string notr="true">buttonGroup</string>
-            </attribute>
-           </widget>
-          </item>
-          <item row="3" column="1">
-           <widget class="QgsDoubleSpinBox" name="mapUnitsPerPixel">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="toolTip">
-             <string>This determines the spatial resolution of the resulting map image. It depends on the CRS of the map canvas. For map units in [m], a value of 1 means each pixel covers an area of 1x1 m, a value of 1000 means 1 pixel per square kilometer.</string>
-            </property>
-            <property name="suffix">
-             <string> mupp</string>
-            </property>
-            <property name="value">
-             <double>99.989999999999995</double>
+             <string>When offlining layers, only copy features intersecting the area of interest</string>
             </property>
            </widget>
           </item>
-          <item row="1" column="0" colspan="2">
-           <widget class="QStackedWidget" name="baseMapTypeStack">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
+          <item row="3" column="0" colspan="2">
+           <widget class="QLabel" name="baseMapLabel">
+            <property name="text">
+             <string>A raster base map can be generated upon triggering a cable packaging process. The generated raster will cover the project’s full extent or the customized area of interest defined above.</string>
             </property>
-            <property name="inputMethodHints">
-             <set>Qt::ImhDialableCharactersOnly</set>
+            <property name="font">
+             <font>
+              <italic>true</italic>
+             </font>
             </property>
-            <widget class="QWidget" name="mapThemePage">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <layout class="QGridLayout" name="gridLayout_4" columnstretch="1,3">
-              <property name="leftMargin">
-               <number>0</number>
-              </property>
-              <property name="topMargin">
-               <number>0</number>
-              </property>
-              <property name="rightMargin">
-               <number>0</number>
-              </property>
-              <property name="bottomMargin">
-               <number>0</number>
-              </property>
-              <item row="0" column="0">
-               <widget class="QLabel" name="baseMapMapThemeLabel">
-                <property name="text">
-                 <string>Map Theme</string>
+            <property name="wordWrap">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0" colspan="2">
+           <widget class="QgsCollapsibleGroupBox" name="createBaseMapGroupBox">
+            <property name="title">
+             <string>Generate base map</string>
+            </property>
+            <property name="checkable">
+             <bool>true</bool>
+            </property>
+            <property name="saveCheckedState">
+             <bool>true</bool>
+            </property>
+            <property name="collapsed">
+             <bool>true</bool>
+            </property>
+            <layout class="QGridLayout" name="gridLayout">
+             <item row="0" column="1">
+              <widget class="QRadioButton" name="mapThemeRadioButton">
+               <property name="text">
+                <string>Map theme</string>
+               </property>
+               <attribute name="buttonGroup">
+                <string notr="true">buttonGroup</string>
+               </attribute>
+              </widget>
+             </item>
+             <item row="6" column="1">
+              <widget class="QgsSpinBox" name="baseMapTilesMaxZoomLevelSpinBox">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="toolTip">
+                <string>This determines the maximum zoom level of the basemap tiles (mbtiles format), generated during cable export.</string>
+               </property>
+               <property name="maximum">
+                <number>20</number>
+               </property>
+               <property name="value">
+                <number>14</number>
+               </property>
+              </widget>
+             </item>
+             <item row="2" column="0">
+              <widget class="QLabel" name="tileSizeLabel">
+               <property name="text">
+                <string>Tile size</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+               </property>
+              </widget>
+             </item>
+             <item row="4" column="1">
+              <widget class="QgsSpinBox" name="baseMapTilesMinZoomLevelSpinBox">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="toolTip">
+                <string>This determines the minimum zoom level of the basemap tiles (mbtiles format), generated during cable export.</string>
+               </property>
+               <property name="maximum">
+                <number>20</number>
+               </property>
+               <property name="value">
+                <number>14</number>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="0">
+              <widget class="QRadioButton" name="singleLayerRadioButton">
+               <property name="text">
+                <string>Single layer</string>
+               </property>
+               <attribute name="buttonGroup">
+                <string notr="true">buttonGroup</string>
+               </attribute>
+              </widget>
+             </item>
+             <item row="3" column="1">
+              <widget class="QgsDoubleSpinBox" name="mapUnitsPerPixel">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="toolTip">
+                <string>This determines the spatial resolution of the resulting map image. It depends on the CRS of the map canvas. For map units in [m], a value of 1 means each pixel covers an area of 1x1 m, a value of 1000 means 1 pixel per square kilometer.</string>
+               </property>
+               <property name="suffix">
+                <string> mupp</string>
+               </property>
+               <property name="value">
+                <double>99.989999999999995</double>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="0" colspan="2">
+              <widget class="QStackedWidget" name="baseMapTypeStack">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="inputMethodHints">
+                <set>Qt::ImhDialableCharactersOnly</set>
+               </property>
+               <widget class="QWidget" name="mapThemePage">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
                 </property>
-                <property name="alignment">
-                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                </property>
+                <layout class="QGridLayout" name="gridLayout_4" columnstretch="1,3">
+                 <property name="leftMargin">
+                  <number>0</number>
+                 </property>
+                 <property name="topMargin">
+                  <number>0</number>
+                 </property>
+                 <property name="rightMargin">
+                  <number>0</number>
+                 </property>
+                 <property name="bottomMargin">
+                  <number>0</number>
+                 </property>
+                 <item row="0" column="0">
+                  <widget class="QLabel" name="baseMapMapThemeLabel">
+                   <property name="text">
+                    <string>Map Theme</string>
+                   </property>
+                   <property name="alignment">
+                    <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="0" column="1">
+                  <widget class="QComboBox" name="mapThemeComboBox"/>
+                 </item>
+                </layout>
                </widget>
-              </item>
-              <item row="0" column="1">
-               <widget class="QComboBox" name="mapThemeComboBox"/>
-              </item>
-             </layout>
-            </widget>
-            <widget class="QWidget" name="singleLayerPage">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <layout class="QGridLayout" name="gridLayout_5" columnstretch="1,3">
-              <property name="leftMargin">
-               <number>0</number>
-              </property>
-              <property name="topMargin">
-               <number>0</number>
-              </property>
-              <property name="rightMargin">
-               <number>0</number>
-              </property>
-              <property name="bottomMargin">
-               <number>0</number>
-              </property>
-              <item row="0" column="0">
-               <widget class="QLabel" name="baseMapLayerLabel">
-                <property name="text">
-                 <string>Layer</string>
+               <widget class="QWidget" name="singleLayerPage">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
                 </property>
-                <property name="alignment">
-                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                </property>
+                <layout class="QGridLayout" name="gridLayout_5" columnstretch="1,3">
+                 <property name="leftMargin">
+                  <number>0</number>
+                 </property>
+                 <property name="topMargin">
+                  <number>0</number>
+                 </property>
+                 <property name="rightMargin">
+                  <number>0</number>
+                 </property>
+                 <property name="bottomMargin">
+                  <number>0</number>
+                 </property>
+                 <item row="0" column="0">
+                  <widget class="QLabel" name="baseMapLayerLabel">
+                   <property name="text">
+                    <string>Layer</string>
+                   </property>
+                   <property name="alignment">
+                    <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="0" column="1">
+                  <widget class="QgsMapLayerComboBox" name="layerComboBox"/>
+                 </item>
+                </layout>
                </widget>
-              </item>
-              <item row="0" column="1">
-               <widget class="QgsMapLayerComboBox" name="layerComboBox"/>
-              </item>
-             </layout>
-            </widget>
-           </widget>
-          </item>
-          <item row="4" column="0">
-           <widget class="QLabel" name="baseMapTilesMinZoomLevelLabel">
-            <property name="text">
-             <string>Tiles min zoom level</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="1">
-           <widget class="QgsSpinBox" name="tileSize">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="toolTip">
-             <string>Rendering will happen in tiles. This number determines the width and height (in pixels) that will be rendered per tile.</string>
-            </property>
-            <property name="suffix">
-             <string> px</string>
-            </property>
-            <property name="minimum">
-             <number>1</number>
-            </property>
-            <property name="maximum">
-             <number>10240</number>
-            </property>
-            <property name="value">
-             <number>1024</number>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="0">
-           <widget class="QLabel" name="mapUnitsPerPixelLabel">
-            <property name="text">
-             <string>Map units per pixel</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-            </property>
-           </widget>
-          </item>
-          <item row="6" column="0">
-           <widget class="QLabel" name="baseMapTilesMaxZoomLevelLabel">
-            <property name="text">
-             <string>Tiles max zoom level</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-            </property>
+              </widget>
+             </item>
+             <item row="4" column="0">
+              <widget class="QLabel" name="baseMapTilesMinZoomLevelLabel">
+               <property name="text">
+                <string>Tiles min zoom level</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+               </property>
+              </widget>
+             </item>
+             <item row="2" column="1">
+              <widget class="QgsSpinBox" name="tileSize">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="toolTip">
+                <string>Rendering will happen in tiles. This number determines the width and height (in pixels) that will be rendered per tile.</string>
+               </property>
+               <property name="suffix">
+                <string> px</string>
+               </property>
+               <property name="minimum">
+                <number>1</number>
+               </property>
+               <property name="maximum">
+                <number>10240</number>
+               </property>
+               <property name="value">
+                <number>1024</number>
+               </property>
+              </widget>
+             </item>
+             <item row="3" column="0">
+              <widget class="QLabel" name="mapUnitsPerPixelLabel">
+               <property name="text">
+                <string>Map units per pixel</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+               </property>
+              </widget>
+             </item>
+             <item row="6" column="0">
+              <widget class="QLabel" name="baseMapTilesMaxZoomLevelLabel">
+               <property name="text">
+                <string>Tiles max zoom level</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+               </property>
+              </widget>
+             </item>
+            </layout>
            </widget>
           </item>
          </layout>
@@ -427,6 +574,11 @@
            <widget class="QLabel" name="geofencingIntroductionLabel">
             <property name="text">
              <string>QField provides real-time feedback to users when their device position falls within or outside of areas defined by a selected polygon layer.</string>
+            </property>
+            <property name="font">
+             <font>
+              <italic>true</italic>
+             </font>
             </property>
             <property name="wordWrap">
              <bool>true</bool>
@@ -495,82 +647,10 @@
             <layout class="QVBoxLayout" name="verticalLayout_8"/>
            </widget>
           </item>
-          <item row="4" column="0">
-           <widget class="QLabel" name="attachmentDirsLabel">
-            <property name="toolTip">
-             <string>A list of directories and files to be treated as attachments or data. Usually the directories that store images and/or SVG are here.</string>
-            </property>
-            <property name="text">
-             <string>Directories</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-            </property>
-           </widget>
-          </item>
           <item row="0" column="0">
            <widget class="QLabel" name="labelDigitizingLogsLayer">
             <property name="text">
              <string>Digitizing logs layer</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="1">
-           <widget class="QCheckBox" name="onlyOfflineCopyFeaturesInAoi">
-            <property name="text">
-             <string>Only copy features in area of interest</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="1">
-           <widget class="QgsSpinBox" name="maximumImageWidthHeight">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="toolTip">
-             <string>This number sets the maximum allowed width or height (in pixels) of an image attached to feature forms.</string>
-            </property>
-            <property name="suffix">
-             <string> px</string>
-            </property>
-            <property name="minimum">
-             <number>0</number>
-            </property>
-            <property name="maximum">
-             <number>99999999</number>
-            </property>
-            <property name="value">
-             <number>0</number>
-            </property>
-            <property name="showClearButton">
-             <bool>true</bool>
-            </property>
-            <property name="clearValue">
-             <bool>false</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="0">
-           <widget class="QLabel" name="maximumImageWidthHeightLabel">
-            <property name="text">
-             <string>Max. image attachment
-(width or height)</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="areaOfInterestLabel">
-            <property name="text">
-             <string>Area of interest</string>
             </property>
             <property name="alignment">
              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -633,9 +713,13 @@
   <tabstop>cloudAdvancedSettings</tabstop>
   <tabstop>forceAutoPush</tabstop>
   <tabstop>forceAutoPushInterval</tabstop>
+  <tabstop>maximumImageWidthHeight</tabstop>
+  <tabstop>areaOfInterestBaseMapGroupBox</tabstop>
+  <tabstop>onlyOfflineCopyFeaturesInAoi</tabstop>
   <tabstop>createBaseMapGroupBox</tabstop>
   <tabstop>singleLayerRadioButton</tabstop>
   <tabstop>mapThemeRadioButton</tabstop>
+  <tabstop>layerComboBox</tabstop>
   <tabstop>mapThemeComboBox</tabstop>
   <tabstop>tileSize</tabstop>
   <tabstop>mapUnitsPerPixel</tabstop>
@@ -645,10 +729,8 @@
   <tabstop>geofencingLayerComboBox</tabstop>
   <tabstop>geofencingBehaviorComboBox</tabstop>
   <tabstop>geofencingShouldPreventDigitizingCheckBox</tabstop>
+  <tabstop>advancedSettingsGroupBox</tabstop>
   <tabstop>digitizingLogsLayerComboBox</tabstop>
-  <tabstop>onlyOfflineCopyFeaturesInAoi</tabstop>
-  <tabstop>maximumImageWidthHeight</tabstop>
-  <tabstop>layerComboBox</tabstop>
  </tabstops>
  <resources/>
  <connections/>


### PR DESCRIPTION
_Preface: the motivation for this PR comes as I'm about to introduce another attachment-related project configuration into QFieldSync and I did *not* want to simply throw another setting in the advanced settings groupbox, which had become an aggregation of everything under the sun._

This PR focuses on restructuring the QFS project properties widget, as well as add short introduction labels to sections to provide preliminary guidance to users. This adopts a practice increasingly used in QGIS itself and IMHO can be quite useful in better sharing the purpose of various settings.

Before (left) vs. PR (right):

![image322](https://github.com/user-attachments/assets/364c6d8e-7fbb-4bd5-a013-537c61a4c10e)

Improvements here include:
- the regrouping of AOI and base map together; these settings work together and it was really not that clear before now
- an explicit, visual guide as to what it means to leave an empty AOI
- crucial help in guiding people on how to set the right packaging action

On the regrouping of attachment settings into its own tab, here's a before( left) vs. PR (right):

![image3462](https://github.com/user-attachments/assets/72287e26-1b7f-4b00-b90d-d01997a7856e)

In a few days, that section will have another setting (photo information stamping customization), and will look ever nicer :sunglasses: 

I've also taken the time to move the semi-hidden but crucial mouse hover UUID tip into what I believe is a better context, within the layer properties panel alongside the relationship settings (where UUID usage is most important). That was a good occasion to apply a similar cleanup.

Before (left) vs. PR (right):

![image374](https://github.com/user-attachments/assets/16285ce8-f013-4055-9622-6ecf3b67ebc7)

By moving attachments and relationship setting into its own collapsible groupbox, it allows us with a simple logic in the code to collapse these when no attachment editor widgets and/or relationships exist for a given vector layer, which leaves the space for other settings including the tracker session groupbox. Here's an example of what it looks like to open a vector layer with a tracker session configured where no attachments and relationships exist:

![image398](https://github.com/user-attachments/assets/56c9568f-4f04-47eb-b93d-39871be8ed62)
