### PR TITLE
Remove completely redundant scripts directory as nobody uses the scripts in there

### DIFF
--- a/scripts/prepare-commit.sh
+++ b/scripts/prepare-commit.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-ROOT_DIR=$(git rev-parse --show-toplevel)
-
-autopep8 -r --in-place --ignore=E261,E265,E402,E501 $ROOT_DIR/qfieldsync/core
-autopep8 -r --in-place --ignore=E261,E265,E402,E501 $ROOT_DIR/qfieldsync/gui


### PR DESCRIPTION
We have pre-commit CLI to handle.