### PR TITLE
Fix image stamping trail not removed when going back to the main settings panel

### DIFF
--- a/qfieldsync/gui/project_configuration_widget.py
+++ b/qfieldsync/gui/project_configuration_widget.py
@@ -507,6 +507,7 @@ class ProjectConfigurationWidget(WidgetUi, QgsPanelWidget):
         self.stamping_image_decoration = self.image_stamping_panel.image_decoration()
         self.stamping_details_template = self.image_stamping_panel.details_template()
         self.force_stamping = self.image_stamping_panel.force_stamping()
+        self.image_stamping_panel.deleteLater()
         self.image_stamping_panel = None
 
     def _on_force_auto_push_clicked(self, checked):


### PR DESCRIPTION
Fixes this:

<img width="682" height="371" alt="Screenshot From 2026-04-15 19-00-32" src="https://github.com/user-attachments/assets/3a9c3a30-e7fc-44dc-8229-290bcbc28382" />

@suricactus , fixing what you pointed out during you stay over here :)