### PR TITLE
 Add a feature form wizard mode enabled checkbox in the QFeld project properties panel

### DIFF
--- a/qfieldsync/gui/project_configuration_widget.py
+++ b/qfieldsync/gui/project_configuration_widget.py
@@ -306,6 +306,10 @@ class ProjectConfigurationWidget(WidgetUi, QgsPanelWidget):
             mode_index = 0
         self.initialMapModeComboBox.setCurrentIndex(mode_index)
 
+        self.featureFormWizardModeCheckBox.setChecked(
+            self.__project_configuration.feature_form_wizard_mode_enabled
+        )
+
         self.maximumImageWidthHeight.setClearValueMode(
             QgsSpinBox.ClearValueMode.CustomValue, self.tr("No restriction")
         )
@@ -424,6 +428,10 @@ class ProjectConfigurationWidget(WidgetUi, QgsPanelWidget):
 
         self.__project_configuration.initial_map_mode = (
             self.initialMapModeComboBox.currentData()
+        )
+
+        self.__project_configuration.feature_form_wizard_mode_enabled = (
+            self.featureFormWizardModeCheckBox.isChecked()
         )
 
         self.__project_configuration.base_map_tile_size = int(

--- a/qfieldsync/ui/project_configuration_widget.ui
+++ b/qfieldsync/ui/project_configuration_widget.ui
@@ -274,7 +274,9 @@
              <string>Enable QField feature forms' wizard mode</string>
             </property>
             <property name="toolTip">
-             <string>When enabled, QField will display root tabs of a given feature form as a series of pages. This provides users with a linear journey, with constraints guiding the process along.</string>
+             <string>When enabled, QField will display root tabs of feature forms as
+a series of pages. This provides a simpler linear journey for users
+to fill forms, with constraints guiding the process along.</string>
             </property>
            </widget>
           </item>

--- a/qfieldsync/ui/project_configuration_widget.ui
+++ b/qfieldsync/ui/project_configuration_widget.ui
@@ -268,6 +268,16 @@
           <item row="2" column="1">
            <widget class="QgsMapLayerComboBox" name="digitizingLogsLayerComboBox"/>
           </item>
+          <item row="3" column="0" colspan="2">
+           <widget class="QCheckBox" name="featureFormWizardModeCheckBox">
+            <property name="text">
+             <string>Enable QField feature forms' wizard mode</string>
+            </property>
+            <property name="toolTip">
+             <string>When enabled, QField will display root tabs of a given feature form as a series of pages. This provides users with a linear journey, with constraints guiding the process along.</string>
+            </property>
+           </widget>
+          </item>
          </layout>
         </widget>
        </item>

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ future
 transifex-client
 
 # NOTE `libqfielsync` version should be defined in the `*.tar.gz` format, not `git+https://` to make `wheel` happy
-libqfieldsync @ https://github.com/opengisch/libqfieldsync/archive/c34e97b867dadd84e5fe0db3c0f8b07065315849.tar.gz
+libqfieldsync @ https://github.com/opengisch/libqfieldsync/archive/74cbed1dbe02a450a6dde5a2b1a57fc72be093ce.tar.gz


### PR DESCRIPTION
Screenshot:

<img width="1238" height="513" alt="Screenshot From 2026-04-17 11-40-46" src="https://github.com/user-attachments/assets/7ebec1ea-05c3-4daa-8e4b-5f0055041eb8" />

Companion QField PR (https://github.com/opengisch/QField/pull/7316).

ETA for QField 4.2 is May 20, so we'll need a new version of QFieldSync by then. No rush.