### PR TITLE
Fix offlining feature intersecting AOI checkbox

### DIFF
--- a/qfieldsync/ui/project_configuration_widget.ui
+++ b/qfieldsync/ui/project_configuration_widget.ui
@@ -263,11 +263,8 @@
           <item row="2" column="0" colspan="2">
            <widget class="QCheckBox" name="onlyOfflineCopyFeaturesInAoi">
             <property name="text">
-             <string>Map theme</string>
+             <string>When offlining layers, only copy features intersecting the area of interest</string>
             </property>
-            <attribute name="buttonGroup">
-             <string notr="true">buttonGroup</string>
-            </attribute>
            </widget>
           </item>
           <item row="3" column="0" colspan="2">
@@ -356,7 +353,7 @@
                   <string>Single layer</string>
                  </property>
                  <attribute name="buttonGroup">
-                  <string notr="true">buttonGroup</string>
+                  <string notr="true">baseMapButtonGroup</string>
                  </attribute>
                 </widget>
                </item>
@@ -366,7 +363,7 @@
                   <string>Map theme</string>
                  </property>
                  <attribute name="buttonGroup">
-                  <string notr="true">buttonGroup</string>
+                  <string notr="true">baseMapButtonGroup</string>
                  </attribute>
                 </widget>
                </item>
@@ -608,6 +605,6 @@
  <resources/>
  <connections/>
  <buttongroups>
-  <buttongroup name="buttonGroup"/>
+  <buttongroup name="baseMapButtonGroup"/>
  </buttongroups>
 </ui>


### PR DESCRIPTION
Fix regression from rebase commit here (https://github.com/opengisch/qfieldsync/commit/45333da5a514336bfb9354306d79d6413bc9a54e) whereas the checkbox that dictate whether layers being offlined should only copy features interesting the AOI was renamed to "map theme", and added to the "buttonGroup" group, which led to a broken checkbox state.

@gounux , gentle ping.