### PR TITLE
Fixing [WinError 183] Cannot create a file when that file already exists

### DIFF
--- a/qfieldsync/core/cloud_transferrer.py
+++ b/qfieldsync/core/cloud_transferrer.py
@@ -95,10 +95,16 @@ class CloudTransferrer(QObject):
         if self.temp_dir.exists():
             rmtree_onedrive_safe(self.temp_dir)
 
-        mkdir(self.temp_dir)
-        mkdir(self.temp_dir.joinpath("backup"))
-        mkdir(self.temp_dir.joinpath(FileTransfer.TransferType.UPLOAD.value))
-        mkdir(self.temp_dir.joinpath(FileTransfer.TransferType.DOWNLOAD.value))
+        mkdir(self.temp_dir, exist_ok=True)
+        mkdir(self.temp_dir.joinpath("backup"), exist_ok=True)
+        mkdir(
+            self.temp_dir.joinpath(FileTransfer.TransferType.UPLOAD.value),
+            exist_ok=True,
+        )
+        mkdir(
+            self.temp_dir.joinpath(FileTransfer.TransferType.DOWNLOAD.value),
+            exist_ok=True,
+        )
 
         self.localized_datasets_upload_finished.connect(
             self._on_localized_datasets_upload_finished


### PR DESCRIPTION
## Description

When attempting to synchronize a project on Windows, QFieldSync throws a FileExistsError: [WinError 183] Cannot create a file when that file already exists for the .qfieldsync temporary directory.

```bash
An error has occurred while executing Python code: 
FileExistsError: [WinError 183] Cannot create a file when that file already exists: 'C:\\Users\\<username>\\QField\\cloud\\workshops_April7\\.qfieldsync' 
Traceback (most recent call last):
  File "C:\Users/<username>/AppData/Roaming/QGIS/QGIS3\profiles\OPENGIS.ch/python/plugins\qfieldsync\gui\cloud_transfer_dialog.py", line 293, in 
    reply.finished.connect(lambda: self.check_localized_datasets())
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users/<username>/AppData/Roaming/QGIS/QGIS3\profiles\OPENGIS.ch/python/plugins\qfieldsync\gui\cloud_transfer_dialog.py", line 367, in check_localized_datasets
    self.prepare_project_transfer()
  File "C:\Users/<username>/AppData/Roaming/QGIS/QGIS3\profiles\OPENGIS.ch/python/plugins\qfieldsync\gui\cloud_transfer_dialog.py", line 443, in prepare_project_transfer
    self.project_transfer = CloudTransferrer(
                            ^^^^^^^^^^^^^^^^^
  File "C:\Users/<username>/AppData/Roaming/QGIS/QGIS3\profiles\OPENGIS.ch/python/plugins\qfieldsync\core\cloud_transferrer.py", line 98, in __init__
    mkdir(self.temp_dir)
  File "C:\Users/<username>/AppData/Roaming/QGIS/QGIS3\profiles\OPENGIS.ch/python/plugins\qfieldsync\utils\file_utils.py", line 108, in mkdir
    path.mkdir(mode, parents, exist_ok)
  File "C:\PROGRA1\QGIS331.4\apps\Python312\Lib\pathlib.py", line 1311, in mkdir
    os.mkdir(self, mode)
FileExistsError: [WinError 183] Cannot create a file when that file already exists: 'C:\\Users\\<username>\\QField\\cloud\\workshops_April7\\.qfieldsync'


Python version: 3.12.13 (main, Mar  5 2026, 15:14:54) [MSC v.1944 64 bit (AMD64)] 
QGIS version: 3.44.8-Solothurn Solothurn, d25052deb8b 
```