### PR TITLE
Add logic to avoid auto uploading offline editing-driven datasets to QFieldCloud

### DIFF
--- a/qfieldsync/gui/cloud_transfer_dialog.py
+++ b/qfieldsync/gui/cloud_transfer_dialog.py
@@ -552,7 +552,7 @@ class CloudTransferDialog(QDialog, CloudTransferDialogUi):
         self.filesTree.expandAll()
         # NOTE END algorithmic part
 
-    def _get_offline_layers(self):
+    def _get_offline_layers(self) -> List[str]:
         """
         Returns a list of paths for project layers which have been configured for offline editing.
         """

--- a/qfieldsync/gui/cloud_transfer_dialog.py
+++ b/qfieldsync/gui/cloud_transfer_dialog.py
@@ -553,6 +553,9 @@ class CloudTransferDialog(QDialog, CloudTransferDialogUi):
         # NOTE END algorithmic part
 
     def _get_offline_layers(self):
+        """
+        Returns a list of paths for project layers which have been configured for offline editing.
+        """
         offline_layers_paths = []
         if self.cloud_project and self.cloud_project.is_current_qgis_project:
             project_layers = list(QgsProject.instance().mapLayers().values())


### PR DESCRIPTION
This pull request guards users from unknowingly overwrite datasets tied to layers set to offline editing when triggering a cloud transfer push/pull within QFieldSync. 

Instead of automatically setting the upload/download action for datasets tied to layers being offlined to _upload_ when the dataset's local modified time is more recent than what is on QFieldCloud, the cloud transfer dialog now defaults to _no action_. That is meant to prevent accidental upload and force the users to be intentional about the action for such datasets.

For non-datasets or datasets set to direct access, nothing changes. Similarly, if a dataset that is set to offline editing has a modification time that is more recent than the locally stored file, we are still auto-setting the action to download, nothing changes on that front so people won't start reporting "where's my data?!" :)

Here's what it looks like when the local version of my cloud project has its project file modified as well as a geopackage dataset modified (because WAL et al) that is configured to be offlined:

![image](https://github.com/user-attachments/assets/619bbfb2-dac3-433a-aca8-6e5027ec58c7)
