### PR TITLE
Fix shared dataset project creation

### DIFF
--- a/qfieldsync/core/cloud_api.py
+++ b/qfieldsync/core/cloud_api.py
@@ -526,7 +526,7 @@ class CloudNetworkAccessManager(QObject):
             self._prepare_uri("projects").toString(),
             headers=headers,
             params=params,
-            timeout=0,
+            timeout=120,
         )
         response.raise_for_status()
 


### PR DESCRIPTION
This commit - https://github.com/opengisch/qfieldsync/commit/fb505bdbc70bc8c02177d26767cc4b363f888ee1 - broke creation of shared datasets on QFieldSync. 

Setting the timeout to 0 results in an exception thrown:

`Error:Attempted to set connect timeout to 0, but the timeout cannot be set to a value less than or equal to 0.`

In turn, this results in a shared dataset *never* created when missing (or when the project cache hasn't been fetched yet).
