### PR TITLE
fix: stream large files using QFile.setBodyDevice to avoid 2GB limit

### DIFF
--- a/qfieldsync/core/cloud_api.py
+++ b/qfieldsync/core/cloud_api.py
@@ -39,6 +39,7 @@ from qgis.core import (
 from qgis.PyQt.QtCore import (
     QByteArray,
     QEventLoop,
+    QFile,
     QFileSystemWatcher,
     QObject,
     QUrl,
@@ -873,16 +874,21 @@ class CloudNetworkAccessManager(QObject):
 
         # now attach each file
         for filename in filenames:
-            # this might be optimized by usung QFile and QHttpPart.setBodyDevice, but didn't work on the first
-            with open(filename, "rb") as file:
-                file_part = QHttpPart()
-                file_part.setBody(file.read())
-                file_part.setHeader(
-                    QNetworkRequest.KnownHeaders.ContentDispositionHeader,
-                    'form-data; name="file"; filename="{}"'.format(filename),
-                )
+            # Use setBodyDevice with QFile to stream the file, avoiding QByteArray's
+            # 32-bit size limit which silently truncates files larger than 2GB.
+            # QFile must be parented to multi_part so it stays open for the full
+            # duration of the request (multi_part itself is parented to reply below).
+            qfile = QFile(filename)
+            qfile.open(QFile.OpenModeFlag.ReadOnly)
+            qfile.setParent(multi_part)
+            file_part = QHttpPart()
+            file_part.setBodyDevice(qfile)
+            file_part.setHeader(
+                QNetworkRequest.KnownHeaders.ContentDispositionHeader,
+                'form-data; name="file"; filename="{}"'.format(filename),
+            )
 
-                multi_part.append(file_part)
+            multi_part.append(file_part)
 
         with disable_nam_timeout(self._nam):
             reply = self._nam.post(request, multi_part)


### PR DESCRIPTION
QHttpPart.setBody() loads the entire file into a QByteArray, which uses a 32-bit signed integer for size. Files >= 2GB overflow this limit, causing the upload to silently succeed while only writing ~3 bytes to the server.

Fix by using setBodyDevice(QFile) instead, which streams the file directly without loading it into memory. QFile is parented to multi_part (which is parented to reply) to ensure it stays open for the full duration of the request.

Compared it to qfieldcloud-sdk solution and found+created the fix with the help of claude.ai !

Built a local release and tested successfully with QGIS 3.44 on Ubuntu and a 2.5GB .tif.

<img width="685" height="724" alt="grafik" src="https://github.com/user-attachments/assets/14a216bb-b4d1-4e8a-bf2a-cf9cc6591c78" />

<img width="685" height="724" alt="grafik" src="https://github.com/user-attachments/assets/a9b7bde4-34fd-4406-af0c-c692166a36b0" />

Fixes #751