### PR TITLE
Set the `no-commit-to-branch` to be skipped, otherwise the check fails when we merge to `master` branch

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -23,6 +23,9 @@ jobs:
       - uses: actions/setup-python@v6
 
       - uses: pre-commit/action@v3.0.1
+        env:
+          # set the `no-commit-to-branch` to be skipped, otherwise the check fails when we merge to `master` branch
+          SKIP: no-commit-to-branch
 
   pyqt6-check:
     name: PyQt6 compatibility check


### PR DESCRIPTION
It already fails on master, so cannot get worse :)