### PR TITLE
Implement a QFC storage widget and add it in the project creation and synchronization dialogs

### DIFF
--- a/qfieldsync/core/cloud_api.py
+++ b/qfieldsync/core/cloud_api.py
@@ -584,6 +584,10 @@ class CloudNetworkAccessManager(QObject):
         """Gets the available projects for the owner dropdown menu"""
         return self.cloud_get(["users", username, "organizations"])
 
+    def get_subscription_information(self, username: str) -> QNetworkReply:
+        """Get a username subscription information including storage usage and capacity"""
+        return self.cloud_get(f"subscriptions/{username}/current/")
+
     def get_files(self, project_id: str, client: str = "qgis") -> QNetworkReply:
         """Get project files and their versions"""
         return self.cloud_get(

--- a/qfieldsync/gui/cloud_create_project_widget.py
+++ b/qfieldsync/gui/cloud_create_project_widget.py
@@ -47,6 +47,7 @@ from qfieldsync.core.cloud_project import CloudProject
 from qfieldsync.core.cloud_transferrer import CloudTransferrer
 from qfieldsync.core.preferences import Preferences
 from qfieldsync.gui.cloud_login_dialog import CloudLoginDialog
+from qfieldsync.gui.storage_widget import StorageWidget
 from qfieldsync.utils.cloud_utils import (
     LocalDirFeedback,
     local_dir_feedback,
@@ -123,9 +124,16 @@ class CloudCreateProjectWidget(QWidget, WidgetUi):
             )
         )
 
+        self.projectOwnerComboBox.currentTextChanged.connect(
+            lambda: self.on_project_owner_changed()
+        )
+
         self.projectOwnerRefreshButton.clicked.connect(
             lambda: self.on_project_owner_refresh_button_click()
         )
+
+        self.storage_widget = StorageWidget(self.network_manager, self)
+        self.projectDetailsLayout.addWidget(self.storage_widget, 3, 1)
 
     def restart(self):
         self.stackedWidget.setCurrentWidget(self.selectTypePage)
@@ -414,6 +422,13 @@ class CloudCreateProjectWidget(QWidget, WidgetUi):
                 self.set_dirname(str(Path(self.project.fileName()).parent))
 
         self.update_info_visibility()
+
+    def on_project_owner_changed(self):
+        if not self.projectOwnerComboBox.currentText():
+            return
+
+        if self.storage_widget.owner() != self.projectOwnerComboBox.currentText():
+            self.storage_widget.set_owner(self.projectOwnerComboBox.currentText())
 
     def on_project_owner_refresh_button_click(self):
         self.refresh_project_owners()

--- a/qfieldsync/gui/cloud_transfer_dialog.py
+++ b/qfieldsync/gui/cloud_transfer_dialog.py
@@ -42,6 +42,7 @@ from qgis.PyQt.QtWidgets import (
     QHeaderView,
     QLabel,
     QMessageBox,
+    QSizePolicy,
     QTreeWidgetItem,
     QWidget,
 )
@@ -54,6 +55,8 @@ from qfieldsync.core.cloud_transferrer import CloudTransferrer, TransferFileLogs
 from qfieldsync.core.errors import QFieldSyncError
 from qfieldsync.core.preferences import Preferences
 from qfieldsync.gui.checker_feedback_table import CheckerFeedbackTable
+from qfieldsync.gui.storage_widget import StorageWidget
+from qfieldsync.utils.file_utils import filesizeformat10
 from qfieldsync.utils.qt_utils import make_folder_selector, make_icon, make_pixmap
 
 CloudTransferDialogUi, _ = loadUiType(
@@ -126,6 +129,14 @@ class CloudTransferDialog(QDialog, CloudTransferDialogUi):
         self.localized_datasets_project = None
         self.localized_datasets_files = []
 
+        self.storage_widget = StorageWidget(self.network_manager, self)
+        self.filesLayout.insertWidget(
+            self.filesLayout.count() - 1, self.storage_widget, 1
+        )
+
+        self.filesTree.setSizePolicy(
+            QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding
+        )
         self.filesTree.header().setSectionResizeMode(
             0, QHeaderView.ResizeMode.ResizeToContents
         )
@@ -211,6 +222,8 @@ class CloudTransferDialog(QDialog, CloudTransferDialogUi):
         self._update_window_title()
 
         if self.cloud_project:
+            self.storage_widget.set_owner(self.cloud_project.owner)
+
             if self.cloud_project.local_dir:
                 self.show_project_compatibility_page()
             else:
@@ -292,6 +305,7 @@ class CloudTransferDialog(QDialog, CloudTransferDialogUi):
         self._update_window_title()
 
         if self.cloud_project:
+            self.storage_widget.set_owner(self.cloud_project.owner)
             reply = self.network_manager.projects_cache.get_project_files(
                 self.cloud_project.id
             )
@@ -653,6 +667,37 @@ class CloudTransferDialog(QDialog, CloudTransferDialogUi):
         if dirname and Path(dirname).exists():
             QDesktopServices.openUrl(QUrl.fromLocalFile(dirname))
 
+    def _out_of_storage_triggered(self, total_upload_size):
+        message_box = QMessageBox(self)
+        message_box.setWindowTitle(self.tr("Warning"))
+        if self.storage_widget.storage_management_hyperlink:
+            message_box.setIcon(QMessageBox.Icon.Question)
+            message_box.setText(
+                self.tr(
+                    "You are trying to upload {} to QFieldCloud which is above the remaining available storage. To proceed, you can upgrade your storage or reduce the upload size."
+                ).format(filesizeformat10(total_upload_size))
+            )
+            message_box.setStandardButtons(
+                QMessageBox.StandardButton.Ok | QMessageBox.StandardButton.Cancel
+            )
+            message_box.button(QMessageBox.StandardButton.Ok).setText(
+                self.tr("Upgrade storage")
+            )
+            if message_box.exec() == QMessageBox.StandardButton.Ok:
+                QDesktopServices.openUrl(
+                    QUrl(self.storage_widget.storage_management_hyperlink())
+                )
+
+        else:
+            message_box.setIcon(QMessageBox.Icon.Warning)
+            message_box.setText(
+                self.tr(
+                    "You are trying to upload {} to QFieldCloud which is above the remaining available storage. To proceed, you must reduce the upload size."
+                ).format(filesizeformat10(total_upload_size))
+            )
+            message_box.setStandardButtons(QMessageBox.StandardButton.Ok)
+            message_box.exec()
+
     def _start_synchronization(self):
         assert self.cloud_project
 
@@ -690,18 +735,6 @@ class CloudTransferDialog(QDialog, CloudTransferDialogUi):
             )
             self.show_project_compatibility_page()
         else:
-            self.buttonBox.button(QDialogButtonBox.StandardButton.Ok).setVisible(True)
-            self.buttonBox.button(QDialogButtonBox.StandardButton.Ok).setEnabled(False)
-            self.buttonBox.button(QDialogButtonBox.StandardButton.Abort).setVisible(
-                True
-            )
-            self.buttonBox.button(QDialogButtonBox.StandardButton.Apply).setVisible(
-                False
-            )
-            self.buttonBox.button(QDialogButtonBox.StandardButton.Cancel).setVisible(
-                False
-            )
-
             files: dict[str, list[ProjectFile]] = {
                 "to_upload": [],
                 "to_download": [],
@@ -716,6 +749,31 @@ class CloudTransferDialog(QDialog, CloudTransferDialogUi):
 
             if self.uploadLocalizedDatasetsCheck.isChecked():
                 files["localized_datasets_to_upload"] = self.localized_datasets_files
+
+            total_upload_size = 0
+            for f in files["to_upload"]:
+                total_upload_size += f.local_size
+
+            if (
+                self.storage_widget.active_storage_total_bytes() > 0
+                and total_upload_size
+                > self.storage_widget.active_storage_total_bytes()
+                - self.storage_widget.storage_used_bytes()
+            ):
+                self._out_of_storage_triggered(total_upload_size)
+                return
+
+            self.buttonBox.button(QDialogButtonBox.StandardButton.Ok).setVisible(True)
+            self.buttonBox.button(QDialogButtonBox.StandardButton.Ok).setEnabled(False)
+            self.buttonBox.button(QDialogButtonBox.StandardButton.Abort).setVisible(
+                True
+            )
+            self.buttonBox.button(QDialogButtonBox.StandardButton.Apply).setVisible(
+                False
+            )
+            self.buttonBox.button(QDialogButtonBox.StandardButton.Cancel).setVisible(
+                False
+            )
 
             has_localized_datasets_uploads = len(files["localized_datasets_to_upload"])
             self.localizedDatasetsUploadLabel.setVisible(has_localized_datasets_uploads)

--- a/qfieldsync/gui/storage_widget.py
+++ b/qfieldsync/gui/storage_widget.py
@@ -1,0 +1,162 @@
+"""
+/***************************************************************************
+ StorageWidget
+                                A QGIS plugin to
+                           Sync your projects to QField
+                             -------------------
+        begin                : 2026-04-24
+        git sha              : $Format:%H$
+        copyright            : (C) 2026 by OPENGIS.ch
+        email                : info@opengis.ch
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+"""
+
+import os
+
+from qgis.PyQt.QtWidgets import QWidget
+from qgis.PyQt.uic import loadUiType
+
+from qfieldsync.core.cloud_api import CloudNetworkAccessManager, QfcError
+from qfieldsync.utils.file_utils import filesizeformat10
+
+StorageWidgetUi, _ = loadUiType(
+    os.path.join(os.path.dirname(__file__), "../ui/storage_widget.ui")
+)
+
+
+class StorageWidget(QWidget, StorageWidgetUi):
+    WARNING_THRESHOLD = 0.8
+    CRITICAL_THRESHOLD = 0.95
+
+    NORMAL_COLOR = "#4a6fae"
+    WARNING_COLOR = "#ffa500"
+    CRITICAL_COLOR = "#c0392b"
+
+    PROGRESSBAR_STYLESHEET = "QProgressBar {{ border: 1px solid palette(Mid); border-radius: 2px; }} QProgressBar::chunk {{ background-color: {}; }}"
+
+    def __init__(
+        self, network_manager: CloudNetworkAccessManager, parent: QWidget = None
+    ) -> None:
+        super().__init__(parent=parent)
+        self.setupUi(self)
+
+        self.progressBar.setMaximum(100)
+        self.progressBar.setStyleSheet(
+            self.PROGRESSBAR_STYLESHEET.format(self.NORMAL_COLOR)
+        )
+
+        self.network_manager = network_manager
+
+        self._owner = ""
+        self._active_storage_total_bytes = 0
+        self._storage_used_bytes = 0
+        self._storage_used_percent = 0.0
+        self._storage_management_hyperlink = ""
+
+    def set_owner(self, owner: str) -> None:
+        self._owner = owner
+        if self._owner:
+            self.refresh()
+
+    def owner(self) -> str:
+        return self._owner
+
+    def active_storage_total_bytes(self) -> int:
+        return self._active_storage_total_bytes
+
+    def storage_used_bytes(self) -> int:
+        return self._storage_used_bytes
+
+    def storage_used_percent(self) -> float:
+        return self._storage_used_percent
+
+    def storage_management_hyperlink(self) -> str:
+        return self._storage_management_hyperlink
+
+    def refresh(self) -> None:
+        if self._owner:
+            self.progressBar.setMaximum(0)
+            self.usageLabel.setText(self.tr("Fetching storage details..."))
+
+            reply = self.network_manager.get_subscription_information(self._owner)
+            reply.finished.connect(
+                lambda: self.on_get_subscription_information_finished(reply)
+            )
+
+    def on_get_subscription_information_finished(self, reply) -> None:
+        try:
+            subscription_information = self.network_manager.json_object(reply)
+        except QfcError:
+            subscription_information = {}
+
+        self.progressBar.setMaximum(100)
+
+        reply.deleteLater()
+
+        self._active_storage_total_bytes = subscription_information.get(
+            "active_storage_total_bytes", 0
+        )
+        self._storage_used_bytes = subscription_information.get("storage_used_bytes", 0)
+
+        if self._active_storage_total_bytes > 0:
+            self._storage_used_percent = (
+                self._storage_used_bytes / self._active_storage_total_bytes
+            )
+        else:
+            self._storage_used_percent = 0
+
+        self.progressBar.setValue(int(self._storage_used_percent * 100))
+        self.progressBar.setStyleSheet(
+            self.PROGRESSBAR_STYLESHEET.format(
+                self._get_progressbar_color(self._storage_used_percent)
+            )
+        )
+
+        usage_label = self.tr("Used {} of {}").format(
+            filesizeformat10(self._storage_used_bytes),
+            filesizeformat10(self._active_storage_total_bytes),
+        )
+        if self._owner == self.network_manager.user_details.get("username"):
+            self._storage_management_hyperlink = self._get_upgrade_link_url(
+                subscription_information.get("plan_is_premium")
+            )
+            usage_label += " / <a href='{}'>{}</a>".format(
+                self._storage_management_hyperlink,
+                self._get_upgrade_link_label(self._storage_used_percent),
+            )
+        else:
+            self._storage_management_hyperlink = ""
+
+        if subscription_information:
+            self.usageLabel.setText(usage_label)
+        else:
+            self.usageLabel.setText(self.tr("N/A"))
+
+    def _get_progressbar_color(self, storage_used_percent: float) -> str:
+        if storage_used_percent >= self.CRITICAL_THRESHOLD:
+            return self.CRITICAL_COLOR
+        elif storage_used_percent >= self.WARNING_THRESHOLD:
+            return self.WARNING_COLOR
+        else:
+            return self.NORMAL_COLOR
+
+    def _get_upgrade_link_label(self, storage_used_percent: float) -> str:
+        if storage_used_percent >= self.CRITICAL_THRESHOLD:
+            return self.tr("upgrade storage")
+        else:
+            return self.tr("manage storage")
+
+    def _get_upgrade_link_url(self, is_premium: bool) -> str:
+        if is_premium:
+            return f"https://app.qfield.cloud/settings/{self._owner}/billing"
+        else:
+            return "https://app.qfield.cloud/plans"

--- a/qfieldsync/ui/cloud_create_project_widget.ui
+++ b/qfieldsync/ui/cloud_create_project_widget.ui
@@ -155,7 +155,7 @@
          <property name="title">
           <string>Project Details</string>
          </property>
-         <layout class="QGridLayout" name="gridLayout_4">
+         <layout class="QGridLayout" name="projectDetailsLayout">
           <item row="2" column="1">
            <layout class="QHBoxLayout" name="projectOwnerHLayout">
             <item>

--- a/qfieldsync/ui/cloud_transfer_dialog.ui
+++ b/qfieldsync/ui/cloud_transfer_dialog.ui
@@ -377,7 +377,7 @@
       </layout>
      </widget>
      <widget class="QWidget" name="filesPage">
-      <layout class="QVBoxLayout" name="verticalLayout_3">
+      <layout class="QVBoxLayout" name="filesLayout">
        <property name="leftMargin">
         <number>0</number>
        </property>

--- a/qfieldsync/ui/storage_widget.ui
+++ b/qfieldsync/ui/storage_widget.ui
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>StorageMeter</class>
+ <widget class="QWidget" name="StorageMeter">
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="MinimumExpanding" vsizetype="Maximum">
+    <horstretch>1</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>234</width>
+    <height>80</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>StorageMeter</string>
+  </property>
+  <layout class="QVBoxLayout" name="layout">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item>
+    <widget class="QProgressBar" name="progressBar">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Maximum">
+       <horstretch>1</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumHeight">
+      <number>8</number>
+     </property>
+     <property name="maximumHeight">
+      <number>8</number>
+     </property>
+     <property name="textVisible">
+      <bool>false</bool>
+     </property>
+     <property name="minimum">
+      <number>0</number>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="usageLabel">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+       <horstretch>1</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="font">
+      <font>
+       <italic>true</italic>
+      </font>
+     </property>
+     <property name="text">
+      <string></string>
+     </property>
+     <property name="openExternalLinks">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/qfieldsync/utils/file_utils.py
+++ b/qfieldsync/utils/file_utils.py
@@ -29,6 +29,8 @@ from enum import Enum
 from pathlib import Path
 from typing import Optional, TypedDict, Union
 
+from qgis.PyQt.QtCore import QObject
+
 # OneDrive Files On-Demand file attributes (Windows)
 _FILE_ATTRIBUTE_RECALL_ON_DATA_ACCESS = 0x00400000
 _FILE_ATTRIBUTE_RECALL_ON_OPEN = 0x00040000
@@ -297,3 +299,42 @@ def rmtree_onedrive_safe(
         max_retries,
         last_error,
     )
+
+
+def filesizeformat10(bytes_: int) -> str:
+    """
+    Format the value like a 'human-readable' file size (i.e. 13 KB, 4.1 MB,
+    102 bytes, etc.).
+    """
+    try:
+        bytes_ = int(bytes_)
+    except (TypeError, ValueError, UnicodeDecodeError):
+        return QObject.tr("%n byte(s)", "", 0)
+
+    KB = 10**3  # noqa: N806
+    MB = 10**6  # noqa: N806
+    GB = 10**9  # noqa: N806
+    TB = 10**12  # noqa: N806
+    PB = 10**15  # noqa: N806
+
+    negative = bytes_ < 0
+    if negative:
+        bytes_ = -bytes_  # Allow formatting of negative numbers.
+
+    if bytes_ < KB:
+        value = QObject.tr("%n byte(s)", "", bytes_)
+    elif bytes_ < MB:
+        value = QObject.tr("{} KB").format(round(bytes_ / KB, 1))
+    elif bytes_ < GB:
+        value = QObject.tr("{} MB").format(round(bytes_ / MB, 1))
+    elif bytes_ < TB:
+        value = QObject.tr("{} GB").format(round(bytes_ / GB, 1))
+    elif bytes_ < PB:
+        value = QObject.tr("{} TB").format(round(bytes_ / TB, 1))
+    else:
+        value = QObject.tr("{} PB").format(round(bytes_ / PB, 1))
+
+    if negative:
+        value = "-{}".format(value)
+
+    return value


### PR DESCRIPTION
This PR implements a storage widget to display a given QFC user's used and available storage. As with QField, if the user is getting close or as used 100% of their available storage, they will be invited to upgrade via an hyperlink attached to the storage widget.

The storage widget is being used in two places:
- Within the project creation dialog; and
- Within the project synchronization dialog

Screenshot time.

<img width="2005" height="721" alt="image1" src="https://github.com/user-attachments/assets/0d245ae3-ff5c-4317-968a-a513c68b9870" />

<img width="1878" height="630" alt="image2" src="https://github.com/user-attachments/assets/951f8232-030c-4f17-8ae5-cac754c2db17" />

