### PR TITLE
Let Qt handle styling for the read-only local project path line edit

### DIFF
--- a/qfieldsync/ui/cloud_transfer_dialog.ui
+++ b/qfieldsync/ui/cloud_transfer_dialog.ui
@@ -541,9 +541,6 @@
              <layout class="QHBoxLayout" name="localDirHBoxLayout">
               <item>
                <widget class="QLineEdit" name="projectLocalDirValueLineEdit">
-                <property name="styleSheet">
-                 <string notr="true">[readOnly=&quot;true&quot;] {color: palette(shadow );}</string>
-                </property>
                 <property name="readOnly">
                  <bool>true</bool>
                 </property>


### PR DESCRIPTION
I keep stumbling on this and forget to fix it. No more!

In the cloud transfer dialog, when using a dark theme, the local project line edit is essentially unreadable:

<img width="989" height="501" alt="image1-3" src="https://github.com/user-attachments/assets/d661a666-1187-4f38-8453-43e9b6fc8eb5" />

The PR fixes the situation by removing the custom stylesheet we apply there and revert to Qt's default handling.