### PR TITLE
Fix autopush to QFieldCloud setting gone missing

### DIFF
--- a/qfieldsync/ui/project_configuration_widget.ui
+++ b/qfieldsync/ui/project_configuration_widget.ui
@@ -84,7 +84,7 @@
              </property>
             </widget>
            </item>
-           <item row="2" column="0">
+           <item row="3" column="0">
             <layout class="QHBoxLayout" name="horizontalLayout">
              <item>
               <widget class="QCheckBox" name="forceAutoPush">


### PR DESCRIPTION
While showcasing QField[Cloud] during FOSS4G 2025, I noticed our autopush ot QFieldCloud spinbox had gone missing from the interface :scream: . The PR fixes this regression. Proof of resurrection: 

<img width="853" height="659" alt="image" src="https://github.com/user-attachments/assets/9c64f345-df04-4a0f-bef7-89b31b4939c1" />

