### PR TITLE
Add image stamping customization functionality

### DIFF
--- a/qfieldsync/gui/image_stamping_configuration_widget.py
+++ b/qfieldsync/gui/image_stamping_configuration_widget.py
@@ -2,9 +2,9 @@
 """
 /***************************************************************************
                               -------------------
-        begin                : 21.11.2016
+        begin                : 15.07.2025
         git sha              : :%H$
-        copyright            : (C) 2016 by OPENGIS.ch
+        copyright            : (C) 2025 by OPENGIS.ch
         email                : info@opengis.ch
  ***************************************************************************/
 
@@ -46,6 +46,10 @@ class ImageStampingConfigurationWidget(WidgetUi, QgsPanelWidget):
     """
     Configuration widget for QFieldSync on a particular project.
     """
+
+    DEFAULT_DETAILS_TEMPLATE = """[% format_date(now(), 'yyyy-MM-dd @ HH:mm') %]
+Latitude [% coalesce(format_number(y(@gnss_coordinate), 7), 'N/A') %] | Longitude [% coalesce(format_number(x(@gnss_coordinate), 7), 'N/A') %] | Altitude [% coalesce(format_number(z(@gnss_coordinate), 3) || ' m', 'N/A') %]
+Speed [% if(@gnss_ground_speed != 'nan', format_number(@gnss_ground_speed, 3) || ' m/s', 'N/A') %] | Orientation [% if(@gnss_orientation != 'nan', format_number(@gnss_orientation, 1) || ' °', 'N/A') %]"""
 
     def __init__(self, parent=None):
         """Constructor."""
@@ -276,11 +280,15 @@ class ImageStampingConfigurationWidget(WidgetUi, QgsPanelWidget):
     def set_image_decoration(self, file_path):
         self.customImageDecorationFile.setFilePath(file_path)
 
-    def details_expression(self):
-        return self.customDetailsTextEdit.toPlainText()
+    def details_template(self):
+        details = self.customDetailsTextEdit.toPlainText().strip()
+        return details if details != self.DEFAULT_DETAILS_TEMPLATE else ""
 
-    def set_details_expression(self, details_expression):
-        self.customDetailsTextEdit.setPlainText(details_expression)
+    def set_details_template(self, details_template):
+        details = details_template.strip()
+        self.customDetailsTextEdit.setPlainText(
+            details if details != "" else self.DEFAULT_DETAILS_TEMPLATE
+        )
 
     def force_stamping(self):
         return self.forceStampingCheckBox.isChecked()

--- a/qfieldsync/gui/image_stamping_configuration_widget.py
+++ b/qfieldsync/gui/image_stamping_configuration_widget.py
@@ -1,0 +1,289 @@
+# -*- coding: utf-8 -*-
+"""
+/***************************************************************************
+                              -------------------
+        begin                : 21.11.2016
+        git sha              : :%H$
+        copyright            : (C) 2016 by OPENGIS.ch
+        email                : info@opengis.ch
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+"""
+import os
+
+from qgis.core import (
+    QgsExpression,
+    QgsExpressionContext,
+    QgsExpressionContextScope,
+    QgsExpressionContextUtils,
+    QgsGeometry,
+    QgsPoint,
+    QgsProject,
+    QgsReadWriteContext,
+    QgsTextFormat,
+)
+from qgis.gui import QgsExpressionBuilderDialog, QgsPanelWidget
+from qgis.PyQt.QtCore import QDateTime
+from qgis.PyQt.QtXml import QDomDocument
+from qgis.PyQt.uic import loadUiType
+
+WidgetUi, _ = loadUiType(
+    os.path.join(
+        os.path.dirname(__file__), "../ui/image_stamping_configuration_widget.ui"
+    )
+)
+
+
+class ImageStampingConfigurationWidget(WidgetUi, QgsPanelWidget):
+    """
+    Configuration widget for QFieldSync on a particular project.
+    """
+
+    def __init__(self, parent=None):
+        """Constructor."""
+        super().__init__(parent)
+        self.setupUi(self)
+
+        self.setPanelTitle(self.tr("Image Stamping"))
+
+        self.customFontStyleButton.setShowNullFormat(True)
+        self.customFontStyleButton.setShowNullFormat(True)
+        self.customFontStyleButton.setNoFormatString(self.tr("Default font style"))
+
+        self.customAlignmentComboBox.addItem(self.tr("Left"))
+        self.customAlignmentComboBox.addItem(self.tr("Center"))
+        self.customAlignmentComboBox.addItem(self.tr("Right"))
+
+        self.expression_context = QgsExpressionContext()
+        self.expression_context.appendScopes(
+            QgsExpressionContextUtils.globalProjectLayerScopes(None)
+        )
+
+        cloud_expression_context_scope = QgsExpressionContextScope(
+            self.tr("Cloud User Info")
+        )
+        cloud_expression_context_scope.addVariable(
+            QgsExpressionContextScope.StaticVariable(
+                "cloud_username", "nyuki", True, True
+            )
+        )
+        cloud_expression_context_scope.addVariable(
+            QgsExpressionContextScope.StaticVariable(
+                "cloud_useremail", "nyuki@qfield.cloud", True, True
+            )
+        )
+        self.expression_context.appendScope(cloud_expression_context_scope)
+
+        point = QgsGeometry(QgsPoint(0, 0, 0))
+        position_expression_context_scope = QgsExpressionContextScope(
+            self.tr("Position")
+        )
+        position_expression_context_scope.addVariable(
+            QgsExpressionContextScope.StaticVariable(
+                "gnss_coordinate", point, True, True
+            )
+        )
+        position_expression_context_scope.addVariable(
+            QgsExpressionContextScope.StaticVariable(
+                "gnss_timestamp", QDateTime.currentDateTime(), True, True
+            )
+        )
+        position_expression_context_scope.addVariable(
+            QgsExpressionContextScope.StaticVariable("gnss_direction", 0, True, True)
+        )
+        position_expression_context_scope.addVariable(
+            QgsExpressionContextScope.StaticVariable("gnss_ground_speed", 0, True, True)
+        )
+        position_expression_context_scope.addVariable(
+            QgsExpressionContextScope.StaticVariable("gnss_orientation", 0, True, True)
+        )
+        position_expression_context_scope.addVariable(
+            QgsExpressionContextScope.StaticVariable(
+                "gnss_magnetic_variation", 0, True, True
+            )
+        )
+        position_expression_context_scope.addVariable(
+            QgsExpressionContextScope.StaticVariable(
+                "gnss_horizontal_accuracy", 0, True, True
+            )
+        )
+        position_expression_context_scope.addVariable(
+            QgsExpressionContextScope.StaticVariable(
+                "gnss_vertical_accuracy", 0, True, True
+            )
+        )
+        position_expression_context_scope.addVariable(
+            QgsExpressionContextScope.StaticVariable("gnss_3d_accuracy", 0, True, True)
+        )
+        position_expression_context_scope.addVariable(
+            QgsExpressionContextScope.StaticVariable(
+                "gnss_vertical_speed", 0, True, True
+            )
+        )
+        position_expression_context_scope.addVariable(
+            QgsExpressionContextScope.StaticVariable("gnss_source_name", 0, True, True)
+        )
+        position_expression_context_scope.addVariable(
+            QgsExpressionContextScope.StaticVariable("gnss_pdop", 0, True, True)
+        )
+        position_expression_context_scope.addVariable(
+            QgsExpressionContextScope.StaticVariable("gnss_hdop", 0, True, True)
+        )
+        position_expression_context_scope.addVariable(
+            QgsExpressionContextScope.StaticVariable("gnss_vdop", 0, True, True)
+        )
+        position_expression_context_scope.addVariable(
+            QgsExpressionContextScope.StaticVariable(
+                "gnss_number_of_used_satellites", 0, True, True
+            )
+        )
+        position_expression_context_scope.addVariable(
+            QgsExpressionContextScope.StaticVariable(
+                "gnss_used_satellites", [], True, True
+            )
+        )
+        position_expression_context_scope.addVariable(
+            QgsExpressionContextScope.StaticVariable(
+                "gnss_quality_description", 0, True, True
+            )
+        )
+        position_expression_context_scope.addVariable(
+            QgsExpressionContextScope.StaticVariable(
+                "gnss_fix_status_description", 0, True, True
+            )
+        )
+        position_expression_context_scope.addVariable(
+            QgsExpressionContextScope.StaticVariable("gnss_fix_mode", 0, True, True)
+        )
+        position_expression_context_scope.addVariable(
+            QgsExpressionContextScope.StaticVariable(
+                "gnss_averaged_count", 0, True, True
+            )
+        )
+        position_expression_context_scope.addVariable(
+            QgsExpressionContextScope.StaticVariable(
+                "gnss_imu_correction", 0, True, True
+            )
+        )
+        position_expression_context_scope.addVariable(
+            QgsExpressionContextScope.StaticVariable("gnss_imu_roll", 0, True, True)
+        )
+        position_expression_context_scope.addVariable(
+            QgsExpressionContextScope.StaticVariable("gnss_imu_pitch", 0, True, True)
+        )
+        position_expression_context_scope.addVariable(
+            QgsExpressionContextScope.StaticVariable("gnss_imu_heading", 0, True, True)
+        )
+        position_expression_context_scope.addVariable(
+            QgsExpressionContextScope.StaticVariable("gnss_imu_steering", 0, True, True)
+        )
+        self.expression_context.appendScope(position_expression_context_scope)
+
+        self.expression_context.setHighlightedVariables(
+            position_expression_context_scope.variableNames()
+            + cloud_expression_context_scope.variableNames()
+        )
+
+        self.expression_builder_dialog = QgsExpressionBuilderDialog(
+            None, "", self, "generic", self.expression_context
+        )
+        self.insertExpressionButton.clicked.connect(self.show_builder)
+
+        # self.customDetailsTextEdit.setWordWrapMode(QTextOption.WordWrap)
+        # self.customDetailsTextEdit.setLineWrapMode(QPlainTextEdit.WidgetWidth)
+        self.customDetailsTextEdit.textChanged.connect(self.update_preview)
+
+        self.update_preview()
+
+    def show_builder(self):
+        if self.customDetailsTextEdit.textCursor().selectedText():
+            self.expression_builder_dialog.setExpressionText(
+                self.customDetailsTextEdit.textCursor().selectedText()
+            )
+        else:
+            self.expression_builder_dialog.setExpressionText("")
+
+        if self.expression_builder_dialog.exec():
+            if self.expression_builder_dialog.expressionText():
+                self.customDetailsTextEdit.textCursor().removeSelectedText()
+                self.customDetailsTextEdit.insertPlainText(
+                    f"[% {self.expression_builder_dialog.expressionText()} %]"
+                )
+            self.update_preview()
+
+    def update_preview(self):
+        if self.customDetailsTextEdit.toPlainText():
+            preview_text = QgsExpression.replaceExpressionText(
+                self.customDetailsTextEdit.toPlainText(), self.expression_context
+            )
+        else:
+            preview_text = QgsExpression.replaceExpressionText(
+                "[% format_date(now(), 'yyyy-MM-dd @ HH:mm') || if(@gnss_coordinate is not null, format('\n"
+                + self.tr("Latitude")
+                + " %1 | "
+                + self.tr("Longitude")
+                + " %2 | "
+                + self.tr("Altitude")
+                + " %3\n"
+                + self.tr("Speed")
+                + " %4 | "
+                + self.tr("Orientation")
+                + " %5', coalesce(format_number(y(@gnss_coordinate), 7), 'N/A'), coalesce(format_number(x(@gnss_coordinate), 7), 'N/A'), coalesce(format_number(z(@gnss_coordinate), 3) || ' m', 'N/A'), if(@gnss_ground_speed != 'nan', format_number(@gnss_ground_speed, 3) || ' m/s', 'N/A'), if(@gnss_orientation != 'nan', format_number(@gnss_orientation, 1) || ' °', 'N/A')), '') %]",
+                self.expression_context,
+            )
+
+        self.previewLabel.setText(preview_text)
+
+    def font_style(self):
+        text_format = self.customFontStyleButton.textFormat()
+        if text_format.isValid():
+            rw_context = QgsReadWriteContext()
+            document = QDomDocument()
+            element = text_format.writeXml(document, rw_context)
+            document.appendChild(element)
+            return document.toString()
+
+        return ""
+
+    def set_font_style(self, xml_string):
+        text_format = QgsTextFormat()
+        if xml_string:
+            rw_context = QgsReadWriteContext()
+            rw_context.setPathResolver(QgsProject.instance().pathResolver())
+            document = QDomDocument()
+            document.setContent(xml_string)
+            text_format.readXml(document.documentElement(), rw_context)
+
+        self.customFontStyleButton.setTextFormat(text_format)
+
+    def horizontal_alignment(self):
+        return self.customAlignmentComboBox.currentIndex()
+
+    def set_horizontal_alignment(self, horizontal_alignment):
+        self.customAlignmentComboBox.setCurrentIndex(horizontal_alignment)
+
+    def image_decoration(self):
+        return self.customImageDecorationFile.filePath()
+
+    def set_image_decoration(self, file_path):
+        self.customImageDecorationFile.setFilePath(file_path)
+
+    def details_expression(self):
+        return self.customDetailsTextEdit.toPlainText()
+
+    def set_details_expression(self, details_expression):
+        self.customDetailsTextEdit.setPlainText(details_expression)
+
+    def force_stamping(self):
+        return self.forceStampingCheckBox.isChecked()
+
+    def set_force_stamping(self, force_stamping):
+        self.forceStampingCheckBox.setChecked(force_stamping)

--- a/qfieldsync/gui/project_configuration_dialog.py
+++ b/qfieldsync/gui/project_configuration_dialog.py
@@ -21,7 +21,7 @@
 from qgis.gui import QgsGui
 from qgis.PyQt.QtWidgets import QDialog, QDialogButtonBox, QVBoxLayout
 
-from qfieldsync.gui.project_configuration_widget import ProjectConfigurationWidget
+from qfieldsync.gui.project_configuration_widget import ProjectConfigurationStackWidget
 
 
 class ProjectConfigurationDialog(QDialog):
@@ -38,14 +38,14 @@ class ProjectConfigurationDialog(QDialog):
 
         self.setWindowTitle("QFieldSync Project Properties")
 
-        self.projectConfigurationWidget = ProjectConfigurationWidget(self)
+        self.projectConfigurationStackWidget = ProjectConfigurationStackWidget(self)
 
         self.buttonBox = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
         self.buttonBox.accepted.connect(lambda: self.onAccepted())
         self.buttonBox.rejected.connect(self.reject)
 
         self.layout = QVBoxLayout()
-        self.layout.addWidget(self.projectConfigurationWidget)
+        self.layout.addWidget(self.projectConfigurationStackWidget)
         self.layout.addWidget(self.buttonBox)
         self.setLayout(self.layout)
 

--- a/qfieldsync/gui/project_configuration_widget.py
+++ b/qfieldsync/gui/project_configuration_widget.py
@@ -120,8 +120,8 @@ class ProjectConfigurationWidget(WidgetUi, QgsPanelWidget):
             )
         else:
             self.stamping_image_decoration = ""
-        self.stamping_details_expression = (
-            self.__project_configuration.stamping_details_expression
+        self.stamping_details_template = (
+            self.__project_configuration.stamping_details_template
         )
         self.force_stamping = self.__project_configuration.force_stamping
         self.customizeImageStampingButton.clicked.connect(
@@ -465,8 +465,8 @@ class ProjectConfigurationWidget(WidgetUi, QgsPanelWidget):
             )
         else:
             self.__project_configuration.stamping_image_decoration = ""
-        self.__project_configuration.stamping_details_expression = (
-            self.stamping_details_expression
+        self.__project_configuration.stamping_details_template = (
+            self.stamping_details_template
         )
         self.__project_configuration.force_stamping = self.force_stamping
 
@@ -477,9 +477,7 @@ class ProjectConfigurationWidget(WidgetUi, QgsPanelWidget):
             self.stamping_horizontal_alignment
         )
         self.image_stamping_panel.set_image_decoration(self.stamping_image_decoration)
-        self.image_stamping_panel.set_details_expression(
-            self.stamping_details_expression
-        )
+        self.image_stamping_panel.set_details_template(self.stamping_details_template)
         self.image_stamping_panel.set_force_stamping(self.force_stamping)
         self.image_stamping_panel.panelAccepted.connect(
             self.apply_image_stamping_settings
@@ -492,9 +490,7 @@ class ProjectConfigurationWidget(WidgetUi, QgsPanelWidget):
             self.image_stamping_panel.horizontal_alignment()
         )
         self.stamping_image_decoration = self.image_stamping_panel.image_decoration()
-        self.stamping_details_expression = (
-            self.image_stamping_panel.details_expression()
-        )
+        self.stamping_details_template = self.image_stamping_panel.details_template()
         self.force_stamping = self.image_stamping_panel.force_stamping()
         self.image_stamping_panel = None
 

--- a/qfieldsync/gui/project_configuration_widget.py
+++ b/qfieldsync/gui/project_configuration_widget.py
@@ -297,7 +297,6 @@ class ProjectConfigurationWidget(WidgetUi, QgsPanelWidget):
             self.__project_configuration.maximum_image_width_height
         )
 
-        self.mapUnitsPerPixel.setValue(self.__project_configuration.base_map_mupp)
         self.tileSize.setValue(self.__project_configuration.base_map_tile_size)
 
         self.baseMapTilesMinZoomLevelSpinBox.setValue(
@@ -410,9 +409,6 @@ class ProjectConfigurationWidget(WidgetUi, QgsPanelWidget):
         except AttributeError:
             pass
 
-        self.__project_configuration.base_map_mupp = float(
-            self.mapUnitsPerPixel.value()
-        )
         self.__project_configuration.base_map_tile_size = self.tileSize.value()
 
         self.__project_configuration.base_map_tiles_min_zoom_level = (

--- a/qfieldsync/qfield_sync.py
+++ b/qfieldsync/qfield_sync.py
@@ -42,7 +42,7 @@ from qfieldsync.gui.map_layer_config_widget import MapLayerConfigWidgetFactory
 from qfieldsync.gui.package_dialog import PackageDialog
 from qfieldsync.gui.preferences_widget import PreferencesWidget
 from qfieldsync.gui.project_configuration_dialog import ProjectConfigurationDialog
-from qfieldsync.gui.project_configuration_widget import ProjectConfigurationWidget
+from qfieldsync.gui.project_configuration_widget import ProjectConfigurationStackWidget
 from qfieldsync.gui.synchronize_dialog import SynchronizeDialog
 
 
@@ -60,7 +60,7 @@ class QFieldSyncProjectPropertiesFactory(QgsOptionsWidgetFactory):
         )
 
     def createWidget(self, parent):
-        return ProjectConfigurationWidget(parent)
+        return ProjectConfigurationStackWidget(parent)
 
 
 class QFieldSyncOptionsFactory(QgsOptionsWidgetFactory):

--- a/qfieldsync/ui/image_stamping_configuration_widget.ui
+++ b/qfieldsync/ui/image_stamping_configuration_widget.ui
@@ -20,25 +20,7 @@
    <item>
     <widget class="QGroupBox" name="stampingSettingsGroupBox">
      <property name="title">
-      <string>Settings</string>
-     </property>
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>50</width>
-       <height>120</height>
-      </size>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>16777215</width>
-       <height>300</height>
-      </size>
+      <string>Styling Settings</string>
      </property>
      <layout class="QGridLayout" name="stampingSettingsLayout">
       <item row="0" column="0">
@@ -61,7 +43,7 @@
       <item row="1" column="0">
        <widget class="QLabel" name="customAlignmentLabel">
         <property name="text">
-         <string>Text horizontal alignment</string>
+         <string>Horizontal alignment</string>
         </property>
        </widget>
       </item>
@@ -79,27 +61,6 @@
        <widget class="QgsFileWidget" name="customImageDecorationFile" native="true"/>
       </item>
       <item row="3" column="0" colspan="2">
-       <widget class="QLabel" name="customDetailsLabel">
-        <property name="text">
-         <string>Details expression</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="0" colspan="2">
-       <widget class="QPlainTextEdit" name="customDetailsTextEdit">
-        <property name="placeholderText">
-         <string>Leave empty to use the default details string</string>
-        </property>
-       </widget>
-      </item>
-      <item row="5" column="0" colspan="2">
-       <widget class="QPushButton" name="insertExpressionButton">
-        <property name="text">
-         <string>Insert/Edit Expression...</string>
-        </property>
-       </widget>
-      </item>
-      <item row="6" column="0" colspan="2">
        <widget class="QCheckBox" name="forceStampingCheckBox">
         <property name="text">
          <string>Always stamp images taken using the QField camera</string>
@@ -110,11 +71,50 @@
     </widget>
    </item>
    <item>
-    <widget class="QGroupBox" name="previewGroupBox">
+    <widget class="QGroupBox" name="customDetailsGroupBox">
      <property name="title">
-      <string>Preview</string>
+      <string>Details Template Settings</string>
      </property>
      <layout class="QVBoxLayout" name="previewLayout">
+      <item>
+       <widget class="QLabel" name="customDetailsLabel">
+        <property name="text">
+         <string>Details template</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPlainTextEdit" name="customDetailsTextEdit">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>50</width>
+          <height>120</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>16777215</width>
+          <height>300</height>
+         </size>
+        </property>
+        <property name="placeholderText">
+         <string>Leave empty to use the default details string</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="insertExpressionButton">
+        <property name="text">
+         <string>Insert/Edit Expression...</string>
+        </property>
+       </widget>
+      </item>
       <item>
        <widget class="QLabel" name="previewLabel">
         <property name="wordWrap">

--- a/qfieldsync/ui/image_stamping_configuration_widget.ui
+++ b/qfieldsync/ui/image_stamping_configuration_widget.ui
@@ -1,0 +1,183 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ImageStampingConfigurationWidgetBase</class>
+ <widget class="QWidget" name="ImageStampingConfigurationWidgetBase">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>737</width>
+    <height>570</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QGroupBox" name="stampingSettingsGroupBox">
+     <property name="title">
+      <string>Settings</string>
+     </property>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>50</width>
+       <height>120</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>300</height>
+      </size>
+     </property>
+     <layout class="QGridLayout" name="stampingSettingsLayout">
+      <item row="0" column="0">
+       <widget class="QLabel" name="customFontStyleLabel">
+        <property name="text">
+         <string>Text style</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QgsFontButton" name="customFontStyleButton">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+          <horstretch>1</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="customAlignmentLabel">
+        <property name="text">
+         <string>Text horizontal alignment</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QComboBox" name="customAlignmentComboBox"/>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="customImageDecorationLabel">
+        <property name="text">
+         <string>Image decoration</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QgsFileWidget" name="customImageDecorationFile" native="true"/>
+      </item>
+      <item row="3" column="0" colspan="2">
+       <widget class="QLabel" name="customDetailsLabel">
+        <property name="text">
+         <string>Details expression</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0" colspan="2">
+       <widget class="QPlainTextEdit" name="customDetailsTextEdit">
+        <property name="placeholderText">
+         <string>Leave empty to use the default details string</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="0" colspan="2">
+       <widget class="QPushButton" name="insertExpressionButton">
+        <property name="text">
+         <string>Insert/Edit Expression...</string>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="0" colspan="2">
+       <widget class="QCheckBox" name="forceStampingCheckBox">
+        <property name="text">
+         <string>Always stamp images taken using the QField camera</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="previewGroupBox">
+     <property name="title">
+      <string>Preview</string>
+     </property>
+     <layout class="QVBoxLayout" name="previewLayout">
+      <item>
+       <widget class="QLabel" name="previewLabel">
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+        <property name="text">
+         <string></string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::MinimumExpanding</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>0</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsCollapsibleGroupBox</class>
+   <extends>QGroupBox</extends>
+   <header>qgscollapsiblegroupbox.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>qgsdoublespinbox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>qgsspinbox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsExpressionBuilderWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsexpressionbuilderwidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsFileWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsfilewidget.h</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+ <buttongroups>
+  <buttongroup name="buttonGroup"/>
+ </buttongroups>
+</ui>

--- a/qfieldsync/ui/project_configuration_widget.ui
+++ b/qfieldsync/ui/project_configuration_widget.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>QField</class>
- <widget class="QWidget" name="QField">
+ <class>ProjectConfigurationWidgetBase</class>
+ <widget class="QWidget" name="ProjectConfigurationWidgetBase">
   <property name="geometry">
    <rect>
     <x>0</x>
@@ -15,9 +15,6 @@
     <horstretch>0</horstretch>
     <verstretch>0</verstretch>
    </sizepolicy>
-  </property>
-  <property name="windowTitle">
-   <string>Configure Project for QField Synchronisation</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <property name="leftMargin">
@@ -255,6 +252,20 @@
             <widget class="QLabel" name="maximumImageWidthHeightLabel">
              <property name="text">
               <string>Maximum allowed width or height (in pixels) of image attachments</string>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="0">
+            <widget class="QLabel" name="customizeImageStampingLabel">
+             <property name="text">
+              <string>Customize image stamping details</string>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="1">
+            <widget class="QPushButton" name="customizeImageStampingButton">
+             <property name="text">
+              <string>Settings</string>
              </property>
             </widget>
            </item>

--- a/qfieldsync/ui/project_configuration_widget.ui
+++ b/qfieldsync/ui/project_configuration_widget.ui
@@ -477,35 +477,6 @@
                </property>
               </widget>
              </item>
-             <item row="6" column="0">
-              <widget class="QLabel" name="mapUnitsPerPixelLabel">
-               <property name="text">
-                <string>Map units per pixel</string>
-               </property>
-               <property name="alignment">
-                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-               </property>
-              </widget>
-             </item>
-             <item row="6" column="1">
-              <widget class="QgsDoubleSpinBox" name="mapUnitsPerPixel">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="toolTip">
-                <string>This determines the spatial resolution of the resulting map image. It depends on the CRS of the map canvas. For map units in [m], a value of 1 means each pixel covers an area of 1x1 m, a value of 1000 means 1 pixel per square kilometer.</string>
-               </property>
-               <property name="suffix">
-                <string> mupp</string>
-               </property>
-               <property name="value">
-                <double>99.989999999999995</double>
-               </property>
-              </widget>
-             </item>
              <item row="9" column="0">
               <widget class="QLabel" name="baseMapTilesMaxZoomLevelLabel">
                <property name="text">
@@ -686,7 +657,6 @@
   <tabstop>layerComboBox</tabstop>
   <tabstop>mapThemeComboBox</tabstop>
   <tabstop>tileSize</tabstop>
-  <tabstop>mapUnitsPerPixel</tabstop>
   <tabstop>baseMapTilesMinZoomLevelSpinBox</tabstop>
   <tabstop>baseMapTilesMaxZoomLevelSpinBox</tabstop>
   <tabstop>geofencingGroupBox</tabstop>

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ future
 transifex-client
 
 # NOTE `libqfielsync` version should be defined in the `*.tar.gz` format, not `git+https://` to make `wheel` happy
-libqfieldsync @ https://github.com/opengisch/libqfieldsync/archive/3e580428196af61a68f902d8b8927ed062f389f9.tar.gz
+libqfieldsync @ https://github.com/opengisch/libqfieldsync/archive/cd47deb98ae94fb71529e763931c247656b963bf.tar.gz

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ future
 transifex-client
 
 # NOTE `libqfielsync` version should be defined in the `*.tar.gz` format, not `git+https://` to make `wheel` happy
-libqfieldsync @ https://github.com/opengisch/libqfieldsync/archive/cd47deb98ae94fb71529e763931c247656b963bf.tar.gz
+libqfieldsync @ https://github.com/opengisch/libqfieldsync/archive/d392e40e5f86e89df7d845cd92f3ee169a1867c8.tar.gz


### PR DESCRIPTION
This PR adds image stamping customization functionality, available in the project properties' QField panel. First, screenshot time:

<img width="734" height="689" alt="image" src="https://github.com/user-attachments/assets/577ed4be-ad68-4baf-8bf6-161f422d53fd" />

As the screenshot shows above, the stamping customization widgets are offered in a sub-panel which can be opened by click on its settings button within the attachments tab here:

<img width="734" height="689" alt="image" src="https://github.com/user-attachments/assets/e736496e-2a44-4958-a583-155fc34d07b3" />

I'm quite happy about the introduction of a panels stack here, it should give us plenty of space to grow in the future.

The image stamping customization allows for users to:
- customize the details being stamped via the crafting of an expression-based multiline string
- customize the font color/size/drop shadow/etc. used to render the details
- customize the position (left / center / right) of the details
- add an image decoration overlay on top of the image being stamped
- force stamping of images irrespective of QField's own setting (useful for manager distributing over QFC)

As a result, people can come up with this kind of customized stamping with just a little bit of configuration:

![apiary_20250715152419984](https://github.com/user-attachments/assets/6d01726f-d929-4da9-a46a-29ac733829ac)

_Note the top-left logo and the QFC username detail_

