### PR TITLE
refactor: rename all "localized datasets" to "shared datasets"

### DIFF
--- a/qfieldsync/core/cloud_converter.py
+++ b/qfieldsync/core/cloud_converter.py
@@ -89,7 +89,7 @@ class CloudConverter(QObject):
                     continue
 
                 if layer.dataProvider() is not None:
-                    # layer stored in localized data path, skip
+                    # layer stored in shared dataset path, skip
                     if layer_source.is_localized_path:
                         continue
 

--- a/qfieldsync/gui/cloud_create_project_widget.py
+++ b/qfieldsync/gui/cloud_create_project_widget.py
@@ -273,18 +273,14 @@ class CloudCreateProjectWidget(QWidget, WidgetUi):
                     localizedDataPathLayers.append("- {}".format(layer.name()))
 
         if localizedDataPathLayers:
-            if len(localizedDataPathLayers) == 1:
-                self.infoLocalizedLayersLabel.setText(
-                    self.tr(
-                        "The current project relies on datasets stored in localized data paths, make sure to copy the relevant datasets into the localized data path of devices running QField. The layer stored in a localized data path is:\n{}"
-                    ).format("\n".join(localizedDataPathLayers))
-                )
-            else:
-                self.infoLocalizedLayersLabel.setText(
-                    self.tr(
-                        "The current project relies on datasets stored in localized data paths, make sure to copy the relevant datasets into the localized data path of devices running QField. The layers stored in a localized data path are:\n{}"
-                    ).format("\n".join(localizedDataPathLayers))
-                )
+            self.infoLocalizedLayersLabel.setText(
+                self.tr(
+                    "The current project relies on %n shared dataset(s), make sure to copy them into the shared datasets path of devices running QField. The layer(s) stored in a shared dataset(s) are:\n{}",
+                    "",
+                    len(localizedDataPathLayers),
+                ).format("\n".join(localizedDataPathLayers))
+            )
+
             self.infoLocalizedLayersLabel.setVisible(True)
         else:
             self.infoLocalizedLayersLabel.setVisible(False)

--- a/qfieldsync/gui/cloud_transfer_dialog.py
+++ b/qfieldsync/gui/cloud_transfer_dialog.py
@@ -428,7 +428,7 @@ class CloudTransferDialog(QDialog, CloudTransferDialogUi):
             len(self.localized_datasets_files) != 0
         )
         self.uploadLocalizedDatasetsCheck.setToolTip(
-            self.tr("Localized datasets files to upload: {}").format(
+            self.tr("Shared datasets files to upload: {}").format(
                 ", ".join([f.name for f in self.localized_datasets_files])
             )
         )
@@ -1045,16 +1045,11 @@ class CloudTransferDialog(QDialog, CloudTransferDialogUi):
 
         localized_datasets_upload_message = ""
         if localized_datasets_upload_count:
-            if localized_datasets_upload_count > 1:
-                localized_datasets_upload_message += self.tr(
-                    "{} localized datasets to copy to QFieldCloud.".format(
-                        localized_datasets_upload_count
-                    )
-                )
-            elif localized_datasets_upload_count == 1:
-                localized_datasets_upload_message += self.tr(
-                    "1 localized dataset to copy to QFieldCloud."
-                )
+            localized_datasets_upload_message += self.tr(
+                "%n shared dataset(s) to copy to QFieldCloud.",
+                "",
+                localized_datasets_upload_count,
+            )
 
             self.localizedDatasetsUploadProgressBar.setValue(0)
             self.localizedDatasetsUploadProgressBar.setEnabled(True)
@@ -1062,6 +1057,7 @@ class CloudTransferDialog(QDialog, CloudTransferDialogUi):
             self.localizedDatasetsUploadProgressBar.setValue(100)
             self.localizedDatasetsUploadProgressBar.setEnabled(False)
             localized_datasets_upload_message = self.tr("Nothing to do on QFieldCloud.")
+
         self.localizedDatasetsUploadProgressFeedbackLabel.setText(
             localized_datasets_upload_message
         )

--- a/qfieldsync/gui/package_dialog.py
+++ b/qfieldsync/gui/package_dialog.py
@@ -303,18 +303,14 @@ class PackageDialog(QDialog, DialogUi):
                 localizedDataPathLayers.append("- {}".format(layer.name()))
 
         if localizedDataPathLayers:
-            if len(localizedDataPathLayers) == 1:
-                self.infoLocalizedLayersLabel.setText(
-                    self.tr(
-                        "The current project relies on datasets stored in localized data paths, make sure to copy the relevant datasets into the localized data path of devices running QField. The layer stored in a localized data path is:\n{}"
-                    ).format("\n".join(localizedDataPathLayers))
-                )
-            else:
-                self.infoLocalizedLayersLabel.setText(
-                    self.tr(
-                        "The current project relies on datasets stored in localized data paths, make sure to copy the relevant datasets into the localized data path of devices running QField. The layers stored in a localized data path are:\n{}"
-                    ).format("\n".join(localizedDataPathLayers))
-                )
+            self.infoLocalizedLayersLabel.setText(
+                self.tr(
+                    "The current project relies on %n shared dataset(s), make sure to copy them into the shared datasets path of devices running QField. The layer(s) stored in a shared dataset(s) are:\n{}",
+                    "",
+                    len(localizedDataPathLayers),
+                ).format("\n".join(localizedDataPathLayers))
+            )
+
             self.infoLocalizedLayersLabel.setVisible(True)
         else:
             self.infoLocalizedLayersLabel.setVisible(False)

--- a/qfieldsync/ui/cloud_transfer_dialog.ui
+++ b/qfieldsync/ui/cloud_transfer_dialog.ui
@@ -280,7 +280,7 @@
          <item>
           <widget class="QLabel" name="localizedDatasetsUploadLabel">
            <property name="text">
-            <string>Uploading localized datasets</string>
+            <string>Uploading shared datasets</string>
            </property>
           </widget>
          </item>
@@ -470,7 +470,7 @@
        <item>
         <widget class="QCheckBox" name="uploadLocalizedDatasetsCheck">
          <property name="text">
-          <string>Upload missing localized dataset(s)</string>
+          <string>Upload missing shared dataset(s)</string>
          </property>
          <property name="checked">
           <bool>false</bool>

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ future
 transifex-client
 
 # NOTE `libqfielsync` version should be defined in the `*.tar.gz` format, not `git+https://` to make `wheel` happy
-libqfieldsync @ https://github.com/opengisch/libqfieldsync/archive/d392e40e5f86e89df7d845cd92f3ee169a1867c8.tar.gz
+libqfieldsync @ https://github.com/opengisch/libqfieldsync/archive/0d143dd958c38595bca8ade31293521182f7a3a2.tar.gz


### PR DESCRIPTION
See https://github.com/opengisch/libqfieldsync/pull/120

Also took the opportunity to remove some code branching for pluralization that is actually taken care of by Transifex+translators+qt translation framework.

See the table in the plurals section: https://doc.qt.io/archives/qt-5.15/i18n-source-translation.html#handling-plurals