### PR TITLE
Fixing progressbar stoping after 2GB of file transfer

### DIFF
--- a/qfieldsync/core/cloud_transferrer.py
+++ b/qfieldsync/core/cloud_transferrer.py
@@ -467,7 +467,7 @@ class CloudTransferrer(QObject):
 
 
 class FileTransfer(QObject):
-    progress = pyqtSignal(int, int)
+    progress = pyqtSignal("qint64", "qint64")
     finished = pyqtSignal()
 
     class TransferType(Enum):
@@ -667,7 +667,7 @@ class ThrottledFileTransferrer(QObject):
     finished = pyqtSignal()
     aborted = pyqtSignal()
     file_finished = pyqtSignal(str)
-    progress = pyqtSignal(str, int, int)
+    progress = pyqtSignal(str, "qint64", "qint64")
 
     def __init__(  # noqa: PLR0913
         self,


### PR DESCRIPTION
This PR fixes a UI bug where the upload and download progress bars freeze or display incorrect percentages when transferring files larger than ~2.14 GB. This due to the C++ 32-bit signed integer (by the Qt), which has a maximum limit of 2,147,483,647.

| Before | After |
| ---------- | ------- |
| ![](https://github.com/user-attachments/assets/a0010c41-f419-4e12-8423-5d142e1d1450) | ![](https://github.com/user-attachments/assets/a6834b30-a785-48c9-b1c1-fbcc7970fac9) |