### PR TITLE
Fix error handling presence of gpkg wal/shm files on the cloud

### DIFF
--- a/qfieldsync/core/cloud_transferrer.py
+++ b/qfieldsync/core/cloud_transferrer.py
@@ -400,15 +400,17 @@ class CloudTransferrer(QObject):
             if not dest_path.parent.exists():
                 dest_path.parent.mkdir(parents=True)
 
-            if source_filename.endswith((".gpkg-shm", ".gpkg-wal")):
+            if source_filename.endswith(".gpkg"):
                 for suffix in ("-shm", "-wal"):
-                    source_path = Path(str(self.local_path) + suffix)
+                    source_path = Path(str(filename) + suffix)
                     dest_path = Path(str(dest_filename) + suffix)
 
                     if source_path.exists():
                         shutil.copyfile(source_path, dest_path)
-                    else:
+                    elif dest_path.exists():
                         dest_path.unlink()
+            elif source_filename.endswith((".gpkg-shm", ".gpkg-wal")):
+                continue
 
             shutil.copyfile(filename, dest_filename)
 


### PR DESCRIPTION
@beanzmo stumbled on a silent killer in our QFieldSync code! :wink: 

The code handling the presence of wal and shm files within a cloud project remote files list was broken. The code referred to an nonexistent self.local_path variable, which crashed the copying process.

If you were lucky and the wal file was the first file, you'd end up with an empty directory indicating something very wrong, But, if it happened halfway, you would end up with a half copied cloud project. This could lead to failure to copy attachments, offline data data.gpkg, etc.

