### PR TITLE
fix(login): Align SSO login layout to web

### DIFF
--- a/qfieldsync/gui/cloud_login_dialog.py
+++ b/qfieldsync/gui/cloud_login_dialog.py
@@ -36,8 +36,6 @@ from qgis.PyQt.QtWidgets import (
     QGroupBox,
     QMainWindow,
     QPushButton,
-    QSizePolicy,
-    QSpacerItem,
     QWidget,
 )
 from qgis.PyQt.uic import loadUiType
@@ -197,8 +195,8 @@ class CloudLoginDialog(QDialog, CloudLoginDialogUi):
 
     def clear_login_widgets(self) -> None:
         self.set_login_groupbox_visibility(self.signInUsernameGroupBox, False)
+        self.authenticationDivider.setVisible(False)
 
-        # clear sso login buttons
         for push_button in self._sso_login_buttons:
             push_button.deleteLater()
 
@@ -245,22 +243,20 @@ class CloudLoginDialog(QDialog, CloudLoginDialogUi):
 
         self.clear_login_widgets()
 
-        # add vertical space before SSO login buttons
-        vertical_spacer = QSpacerItem(
-            0, 10, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Fixed
-        )
-        self.signInUsernameGroupBox.layout().addItem(vertical_spacer)
+        has_credentials = False
 
         for auth_method in auth_methods:
-            # credentials login: enabled static groupbox.
             if auth_method["id"] == "credentials":
                 self.set_login_groupbox_visibility(self.signInUsernameGroupBox, True)
+                has_credentials = True
                 continue
 
-            # sso provider: dynamically generate button to login.
-            login_button = QPushButton(
-                self.tr("Sign In with {provider}").format(provider=auth_method["name"])
-            )
+            # Mirror the web login page: show an "Or" divider between the credentials
+            # form and the SSO provider buttons only when both are present.
+            if has_credentials and not self._sso_login_buttons:
+                self.authenticationDivider.setVisible(True)
+
+            login_button = QPushButton(auth_method["name"])
             login_button.setCursor(QCursor(Qt.CursorShape.PointingHandCursor))
 
             self.set_sso_provider_button_style(auth_method.get("styles"), login_button)
@@ -268,7 +264,7 @@ class CloudLoginDialog(QDialog, CloudLoginDialogUi):
             login_button.clicked.connect(
                 partial(self.on_login_with_sso_provider_button_clicked, auth_method)
             )
-            self.signInUsernameGroupBox.layout().addWidget(login_button)
+            self.signInUsernameGroupBox.layout().addRow(login_button)
             self._sso_login_buttons.append(login_button)
 
     def set_sso_provider_button_style(

--- a/qfieldsync/ui/cloud_login_dialog.ui
+++ b/qfieldsync/ui/cloud_login_dialog.ui
@@ -144,6 +144,72 @@
         </property>
        </widget>
       </item>
+      <item row="4" column="0" colspan="2">
+       <widget class="QWidget" name="authenticationDivider" native="true">
+        <property name="visible">
+         <bool>false</bool>
+        </property>
+        <layout class="QHBoxLayout" name="authenticationDividerLayout">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>4</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>4</number>
+         </property>
+         <property name="spacing">
+          <number>8</number>
+         </property>
+         <item>
+          <widget class="QFrame" name="authenticationDividerLeftLine">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="frameShape">
+            <enum>QFrame::HLine</enum>
+           </property>
+           <property name="frameShadow">
+            <enum>QFrame::Sunken</enum>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="authenticationDividerLabel">
+           <property name="text">
+            <string>Or</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QFrame" name="authenticationDividerRightLine">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="frameShape">
+            <enum>QFrame::HLine</enum>
+           </property>
+           <property name="frameShadow">
+            <enum>QFrame::Sunken</enum>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
       <item row="2" column="1">
        <widget class="QPushButton" name="signInUsernameButton">
         <property name="cursor">


### PR DESCRIPTION
Align Login dialog layout when SSO is enabled to the layout in QField and QFieldCloud.

- Before
<img width="383" height="563" alt="image" src="https://github.com/user-attachments/assets/b3a29d2a-2955-4421-9cc4-05cf362571f5" />

- After
<img width="382" height="578" alt="image" src="https://github.com/user-attachments/assets/4a7d728b-d640-4317-9b3a-9a40680fbaf8" />


Login flow successfully tested with Entra ID.