### PR TITLE
Fix localized dataset processing

### DIFF
--- a/qfieldsync/core/cloud_project.py
+++ b/qfieldsync/core/cloud_project.py
@@ -423,9 +423,11 @@ class CloudProject:
 
         read_flags = QgsProject.ReadFlags()
         if Qgis.versionInt() >= 32600:  # noqa: PLR2004
+            read_flags |= Qgis.ProjectReadFlag.DontLoadLayouts
             read_flags |= Qgis.ProjectReadFlag.TrustLayerMetadata
             read_flags |= Qgis.ProjectReadFlag.DontLoad3DViews
         else:
+            read_flags |= QgsProject.ReadFlag.FlagDontLoadLayouts
             read_flags |= QgsProject.ReadFlag.FlagTrustLayerMetadata
 
         temporary_project = QgsProject()


### PR DESCRIPTION
Undo changes introduced by 3a7c49e: `DontResolveLayers` .
When deciding if a layer is localized we need to read Layers.

There's an issue with the latest qfieldsync release regarding localized datasets:
It's not showing the option to upload shared_datasets in the dialog and therefor it's not creating the shared_datasets project nor uploading any files. I could narrow it down to the `get_localized_dataset_files` function:
```
        for layer in layers.values():
            if not layer.dataProvider():
                continue
```
The problem is with the code change in https://github.com/opengisch/qfieldsync/commit/3a7c49eb6fd761316ea6b0c300aac9dcad1a9de0 we don't resolve the layers and they then don't have a dataProvider so we always go out of the loop.

When disabling:
```
        if Qgis.versionInt() >= 32600:  # noqa: PLR2004
            # read_flags |= Qgis.ProjectReadFlag.DontResolveLayers
            read_flags |= Qgis.ProjectReadFlag.TrustLayerMetadata
            read_flags |= Qgis.ProjectReadFlag.DontLoad3DViews
        else:
            # read_flags |= QgsProject.ReadFlag.FlagDontResolveLayers
            read_flags |= QgsProject.ReadFlag.FlagTrustLayerMetadata
```
everything seems to work again:
- Shared datasets are identified
- Option for uploading missing shared datasets is shown (visibility is set to True)
- When checkbox ticked, the project gets created/uploaded, a `shared_datasets` project is  created and the shared dataset uploaded as well.

I'm unsure if we need the layers for https://github.com/opengisch/qfieldsync/blob/72a8a84880fa7ad5959afcc2e273b24da2c29801/qfieldsync/gui/cloud_transfer_dialog.py#L562
I leave that up to @nirvn to decide.
