### PR TITLE
Prevent choosing the same directory as packaging destination for QFieldSync cable packaging

### DIFF
--- a/qfieldsync/gui/package_dialog.py
+++ b/qfieldsync/gui/package_dialog.py
@@ -213,6 +213,28 @@ class PackageDialog(QDialog, DialogUi):
         self.button_box.button(QDialogButtonBox.StandardButton.Save).setEnabled(False)
 
         packaged_project_file = Path(self.packagedProjectFileWidget.filePath())
+        packaged_project_dir = packaged_project_file.parent
+        open_project_path = self.project.fileName()
+        open_project_dir = Path(open_project_path).parent
+
+        if open_project_dir.resolve() == packaged_project_dir.resolve():
+            QMessageBox.critical(
+                self,
+                self.tr("Invalid Export Directory"),
+                self.tr(
+                    "The export directory cannot be the same as the source project directory.\n"
+                    "Please choose a different folder for the packaged project."
+                ),
+            )
+            return
+            self.button_box.button(QDialogButtonBox.StandardButton.Save).setEnabled(
+                False
+            )
+        else:
+            self.button_box.button(QDialogButtonBox.StandardButton.Save).setEnabled(
+                True
+            )
+
         area_of_interest = (
             self.__project_configuration.area_of_interest
             if self.__project_configuration.area_of_interest


### PR DESCRIPTION
This PR fixes https://github.com/opengisch/qfieldsync/issues/704

This is how looks:

!![](https://github.com/user-attachments/assets/9bd833a0-d3a0-4957-bfd8-ca45b89affe6)
