### PR TITLE
fix: do not pass lambdas on deletable objects from qt

### DIFF
--- a/qfieldsync/gui/cloud_transfer_dialog.py
+++ b/qfieldsync/gui/cloud_transfer_dialog.py
@@ -79,10 +79,10 @@ class CloudTransferDialog(QDialog, CloudTransferDialogUi):
     @staticmethod
     def show_transfer_dialog(
         network_manager: CloudNetworkAccessManager,
-        cloud_project: CloudProject = None,
-        accepted_cb: Callable = None,
-        rejected_cb: Callable = None,
-        parent: QWidget = None,
+        cloud_project: CloudProject | None = None,
+        accepted_cb: Callable | None = None,
+        rejected_cb: Callable | None = None,
+        parent: QWidget | None = None,
     ):
         if CloudTransferDialog.instance:
             CloudTransferDialog.instance.show()


### PR DESCRIPTION
Passing lambdas in qt signal handlers makes code easier to write (and perhaps read), but adds an unexpected reference to object that is not deleted (the lambda function) and keeps the whole reference of a Qt Object that should have been deleted already.

Steps to reproduce:
1) open QFieldSync
2) disable/enable the plugin multiple times very fast (or use Plugin Reloader)
3) you should be presented with an error like:

```
RuntimeError: wrapped C/C++ object of type QFieldCloudRootItem has been deleted
Traceback (most recent call last):
  File "/home/suricactus/.local/share/QGIS/QGIS3/profiles/default/python/plugins/qfieldsync/gui/cloud_browser_tree.py", line 79, in
    self.network_manager.token_changed.connect(lambda: self.update_icon())
                                                       ^^^^^^^^^^^^^^^^^^
  File "/home/suricactus/.local/share/QGIS/QGIS3/profiles/default/python/plugins/qfieldsync/gui/cloud_browser_tree.py", line 123, in update_icon
    self.setIcon(
RuntimeError: wrapped C/C++ object of type QFieldCloudRootItem has been deleted
```

Fixed a few typing problems on the way.

Fixes #558 #701