### PR TITLE
Remove testing with ubuntu 22.04 as nodejs is no longer present

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -2,6 +2,9 @@ ARG QGIS_TEST_VERSION=latest
 FROM  qgis/qgis:${QGIS_TEST_VERSION}
 MAINTAINER Matthias Kuhn <matthias@opengis.ch>
 
+# In older QGIS images (e.g. release_3.22), the base image is no longer supported in the NodeJS repository.
+RUN rm -f /etc/apt/sources.list.d/nodesource.list
+
 RUN apt-get update \
     && apt-get install -y python3-pip \
     && rm -rf /var/lib/apt/lists/*

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -69,32 +69,6 @@ jobs:
         run: |
           docker compose -f .docker/docker-compose.yml run qgis /usr/src/.docker/run-docker-tests.sh
 
-  test-22-04:
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
-
-      - name: Test
-        run: |
-          wget -qO - https://qgis.org/downloads/qgis-2022.gpg.key | sudo gpg --no-default-keyring --keyring gnupg-ring:/etc/apt/trusted.gpg.d/qgis-archive.gpg --import
-          sudo chmod a+r /etc/apt/trusted.gpg.d/qgis-archive.gpg
-          sudo add-apt-repository "deb https://qgis.org/ubuntu $(lsb_release -c -s) main"
-
-          sudo apt update
-          sudo apt install qgis
-          sudo pip3 install pytest nose2 mock
-
-          # Upgrading `pip` fixes: "WARNING: Generating metadata for package libqfieldsync produced metadata for project name unknown. Fix your #egg=libqfieldsync fragments."
-          pip3 install --upgrade pip
-
-          # Install dependencies, including `libqfieldsync`
-          pip3 install -r requirements.txt
-
-          xvfb-run pytest
-
   release:
     runs-on: ubuntu-24.04
     if: ${{ github.event_name == 'release' }}

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -56,7 +56,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        qgis_version: [release-3_22, latest]
+        qgis_version: [release-3_22, 3.44, ltr, stable]
     env:
       QGIS_TEST_VERSION: ${{ matrix.qgis_version }}
     steps:

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -56,7 +56,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        qgis_version: [release-3_22, 3.44, ltr, stable]
+        # TODO @suricactus: enable QGIS 4 tests, but for now it's crashing, see https://github.com/opengisch/qfieldsync/issues/757
+        qgis_version: [release-3_22, 3.44, ltr]
     env:
       QGIS_TEST_VERSION: ${{ matrix.qgis_version }}
     steps:


### PR DESCRIPTION
Ubuntu 22.04 is old enough and seems nodejs does not support it anymore, see the error from this run:

https://github.com/opengisch/qfieldsync/actions/runs/24146265325/job/70566530146?pr=754

see comment https://github.com/opengisch/qfieldsync/pull/754#issuecomment-4207795402

```#8 4.521 E: The repository 'https://deb.nodesource.com/node_18.x jammy Release' no longer has a Release file.
#8 ERROR: process "/bin/sh -c apt-get update     && apt-get install -y python3-pip     && rm -rf /var/lib/apt/lists/*" did not complete successfully: exit code: 100```