### PR TITLE
Fix typo which leads to base map check not respecting configuration

### DIFF
--- a/qfieldsync/ui/project_configuration_widget.ui
+++ b/qfieldsync/ui/project_configuration_widget.ui
@@ -322,7 +322,7 @@
             <property name="checkable">
              <bool>true</bool>
             </property>
-            <property name="saveCheckedState">
+            <property name="saveCollapsedState">
              <bool>true</bool>
             </property>
             <property name="collapsed">


### PR DESCRIPTION
A copy/paste typo has led to base map checkbox not respecting the configuration, this PR fixes that.