### PR TITLE
improve qt6 support

### DIFF
--- a/qfieldsync/core/cloud_api.py
+++ b/qfieldsync/core/cloud_api.py
@@ -64,7 +64,7 @@ class CloudException(Exception):
         super(CloudException, self).__init__(exception)
         self.reply = reply
         self.parent = exception
-        self.httpCode = reply.attribute(QNetworkRequest.HttpStatusCodeAttribute)
+        self.httpCode = reply.attribute(QNetworkRequest.Attribute.HttpStatusCodeAttribute)
 
 
 class disable_nam_timeout:
@@ -86,14 +86,14 @@ class disable_nam_timeout:
 
 
 def from_reply(reply: QNetworkReply) -> Optional[CloudException]:
-    if reply.error() == QNetworkReply.NoError:
+    if reply.error() == QNetworkReply.NetworkError.NoError:
         return None
 
     message = ""
     try:
         payload = reply.readAll().data()
         # workaround to https://github.com/qgis/QGIS/issues/49687
-        content_length = reply.header(QNetworkRequest.ContentLengthHeader)
+        content_length = reply.header(QNetworkRequest.KnownHeaders.ContentLengthHeader)
         payload = payload[:content_length].decode()
 
         try:
@@ -114,7 +114,7 @@ def from_reply(reply: QNetworkReply) -> Optional[CloudException]:
     if not message:
         status_str = ""
 
-        http_status = reply.attribute(QNetworkRequest.HttpStatusCodeAttribute)
+        http_status = reply.attribute(QNetworkRequest.Attribute.HttpStatusCodeAttribute)
         if http_status is not None:
             status_str += f"HTTP-{http_status}/"
 
@@ -413,16 +413,16 @@ class CloudNetworkAccessManager(QObject):
 
         request = QNetworkRequest(url)
         request.setAttribute(
-            QNetworkRequest.RedirectPolicyAttribute,
-            QNetworkRequest.NoLessSafeRedirectPolicy,
+            QNetworkRequest.Attribute.RedirectPolicyAttribute,
+            QNetworkRequest.RedirectPolicy.NoLessSafeRedirectPolicy,
         )
 
         if skip_cache:
             request.setAttribute(
-                QNetworkRequest.CacheLoadControlAttribute, QNetworkRequest.AlwaysNetwork
+                QNetworkRequest.Attribute.CacheLoadControlAttribute, QNetworkRequest.CacheLoadControl.AlwaysNetwork
             )
 
-        request.setHeader(QNetworkRequest.ContentTypeHeader, "application/json")
+        request.setHeader(QNetworkRequest.KnownHeaders.ContentTypeHeader, "application/json")
 
         if self._token:
             request.setRawHeader(
@@ -449,13 +449,13 @@ class CloudNetworkAccessManager(QObject):
     ) -> QNetworkReply:
         request = QNetworkRequest(url)
         request.setAttribute(
-            QNetworkRequest.RedirectPolicyAttribute,
-            QNetworkRequest.UserVerifiedRedirectPolicy,
+            QNetworkRequest.Attribute.RedirectPolicyAttribute,
+            QNetworkRequest.RedirectPolicy.UserVerifiedRedirectPolicy,
         )
 
         if skip_cache:
             request.setAttribute(
-                QNetworkRequest.CacheLoadControlAttribute, QNetworkRequest.AlwaysNetwork
+                QNetworkRequest.Attribute.CacheLoadControlAttribute, QNetworkRequest.CacheLoadControl.AlwaysNetwork
             )
 
         with disable_nam_timeout(self._nam):
@@ -476,7 +476,7 @@ class CloudNetworkAccessManager(QObject):
     def _on_cloud_get_download_finished(
         self, reply: QNetworkReply, local_filename: str
     ) -> None:
-        http_code = reply.attribute(QNetworkRequest.HttpStatusCodeAttribute)
+        http_code = reply.attribute(QNetworkRequest.Attribute.HttpStatusCodeAttribute)
         if http_code is not None and http_code >= 301 and http_code <= 308:
             # redirects should not be saved as files, just ignore them
             return
@@ -494,8 +494,7 @@ class CloudNetworkAccessManager(QObject):
         self._clear_cloud_cookies(url)
 
         request = QNetworkRequest(url)
-        request.setAttribute(QNetworkRequest.FollowRedirectsAttribute, True)
-        request.setHeader(QNetworkRequest.ContentTypeHeader, "application/json")
+        request.setHeader(QNetworkRequest.KnownHeaders.ContentTypeHeader, "application/json")
 
         if self._token:
             request.setRawHeader(
@@ -520,8 +519,7 @@ class CloudNetworkAccessManager(QObject):
         self._clear_cloud_cookies(url)
 
         request = QNetworkRequest(url)
-        request.setAttribute(QNetworkRequest.FollowRedirectsAttribute, True)
-        request.setHeader(QNetworkRequest.ContentTypeHeader, "application/json")
+        request.setHeader(QNetworkRequest.KnownHeaders.ContentTypeHeader, "application/json")
 
         if self._token:
             request.setRawHeader(
@@ -546,8 +544,7 @@ class CloudNetworkAccessManager(QObject):
         self._clear_cloud_cookies(url)
 
         request = QNetworkRequest(url)
-        request.setAttribute(QNetworkRequest.FollowRedirectsAttribute, True)
-        request.setHeader(QNetworkRequest.ContentTypeHeader, "application/json")
+        request.setHeader(QNetworkRequest.KnownHeaders.ContentTypeHeader, "application/json")
 
         if self._token:
             request.setRawHeader(
@@ -570,8 +567,7 @@ class CloudNetworkAccessManager(QObject):
         self._clear_cloud_cookies(url)
 
         request = QNetworkRequest(url)
-        request.setAttribute(QNetworkRequest.FollowRedirectsAttribute, True)
-        request.setHeader(QNetworkRequest.ContentTypeHeader, "application/json")
+        request.setHeader(QNetworkRequest.KnownHeaders.ContentTypeHeader, "application/json")
 
         if self._token:
             request.setRawHeader(
@@ -594,7 +590,6 @@ class CloudNetworkAccessManager(QObject):
         self._clear_cloud_cookies(url)
 
         request = QNetworkRequest(url)
-        request.setAttribute(QNetworkRequest.FollowRedirectsAttribute, True)
 
         if self._token:
             request.setRawHeader(
@@ -611,9 +606,9 @@ class CloudNetworkAccessManager(QObject):
         if payload is not None:
             json_part = QHttpPart()
 
-            json_part.setHeader(QNetworkRequest.ContentTypeHeader, "application/json")
+            json_part.setHeader(QNetworkRequest.KnownHeaders.ContentTypeHeader, "application/json")
             json_part.setHeader(
-                QNetworkRequest.ContentDispositionHeader, 'form-data; name="json"'
+                QNetworkRequest.KnownHeaders.ContentDispositionHeader, 'form-data; name="json"'
             )
             json_part.setBody(json.dumps(payload).encode("utf-8"))
 
@@ -626,7 +621,7 @@ class CloudNetworkAccessManager(QObject):
                 file_part = QHttpPart()
                 file_part.setBody(file.read())
                 file_part.setHeader(
-                    QNetworkRequest.ContentDispositionHeader,
+                    QNetworkRequest.KnownHeaders.ContentDispositionHeader,
                     'form-data; name="file"; filename="{}"'.format(filename),
                 )
 
@@ -722,9 +717,9 @@ class CloudNetworkAccessManager(QObject):
             reply = self._login_error.reply
 
             if (
-                reply.error() == QNetworkReply.HostNotFoundError
+                reply.error() == QNetworkReply.NetworkError.HostNotFoundError
                 # network unreachable goes here
-                or reply.error() == QNetworkReply.UnknownNetworkError
+                or reply.error() == QNetworkReply.NetworkError.UnknownNetworkError
             ):
                 error_str = self.tr(
                     "Failed to connect to {}. Check your internet connection.".format(
@@ -1012,7 +1007,7 @@ class CloudProjectsCache(QObject):
                 self._fs_watcher.addPath(project.local_dir)
 
     def _on_get_projects_reply_finished(self, reply: QNetworkReply) -> None:
-        if reply.error() == QNetworkReply.OperationCanceledError:
+        if reply.error() == QNetworkReply.NetworkError.OperationCanceledError:
             return
 
         self._projects_reply = None

--- a/qfieldsync/core/cloud_transferrer.py
+++ b/qfieldsync/core/cloud_transferrer.py
@@ -662,7 +662,7 @@ class FileTransfer(QObject):
             return False
 
         return self.last_reply.isFinished() and (
-            self.error is not None or self.last_reply.error() != QNetworkReply.NoError
+            self.error is not None or self.last_reply.error() != QNetworkReply.NetworkError.NoError
         )
 
 
@@ -806,7 +806,7 @@ class TransferFileLogsModel(QAbstractListModel):
         if index.row() < 0 or index.row() >= self.rowCount(QModelIndex()):
             return None
 
-        if role == Qt.DisplayRole:
+        if role == Qt.ItemDataRole.DisplayRole:
             return self._data_string(self.transfers[index.row()])
 
         return None
@@ -919,4 +919,4 @@ class TransferFileLogsModel(QAbstractListModel):
         row = self.filename_to_index[filename]
         index = self.createIndex(row, 0)
 
-        self.dataChanged.emit(index, index, [Qt.DisplayRole])
+        self.dataChanged.emit(index, index, [Qt.ItemDataRole.DisplayRole])

--- a/qfieldsync/gui/attachment_naming_widget.py
+++ b/qfieldsync/gui/attachment_naming_widget.py
@@ -54,11 +54,11 @@ class AttachmentNamingTableWidget(QTableWidget):
 
             self.insertRow(row)
             item = QTableWidgetItem(layer.name())
-            item.setData(Qt.UserRole, layer_source)
-            item.setFlags(Qt.ItemIsEnabled)
+            item.setData(Qt.ItemDataRole.UserRole, layer_source)
+            item.setFlags(Qt.ItemFlag.ItemIsEnabled)
             self.setItem(row, 0, item)
             item = QTableWidgetItem(field_name)
-            item.setFlags(Qt.ItemIsEnabled)
+            item.setFlags(Qt.ItemFlag.ItemIsEnabled)
             self.setItem(row, 1, item)
             ew = QgsFieldExpressionWidget()
             ew.setLayer(layer)
@@ -72,7 +72,7 @@ class AttachmentNamingTableWidget(QTableWidget):
 
     def syncLayerSourceValues(self, should_apply=False):
         for i in range(self.rowCount()):
-            layer_source = self.item(i, 0).data(Qt.UserRole)
+            layer_source = self.item(i, 0).data(Qt.ItemDataRole.UserRole)
             field_name = self.item(i, 1).text()
             new_expression = self.cellWidget(i, 2).currentText()
             layer_source.set_attachment_naming(field_name, new_expression)

--- a/qfieldsync/gui/checker_feedback_table.py
+++ b/qfieldsync/gui/checker_feedback_table.py
@@ -38,7 +38,7 @@ class CheckerFeedbackTable(QTableWidget):
         self.horizontalHeader().setStretchLastSection(True)
         self.setRowCount(0)
         self.setMinimumHeight(100)
-        self.setSizePolicy(QSizePolicy.MinimumExpanding, QSizePolicy.MinimumExpanding)
+        self.setSizePolicy(QSizePolicy.Policy.MinimumExpanding, QSizePolicy.Policy.MinimumExpanding)
 
         for layer_id in checker_feedback.feedbacks.keys():
             for feedback in checker_feedback.feedbacks[layer_id]:
@@ -55,7 +55,7 @@ class CheckerFeedbackTable(QTableWidget):
                     level_text = self.tr("Error")
 
                 item = QTableWidgetItem(level_icon, "")
-                item.setFlags(Qt.ItemIsEnabled)
+                item.setFlags(Qt.ItemFlag.ItemIsEnabled)
                 item.setToolTip(level_text)
                 self.setItem(row, 0, item)
 
@@ -66,7 +66,7 @@ class CheckerFeedbackTable(QTableWidget):
                     source = self.tr("Project")
 
                 item = QTableWidgetItem()
-                item.setFlags(Qt.ItemIsEnabled)
+                item.setFlags(Qt.ItemFlag.ItemIsEnabled)
                 item.setToolTip(level_text)
                 self.setItem(row, 1, item)
 
@@ -74,12 +74,12 @@ class CheckerFeedbackTable(QTableWidget):
                 label = QLabel("**{}**\n\n{}".format(source, feedback.message))
                 label.setWordWrap(True)
                 label.setMargin(5)
-                label.setTextFormat(Qt.MarkdownText)
+                label.setTextFormat(Qt.TextFormat.MarkdownText)
                 label.setTextInteractionFlags(
-                    Qt.TextSelectableByMouse
-                    | Qt.TextSelectableByKeyboard
-                    | Qt.LinksAccessibleByMouse
-                    | Qt.LinksAccessibleByKeyboard
+                    Qt.TextInteractionFlag.TextSelectableByMouse
+                    | Qt.TextInteractionFlag.TextSelectableByKeyboard
+                    | Qt.TextInteractionFlag.LinksAccessibleByMouse
+                    | Qt.TextInteractionFlag.LinksAccessibleByKeyboard
                 )
                 label.setOpenExternalLinks(True)
                 self.setCellWidget(row, 1, label)

--- a/qfieldsync/gui/cloud_create_project_widget.py
+++ b/qfieldsync/gui/cloud_create_project_widget.py
@@ -162,7 +162,7 @@ class CloudCreateProjectWidget(QWidget, WidgetUi):
             )
             return
 
-        QApplication.setOverrideCursor(Qt.WaitCursor)
+        QApplication.setOverrideCursor(Qt.CursorShape.WaitCursor)
 
         self.stackedWidget.setCurrentWidget(self.progressPage)
         self.convertProgressBar.setVisible(True)
@@ -186,7 +186,7 @@ class CloudCreateProjectWidget(QWidget, WidgetUi):
                 critical_message = self.tr(
                     "The project could not be converted into the export directory."
                 )
-                self.iface.messageBar().pushMessage(critical_message, Qgis.Critical, 0)
+                self.iface.messageBar().pushMessage(critical_message, Qgis.MessageLevel.Critical, 0)
                 self.close()
                 return
 

--- a/qfieldsync/gui/cloud_login_dialog.py
+++ b/qfieldsync/gui/cloud_login_dialog.py
@@ -161,7 +161,7 @@ class CloudLoginDialog(QDialog, CloudLoginDialogUi):
             self.activateWindow()
 
     def on_login_button_clicked(self) -> None:
-        QApplication.setOverrideCursor(Qt.WaitCursor)
+        QApplication.setOverrideCursor(Qt.CursorShape.WaitCursor)
 
         self.buttonBox.button(QDialogButtonBox.StandardButton.Ok).setEnabled(False)
         self.rememberMeCheckBox.setEnabled(False)

--- a/qfieldsync/gui/cloud_projects_dialog.py
+++ b/qfieldsync/gui/cloud_projects_dialog.py
@@ -315,7 +315,7 @@ class CloudProjectsDialog(QDialog, CloudProjectsDialogUi):
     def on_projects_cached_projects_started(self) -> None:
         self.projectsStack.setEnabled(False)
         self.set_feedback(
-            self.tr("Loading projects list…"), self.palette().color(QPalette.WindowText)
+            self.tr("Loading projects list…"), self.palette().color(QPalette.ColorRole.WindowText)
         )
 
     def on_projects_cached_projects_error(self, error: str) -> None:
@@ -344,8 +344,8 @@ class CloudProjectsDialog(QDialog, CloudProjectsDialogUi):
         )
 
     def on_project_files_toggle_expand_button_clicked(self) -> None:
-        should_expand = not self.projectFilesTree.topLevelItem(0).data(1, Qt.UserRole)
-        self.projectFilesTree.topLevelItem(0).setData(1, Qt.UserRole, should_expand)
+        should_expand = not self.projectFilesTree.topLevelItem(0).data(1, Qt.ItemDataRole.UserRole)
+        self.projectFilesTree.topLevelItem(0).setData(1, Qt.ItemDataRole.UserRole, should_expand)
 
         for idx in range(self.projectFilesTree.topLevelItemCount()):
             self.expand_state(self.projectFilesTree.topLevelItem(idx), should_expand)
@@ -404,7 +404,7 @@ class CloudProjectsDialog(QDialog, CloudProjectsDialogUi):
                 # the length of the stack and the parts is equal for file entries
                 if len(stack) == len(parts):
                     item.setToolTip(0, project_file.name)
-                    item.setData(0, Qt.UserRole, project_file)
+                    item.setData(0, Qt.ItemDataRole.UserRole, project_file)
 
                     item.setText(1, str(project_file.size))
                     item.setTextAlignment(1, Qt.AlignmentFlag.AlignRight)
@@ -414,7 +414,7 @@ class CloudProjectsDialog(QDialog, CloudProjectsDialogUi):
                     for version_idx, version_obj in enumerate(project_file.versions):
                         version_item = QTreeWidgetItem()
 
-                        version_item.setData(0, Qt.UserRole, version_obj)
+                        version_item.setData(0, Qt.ItemDataRole.UserRole, version_obj)
                         # TODO remove default value `versions_count - version_idx`, the "display" key is standard for newer QFC releases
                         version_display = version_obj.get(
                             "display", versions_count - version_idx
@@ -567,7 +567,7 @@ class CloudProjectsDialog(QDialog, CloudProjectsDialogUi):
                 self.tr(
                     "You don't have any projects, create your first one by clicking the button in the bottom bar."
                 ),
-                self.palette().color(QPalette.WindowText),
+                self.palette().color(QPalette.ColorRole.WindowText),
             )
             return
 
@@ -598,10 +598,10 @@ class CloudProjectsDialog(QDialog, CloudProjectsDialogUi):
                 raise NotImplementedError()
 
             pm = QPixmap(40, 20)
-            pm.fill(Qt.transparent)
+            pm.fill(Qt.GlobalColor.transparent)
             painter = QPainter(pm)
-            painter.setPen(QPen(color, 8, Qt.SolidLine))
-            painter.setBrush(QBrush(color, Qt.SolidPattern))
+            painter.setPen(QPen(color, 8, Qt.PenStyle.SolidLine))
+            painter.setBrush(QBrush(color, Qt.BrushStyle.SolidPattern))
             painter.drawEllipse(30, 10, 5, 5)
             icon = QIcon(
                 str(
@@ -615,10 +615,10 @@ class CloudProjectsDialog(QDialog, CloudProjectsDialogUi):
             painter.drawPixmap(0, 0, icon.pixmap(pm.size()))
             del painter
 
-            item.setData(Qt.UserRole, cloud_project)
-            item.setData(Qt.EditRole, cloud_project.name)
+            item.setData(Qt.ItemDataRole.UserRole, cloud_project)
+            item.setData(Qt.ItemDataRole.EditRole, cloud_project.name)
             item.setData(
-                Qt.DecorationRole,
+                Qt.ItemDataRole.DecorationRole,
                 pm,
             )
 
@@ -638,8 +638,8 @@ class CloudProjectsDialog(QDialog, CloudProjectsDialogUi):
             self.projectsTable.setItem(count, 0, item)
             self.projectsTable.setItem(count, 1, QTableWidgetItem(cloud_project.owner))
 
-        self.projectsTable.sortByColumn(1, Qt.AscendingOrder)
-        self.projectsTable.sortByColumn(0, Qt.AscendingOrder)
+        self.projectsTable.sortByColumn(1, Qt.SortOrder.AscendingOrder)
+        self.projectsTable.sortByColumn(0, Qt.SortOrder.AscendingOrder)
         self.projectsTable.setSortingEnabled(True)
         self.update_project_table_selection()
 
@@ -881,17 +881,17 @@ class CloudProjectsDialog(QDialog, CloudProjectsDialogUi):
         )
         self.createdAtLabelValue.setText(
             QDateTime.fromString(
-                self.current_cloud_project.created_at, Qt.ISODateWithMs
+                self.current_cloud_project.created_at, Qt.DateFormat.ISODateWithMs
             ).toString()
         )
         self.updatedAtLabelValue.setText(
             QDateTime.fromString(
-                self.current_cloud_project.updated_at, Qt.ISODateWithMs
+                self.current_cloud_project.updated_at, Qt.DateFormat.ISODateWithMs
             ).toString()
         )
         self.lastSyncedAtLabelValue.setText(
             QDateTime.fromString(
-                self.current_cloud_project.updated_at, Qt.ISODateWithMs
+                self.current_cloud_project.updated_at, Qt.DateFormat.ISODateWithMs
             ).toString()
         )
 
@@ -977,7 +977,7 @@ class CloudProjectsDialog(QDialog, CloudProjectsDialogUi):
 
     def on_create_project_error(self, message) -> None:
         self.set_feedback(message)
-        iface.messageBar().pushMessage(message, Qgis.Critical, 0)
+        iface.messageBar().pushMessage(message, Qgis.MessageLevel.Critical, 0)
 
     def on_create_project_canceled(self) -> None:
         self.projectsStack.setCurrentWidget(self.projectsListPage)
@@ -1032,7 +1032,7 @@ class CloudProjectsDialog(QDialog, CloudProjectsDialogUi):
 
         for row_idx in range(self.projectsTable.rowCount()):
             cloud_project: CloudProject = self.projectsTable.item(row_idx, 0).data(
-                Qt.UserRole
+                Qt.ItemDataRole.UserRole
             )
             is_currently_open_project = (
                 cloud_project
@@ -1051,11 +1051,11 @@ class CloudProjectsDialog(QDialog, CloudProjectsDialogUi):
                 index = self.projectsTable.model().index(row_idx, 0)
                 self.projectsTable.setCurrentIndex(index)
                 self.projectsTable.selectionModel().select(
-                    index, QItemSelectionModel.ClearAndSelect | QItemSelectionModel.Rows
+                    index, QItemSelectionModel.SelectionFlag.ClearAndSelect | QItemSelectionModel.SelectionFlag.Rows
                 )
                 self.projectsTable.scrollToItem(
                     self.projectsTable.item(row_idx, 0),
-                    QAbstractItemView.EnsureVisible,
+                    QAbstractItemView.ScrollHint.EnsureVisible,
                 )
 
             self.update_project_buttons()
@@ -1078,7 +1078,7 @@ class CloudProjectsDialog(QDialog, CloudProjectsDialogUi):
         if self.projectsTable.selectionModel().hasSelection():
             row_idx = self.projectsTable.currentRow()
             self.current_cloud_project = self.projectsTable.item(row_idx, 0).data(
-                Qt.UserRole
+                Qt.ItemDataRole.UserRole
             )
 
         self.update_project_buttons()
@@ -1091,7 +1091,7 @@ class CloudProjectsDialog(QDialog, CloudProjectsDialogUi):
             has_selection = True
             row_idx = self.projectsTable.currentRow()
             self.current_cloud_project = self.projectsTable.item(row_idx, 0).data(
-                Qt.UserRole
+                Qt.ItemDataRole.UserRole
             )
             assert self.current_cloud_project
 

--- a/qfieldsync/gui/cloud_transfer_dialog.py
+++ b/qfieldsync/gui/cloud_transfer_dialog.py
@@ -141,17 +141,17 @@ class CloudTransferDialog(QDialog, CloudTransferDialogUi):
         self.filesTree.expandAll()
 
         self.filesTree.model().setHeaderData(
-            1, Qt.Horizontal, make_icon("computer.svg"), Qt.DecorationRole
+            1, Qt.Orientation.Horizontal, make_icon("computer.svg"), Qt.ItemDataRole.DecorationRole
         )
         self.filesTree.model().setHeaderData(
-            3, Qt.Horizontal, make_icon("cloud.svg"), Qt.DecorationRole
+            3, Qt.Orientation.Horizontal, make_icon("cloud.svg"), Qt.ItemDataRole.DecorationRole
         )
-        self.filesTree.model().setHeaderData(1, Qt.Horizontal, "", Qt.DisplayRole)
-        self.filesTree.model().setHeaderData(2, Qt.Horizontal, "", Qt.DisplayRole)
-        self.filesTree.model().setHeaderData(3, Qt.Horizontal, "", Qt.DisplayRole)
+        self.filesTree.model().setHeaderData(1, Qt.Orientation.Horizontal, "", Qt.ItemDataRole.DisplayRole)
+        self.filesTree.model().setHeaderData(2, Qt.Orientation.Horizontal, "", Qt.ItemDataRole.DisplayRole)
+        self.filesTree.model().setHeaderData(3, Qt.Orientation.Horizontal, "", Qt.ItemDataRole.DisplayRole)
         # The following does not change the icon alignment:
-        # self.filesTree.model().setHeaderData(1, Qt.Horizontal, Qt.AlignCenter, Qt.TextAlignmentRole)
-        # self.filesTree.model().setHeaderData(3, Qt.Horizontal, Qt.AlignCenter, Qt.TextAlignmentRole)
+        # self.filesTree.model().setHeaderData(1, Qt.Orientation.Horizontal, Qt.AlignCenter, Qt.TextAlignmentRole)
+        # self.filesTree.model().setHeaderData(3, Qt.Orientation.Horizontal, Qt.AlignCenter, Qt.TextAlignmentRole)
 
         self._update_window_title()
 
@@ -540,7 +540,7 @@ class CloudTransferDialog(QDialog, CloudTransferDialogUi):
 
                 # the length of the stack and the parts is equal for file entries
                 if len(stack) == len(parts):
-                    item.setData(0, Qt.UserRole, project_file)
+                    item.setData(0, Qt.ItemDataRole.UserRole, project_file)
                     is_offline_layer = (
                         project_file.local_path_exists
                         and str(project_file.local_path) in offline_layers_paths
@@ -741,7 +741,7 @@ class CloudTransferDialog(QDialog, CloudTransferDialogUi):
     def traverse_tree_item(
         self, item: QTreeWidgetItem, files: Dict[str, List[ProjectFile]]
     ) -> None:
-        project_file = item.data(0, Qt.UserRole)
+        project_file = item.data(0, Qt.ItemDataRole.UserRole)
 
         if project_file:
             assert item.childCount() == 0
@@ -859,7 +859,7 @@ class CloudTransferDialog(QDialog, CloudTransferDialogUi):
         self.project_synchronized.emit()
 
     def on_local_checkbox_toggled(self, item: QTreeWidgetItem) -> None:
-        project_file = item.data(0, Qt.UserRole)
+        project_file = item.data(0, Qt.ItemDataRole.UserRole)
         project_file.checkout & ProjectFileCheckout.Cloud
 
         local_checkbox = self.filesTree.itemWidget(item, 1).children()[1]
@@ -871,7 +871,7 @@ class CloudTransferDialog(QDialog, CloudTransferDialogUi):
         self.update_detail(item)
 
     def on_cloud_checkbox_toggled(self, item: QTreeWidgetItem) -> None:
-        project_file = item.data(0, Qt.UserRole)
+        project_file = item.data(0, Qt.ItemDataRole.UserRole)
         project_file.local_path_exists
 
         local_checkbox = self.filesTree.itemWidget(item, 1).children()[1]
@@ -883,7 +883,7 @@ class CloudTransferDialog(QDialog, CloudTransferDialogUi):
         self.update_detail(item)
 
     def project_file_action(self, item: QTreeWidgetItem) -> ProjectFileAction:
-        project_file = item.data(0, Qt.UserRole)
+        project_file = item.data(0, Qt.ItemDataRole.UserRole)
         is_local_enabled = project_file.local_path_exists
         is_cloud_enabled = project_file.checkout & ProjectFileCheckout.Cloud
         local_checkbox = self.filesTree.itemWidget(item, 1).children()[1]
@@ -911,7 +911,7 @@ class CloudTransferDialog(QDialog, CloudTransferDialogUi):
     def update_detail(self, item: QTreeWidgetItem) -> None:
         project_file_action = self.project_file_action(item)
 
-        project_file = item.data(0, Qt.UserRole)
+        project_file = item.data(0, Qt.ItemDataRole.UserRole)
         has_local = project_file.local_path_exists
         has_cloud = project_file.checkout & ProjectFileCheckout.Cloud
 
@@ -1002,7 +1002,7 @@ class CloudTransferDialog(QDialog, CloudTransferDialogUi):
     def _file_tree_set_checkboxes_recursive(
         self, item: QTreeWidgetItem, checkout: ProjectFileCheckout
     ) -> None:
-        project_file = item.data(0, Qt.UserRole)
+        project_file = item.data(0, Qt.ItemDataRole.UserRole)
 
         if project_file:
             assert item.childCount() == 0

--- a/qfieldsync/gui/directories_configuration_widget.py
+++ b/qfieldsync/gui/directories_configuration_widget.py
@@ -88,11 +88,11 @@ class DirectoriesConfigurationWidget(WidgetUi, QWidget):
         for i in range(self.directoriesTable.rowCount()):
             item = self.directoriesTable.item(i, 0)
             cmb = self.directoriesTable.cellWidget(i, 1)
-            if item.data(Qt.EditRole) != "":
+            if item.data(Qt.ItemDataRole.EditRole) != "":
                 if cmb.currentIndex() == 0:
-                    configuration["attachment_dirs"].append(item.data(Qt.EditRole))
+                    configuration["attachment_dirs"].append(item.data(Qt.ItemDataRole.EditRole))
                 elif cmb.currentIndex() == 1:
-                    configuration["data_dirs"].append(item.data(Qt.EditRole))
+                    configuration["data_dirs"].append(item.data(Qt.ItemDataRole.EditRole))
 
         return configuration
 
@@ -101,7 +101,7 @@ class DirectoriesConfigurationWidget(WidgetUi, QWidget):
         self.directoriesTable.insertRow(count)
 
         item = QTableWidgetItem(name)
-        item.setData(Qt.EditRole, name)
+        item.setData(Qt.ItemDataRole.EditRole, name)
         self.directoriesTable.setItem(count, 0, item)
 
         cmb = QComboBox()

--- a/qfieldsync/gui/dirs_to_copy_widget.py
+++ b/qfieldsync/gui/dirs_to_copy_widget.py
@@ -86,18 +86,18 @@ class DirsToCopyWidget(QWidget, LayersConfigWidgetUi):
             #     return False
 
             check_state = (
-                Qt.Checked if dirs_to_copy.get(str_path, True) else Qt.Unchecked
+                Qt.CheckState.Checked if dirs_to_copy.get(str_path, True) else Qt.CheckState.Unchecked
             )
 
             item.setCheckState(0, check_state)
             item.setExpanded(True)
-            item.setData(0, Qt.UserRole, str_path)
+            item.setData(0, Qt.ItemDataRole.UserRole, str_path)
             item.setToolTip(0, str(node["path"].absolute()))
             item.setFlags(
                 item.flags()
-                | Qt.ItemIsUserCheckable
-                | Qt.ItemIsSelectable
-                | Qt.ItemIsAutoTristate
+                | Qt.ItemFlag.ItemIsUserCheckable
+                | Qt.ItemFlag.ItemIsSelectable
+                | Qt.ItemFlag.ItemIsAutoTristate
             )
 
         root_item = self.dirsTreeWidget.invisibleRootItem()
@@ -116,8 +116,8 @@ class DirsToCopyWidget(QWidget, LayersConfigWidgetUi):
             data = {}
             for i in range(root_item.childCount()):
                 item = root_item.child(i)
-                relative_path = item.data(0, Qt.UserRole)
-                is_checked = item.checkState(0) == Qt.Checked
+                relative_path = item.data(0, Qt.ItemDataRole.UserRole)
+                is_checked = item.checkState(0) == Qt.CheckState.Checked
                 data[relative_path] = is_checked
 
                 if item.childCount() > 0:
@@ -146,7 +146,7 @@ class DirsToCopyWidget(QWidget, LayersConfigWidgetUi):
 
     def _set_checked_state_recursively(self, checked: bool) -> None:
         def set_checked_state(item: QTreeWidgetItem) -> None:
-            checked_state = Qt.Checked if checked else Qt.Unchecked
+            checked_state = Qt.CheckState.Checked if checked else Qt.CheckState.Unchecked
             item.setCheckState(0, checked_state)
 
             for i in range(item.childCount()):

--- a/qfieldsync/gui/layers_config_widget.py
+++ b/qfieldsync/gui/layers_config_widget.py
@@ -63,7 +63,7 @@ class LayersConfigWidget(QWidget, LayersConfigWidgetUi):
         self.layersTable.setHorizontalHeaderLabels(
             [self.tr("Layer"), self.tr("Packaging Action"), ""]
         )
-        self.layersTable.horizontalHeader().setSectionResizeMode(0, QHeaderView.Stretch)
+        self.layersTable.horizontalHeader().setSectionResizeMode(0, QHeaderView.ResizeMode.Stretch)
 
         self.multipleToggleButton.setIcon(
             QIcon(
@@ -93,7 +93,7 @@ class LayersConfigWidget(QWidget, LayersConfigWidgetUi):
         self.toggleMenu.addAction(self.addVisibleOfflineAction)
         self.multipleToggleButton.setMenu(self.toggleMenu)
         self.multipleToggleButton.setAutoRaise(True)
-        self.multipleToggleButton.setPopupMode(QToolButton.InstantPopup)
+        self.multipleToggleButton.setPopupMode(QToolButton.ToolButtonPopupMode.InstantPopup)
         self.toggleMenu.triggered.connect(self.toggleMenu_triggered)
 
         self.settingsPackagingButton.setVisible(False)
@@ -191,8 +191,8 @@ class LayersConfigWidget(QWidget, LayersConfigWidgetUi):
             count = self.layersTable.rowCount()
             self.layersTable.insertRow(count)
             item = QTableWidgetItem(layer_source.layer.name())
-            item.setData(Qt.UserRole, layer_source)
-            item.setData(Qt.EditRole, layer_source.layer.name())
+            item.setData(Qt.ItemDataRole.UserRole, layer_source)
+            item.setData(Qt.ItemDataRole.EditRole, layer_source.layer.name())
             item.setIcon(QgsMapLayerModel.iconForLayer(layer_source.layer))
             self.layersTable.setItem(count, 0, item)
 
@@ -214,12 +214,12 @@ class LayersConfigWidget(QWidget, LayersConfigWidgetUi):
 
             if not layer_source.is_supported:
                 self.unsupportedLayersList.append(layer_source)
-                self.layersTable.item(count, 0).setFlags(Qt.NoItemFlags)
+                self.layersTable.item(count, 0).setFlags(Qt.ItemFlag.NoItemFlags)
                 self.layersTable.cellWidget(count, 1).setEnabled(False)
                 cmb.setCurrentIndex(cmb.findData(SyncAction.REMOVE))
 
         self.layersTable.resizeColumnsToContents()
-        self.layersTable.sortByColumn(0, Qt.AscendingOrder)
+        self.layersTable.sortByColumn(0, Qt.SortOrder.AscendingOrder)
         self.layersTable.setSortingEnabled(True)
 
         if self.unsupportedLayersList:
@@ -249,7 +249,7 @@ class LayersConfigWidget(QWidget, LayersConfigWidgetUi):
 
         for i in range(self.layersTable.rowCount()):
             item = self.layersTable.item(i, 0)
-            layer_source = item.data(Qt.UserRole)
+            layer_source = item.data(Qt.ItemDataRole.UserRole)
             cmb = self.layersTable.cellWidget(i, 1)
 
             # It would be annoying to change the action on removed layers.
@@ -279,7 +279,7 @@ class LayersConfigWidget(QWidget, LayersConfigWidgetUi):
         ):
             for i in range(self.layersTable.rowCount()):
                 item = self.layersTable.item(i, 0)
-                layer_source = item.data(Qt.UserRole)
+                layer_source = item.data(Qt.ItemDataRole.UserRole)
                 old_action = self.get_layer_action(layer_source)
                 available_actions, _ = zip(*self.get_available_actions(layer_source))
                 layer_sync_action = (
@@ -331,7 +331,7 @@ class LayersConfigWidget(QWidget, LayersConfigWidgetUi):
 
         for i in range(self.layersTable.rowCount()):
             item = self.layersTable.item(i, 0)
-            layer_source = item.data(Qt.UserRole)
+            layer_source = item.data(Qt.ItemDataRole.UserRole)
             cmb = self.layersTable.cellWidget(i, 1)
 
             self.set_layer_action(layer_source, cmb.itemData(cmb.currentIndex()))

--- a/qfieldsync/gui/mapthemes_config_widget.py
+++ b/qfieldsync/gui/mapthemes_config_widget.py
@@ -56,7 +56,7 @@ class MapThemesConfigWidget(QTableWidget):
             count = self.rowCount()
             self.insertRow(count)
             item = QTableWidgetItem(map_theme)
-            item.setData(Qt.EditRole, map_theme)
+            item.setData(Qt.ItemDataRole.EditRole, map_theme)
             self.setItem(count, 0, item)
 
             cmb = QgsMapLayerComboBox()
@@ -70,14 +70,14 @@ class MapThemesConfigWidget(QTableWidget):
 
         self.setColumnWidth(0, int(self.width() * 0.2))
         self.setColumnWidth(1, int(self.width() * 0.75))
-        self.sortByColumn(0, Qt.AscendingOrder)
+        self.sortByColumn(0, Qt.SortOrder.AscendingOrder)
         self.setSortingEnabled(True)
 
     def createConfiguration(self):
         configuration = {}
         for i in range(self.rowCount()):
             item = self.item(i, 0)
-            map_theme = item.data(Qt.EditRole)
+            map_theme = item.data(Qt.ItemDataRole.EditRole)
             cmb = self.cellWidget(i, 1)
             layer_id = cmb.currentLayer().id() if cmb.currentLayer() else ""
             configuration[map_theme] = layer_id

--- a/qfieldsync/gui/package_dialog.py
+++ b/qfieldsync/gui/package_dialog.py
@@ -249,7 +249,7 @@ class PackageDialog(QDialog, DialogUi):
         )
 
         try:
-            QApplication.setOverrideCursor(Qt.WaitCursor)
+            QApplication.setOverrideCursor(Qt.CursorShape.WaitCursor)
             self._offline_convertor.convert()
             self.do_post_offline_convert_action(True)
         except PackagingCanceledException:

--- a/qfieldsync/gui/project_configuration_widget.py
+++ b/qfieldsync/gui/project_configuration_widget.py
@@ -58,9 +58,9 @@ WidgetUi, _ = loadUiType(
 
 class EventEater(QObject):
     def eventFilter(self, widget, event):
-        if event.type() == QEvent.KeyPress:
-            if event.matches(QKeySequence.Backspace) or event.matches(
-                QKeySequence.Delete
+        if event.type() == QEvent.Type.KeyPress:
+            if event.matches(QKeySequence.StandardKey.Backspace) or event.matches(
+                QKeySequence.StandardKey.Delete
             ):
                 widget.takeItem(widget.currentRow())
 

--- a/qfieldsync/gui/relationship_configuration_widget.py
+++ b/qfieldsync/gui/relationship_configuration_widget.py
@@ -57,14 +57,14 @@ class RelationshipConfigurationTableWidget(QTableWidget):
             row = self.rowCount()
             self.insertRow(row)
             layer_name_item = QTableWidgetItem(layer.name())
-            layer_name_item.setData(Qt.UserRole, layer_source)
-            layer_name_item.setFlags(Qt.ItemIsEnabled)
+            layer_name_item.setData(Qt.ItemDataRole.UserRole, layer_source)
+            layer_name_item.setFlags(Qt.ItemFlag.ItemIsEnabled)
             self.setItem(row, 0, layer_name_item)
             relation_id_item = QTableWidgetItem(relation.id())
-            relation_id_item.setFlags(Qt.ItemIsEnabled)
+            relation_id_item.setFlags(Qt.ItemFlag.ItemIsEnabled)
             self.setItem(row, 1, relation_id_item)
             relation_name_item = QTableWidgetItem(relation.name())
-            relation_name_item.setFlags(Qt.ItemIsEnabled)
+            relation_name_item.setFlags(Qt.ItemFlag.ItemIsEnabled)
             self.setItem(row, 2, relation_name_item)
             spin_item = QgsSpinBox()
             spin_item.setMinimum(0)
@@ -83,7 +83,7 @@ class RelationshipConfigurationTableWidget(QTableWidget):
 
     def syncLayerSourceValues(self, should_apply=False):
         for i in range(self.rowCount()):
-            layer_source = self.item(i, 0).data(Qt.UserRole)
+            layer_source = self.item(i, 0).data(Qt.ItemDataRole.UserRole)
             relation_id = self.item(i, 1).text()
             relationship_maximum_visible = self.cellWidget(i, 3).value()
             layer_source.set_relationship_maximum_visible(

--- a/qfieldsync/utils/qt_utils.py
+++ b/qfieldsync/utils/qt_utils.py
@@ -56,12 +56,11 @@ def rounded_pixmap(img_path: str, diameter: int) -> QPixmap:
     size = QSize(height, width)
 
     target_pixmap = QPixmap(size)
-    target_pixmap.fill(Qt.transparent)
+    target_pixmap.fill(Qt.GlobalColor.transparent)
 
     painter = QPainter(target_pixmap)
-    painter.setRenderHint(QPainter.Antialiasing, True)
-    painter.setRenderHint(QPainter.HighQualityAntialiasing, True)
-    painter.setRenderHint(QPainter.SmoothPixmapTransform, True)
+    painter.setRenderHint(QPainter.RenderHint.Antialiasing, True)
+    painter.setRenderHint(QPainter.RenderHint.SmoothPixmapTransform, True)
 
     path = QPainterPath()
     path.addRoundedRect(
@@ -85,8 +84,8 @@ def rounded_pixmap(img_path: str, diameter: int) -> QPixmap:
         pixmap = pixmap.scaled(
             width,
             height,
-            Qt.KeepAspectRatioByExpanding,
-            Qt.SmoothTransformation,
+            Qt.AspectRatioMode.KeepAspectRatioByExpanding,
+            Qt.TransformationMode.SmoothTransformation,
         )
 
         painter.drawPixmap(0, 0, pixmap)


### PR DESCRIPTION
✨ This PR aims to improve Qt6 support.

Most of it is straightforward find and replace of enums but there are two cases where we don't have a Qt6 equivalent:

1. `QNetworkRequest.FollowRedirectsAttribute` is gone and [the default redirect behavior changes]( https://doc.qt.io/qt-6/network-changes-qt6.html#redirect-policies). I'm not 100% sure but I think this means that we do not need to implicitly set any attribute here and can just delete those lines?
2. `QPainter.HighQualityAntialiasing` was already [obsolete and ignored in Qt5](https://doc.qt.io/archives/qt-5.15/qpainter.html#RenderHint-enum) and got removed in Qt6

AFAICT the plugin works in both Qt5 and Qt6 builds but I am unable to test the cloud related code changes.

Let me know if you need anything more.

Regards