### PR TITLE
fix: add trailing slash to cloud API URL if missing

### DIFF
--- a/qfieldsync/core/cloud_api.py
+++ b/qfieldsync/core/cloud_api.py
@@ -396,6 +396,9 @@ class CloudNetworkAccessManager(QObject):
         else:
             self.url = f"{p.scheme or 'https'}://{p.netloc}{p.path}"
 
+        if not self.url.endswith("/"):
+            self.url += "/"
+
         self.preferences.set_value("qfieldCloudServerUrl", server_url)
 
     @property


### PR DESCRIPTION
When logging in in QFieldsync to a custom URL and the URL doesn't end with a `/` it effects buttons like `Edit on QFieldCloud` and `Forgot password`