### PR TITLE
fix: do not allow "Directly access datasource" on QFieldCloud packaging actions for file based layers that are not readonly

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ future
 transifex-client
 
 # NOTE `libqfielsync` version should be defined in the `*.tar.gz` format, not `git+https://` to make `wheel` happy
-libqfieldsync @ https://github.com/opengisch/libqfieldsync/archive/0d143dd958c38595bca8ade31293521182f7a3a2.tar.gz
+libqfieldsync @ https://github.com/opengisch/libqfieldsync/archive/98fb04b54255dfc9fd80d409c1c12b0e7e5f39cd.tar.gz


### PR DESCRIPTION
See https://github.com/opengisch/libqfieldsync/pull/121