### PR TITLE
Fix broken font rendering when running QGIS built against Qt6

### DIFF
--- a/qfieldsync/ui/cloud_create_project_widget.ui
+++ b/qfieldsync/ui/cloud_create_project_widget.ui
@@ -43,7 +43,6 @@
            <widget class="QRadioButton" name="cloudifyRadioButton">
             <property name="font">
              <font>
-              <weight>75</weight>
               <bold>true</bold>
              </font>
             </property>
@@ -74,7 +73,6 @@
            <widget class="QRadioButton" name="createCloudRadioButton">
             <property name="font">
              <font>
-              <weight>75</weight>
               <bold>true</bold>
              </font>
             </property>

--- a/qfieldsync/ui/cloud_projects_dialog.ui
+++ b/qfieldsync/ui/cloud_projects_dialog.ui
@@ -326,7 +326,6 @@
           <widget class="QLabel" name="projectPropertiesLabel">
            <property name="font">
             <font>
-             <weight>75</weight>
              <bold>true</bold>
             </font>
            </property>


### PR DESCRIPTION
Manually setting font weights can result it bad styling with Qt6 on a number of fonts. Proof:

<img width="856" height="590" alt="Screenshot From 2026-04-14 18-53-38" src="https://github.com/user-attachments/assets/76bd2e8a-8f6b-454e-a69f-04a98f5e7f8b" />
