### PR TITLE
Add a nifty search bar to filter cloud projects table

### DIFF
--- a/qfieldsync/gui/cloud_projects_dialog.py
+++ b/qfieldsync/gui/cloud_projects_dialog.py
@@ -142,6 +142,8 @@ class CloudProjectsDialog(QDialog, CloudProjectsDialogUi):
         self.projectsType.setCurrentIndex(0)
         self.projectsType.currentIndexChanged.connect(lambda: self.show_projects())
 
+        self.projectsSearch.textChanged.connect(self.filter_projects_search)
+
         self.projectsTable.setColumnWidth(0, int(self.projectsTable.width() * 0.75))
         self.projectsTable.setColumnWidth(1, int(self.projectsTable.width() * 0.2))
 
@@ -552,6 +554,20 @@ class CloudProjectsDialog(QDialog, CloudProjectsDialogUi):
     def on_refresh_button_clicked(self) -> None:
         self.network_manager.projects_cache.refresh()
 
+    def filter_projects_search(self) -> None:
+        filter_text = self.projectsSearch.text().lower()
+        for row in range(self.projectsTable.rowCount()):
+            if filter_text:
+                item = self.projectsTable.item(row, 0)
+                cloud_project = item.data(Qt.UserRole)
+                cloud_project_is_visible = (
+                    filter_text in cloud_project.name.lower()
+                    or filter_text in cloud_project.owner.lower()
+                )
+                self.projectsTable.setRowHidden(row, not cloud_project_is_visible)
+            else:
+                self.projectsTable.setRowHidden(row, False)
+
     def show_projects(self) -> None:
         self.set_feedback(None)
 
@@ -641,6 +657,7 @@ class CloudProjectsDialog(QDialog, CloudProjectsDialogUi):
         self.projectsTable.sortByColumn(1, Qt.AscendingOrder)
         self.projectsTable.sortByColumn(0, Qt.AscendingOrder)
         self.projectsTable.setSortingEnabled(True)
+        self.filter_projects_search()
         self.update_project_table_selection()
 
         if self._suggest_upload_files:

--- a/qfieldsync/ui/cloud_projects_dialog.ui
+++ b/qfieldsync/ui/cloud_projects_dialog.ui
@@ -129,6 +129,16 @@
         <widget class="QComboBox" name="projectsType"/>
        </item>
        <item>
+        <widget class="QgsFilterLineEdit" name="projectsSearch">
+         <property name="showSearchIcon">
+          <bool>true</bool>
+         </property>
+         <property name="placeholderText">
+          <string>Search for project…</string>
+         </property>
+        </widget>
+       </item>
+       <item>
         <widget class="QTableWidget" name="projectsTable">
          <property name="enabled">
           <bool>false</bool>
@@ -703,6 +713,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsFilterLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header>qgsfilterlineedit.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>


### PR DESCRIPTION
Because at one point, there are just too many projects not to want to have access to a search filter:

https://github.com/user-attachments/assets/8695aaa1-7949-4647-8a30-714141a10c6a

It also harmonizes the list with that offered on app.qfield.cloud as well as QField, both of which can be searched / filtered.