### PR TITLE
Harmonize project properties' "is public" property, make it functional for projects owned by the logged in user.

### DIFF
--- a/qfieldsync/core/cloud_api.py
+++ b/qfieldsync/core/cloud_api.py
@@ -564,7 +564,7 @@ class CloudNetworkAccessManager(QObject):
             },
         )
 
-    def update_project(self, project_id: str, details: dict) -> QNetworkReply:
+    def update_project(self, project_id: str, details: dict[str, Any]) -> QNetworkReply:
         """Update an existing QFieldCloud project"""
         return self.cloud_patch(
             ["projects", project_id],

--- a/qfieldsync/core/cloud_api.py
+++ b/qfieldsync/core/cloud_api.py
@@ -564,16 +564,11 @@ class CloudNetworkAccessManager(QObject):
             },
         )
 
-    def update_project(
-        self, project_id: str, name: str, description: str
-    ) -> QNetworkReply:
+    def update_project(self, project_id: str, details: dict) -> QNetworkReply:
         """Update an existing QFieldCloud project"""
         return self.cloud_patch(
             ["projects", project_id],
-            {
-                "name": name,
-                "description": description,
-            },
+            details,
         )
 
     def delete_project(self, project_id: str) -> QNetworkReply:

--- a/qfieldsync/core/cloud_project.py
+++ b/qfieldsync/core/cloud_project.py
@@ -268,8 +268,8 @@ class CloudProject:
         return self._data["description"]
 
     @property
-    def is_private(self) -> bool:
-        return self._data["private"]
+    def is_public(self) -> bool:
+        return self._data["is_public"]
 
     @property
     def created_at(self) -> str:

--- a/qfieldsync/gui/cloud_browser_tree.py
+++ b/qfieldsync/gui/cloud_browser_tree.py
@@ -172,8 +172,8 @@ class QFieldCloudGroupItem(QgsDataCollectionItem):
             projects = self.network_manager.projects_cache.projects
 
         for project in self.network_manager.projects_cache.projects:
-            if (self.project_type == "public" and not project.is_private) or (
-                self.project_type == "private" and project.is_private
+            if (self.project_type == "public" and project.is_public) or (
+                self.project_type == "private" and not project.is_public
             ):
                 item = QFieldCloudProjectItem(self, project)
                 item.setState(QgsDataItem.State.Populated)

--- a/qfieldsync/gui/cloud_projects_dialog.py
+++ b/qfieldsync/gui/cloud_projects_dialog.py
@@ -80,7 +80,7 @@ from qfieldsync.utils.cloud_utils import (
     get_cloud_project_status_color,
     local_dir_feedback,
 )
-from qfieldsync.utils.permissions import can_delete_project
+from qfieldsync.utils.permissions import can_delete_project, can_update_project
 from qfieldsync.utils.qt_utils import rounded_pixmap
 
 CloudProjectsDialogUi, _ = loadUiType(
@@ -894,12 +894,25 @@ class CloudProjectsDialog(QDialog, CloudProjectsDialogUi):
 
         self.projectTabs.setTabEnabled(1, True)
         self.projectTabs.setTabEnabled(2, True)
+
         self.projectNameLineEdit.setText(self.current_cloud_project.name)
+        self.projectNameLineEdit.setReadOnly(
+            not can_update_project(self.current_cloud_project)
+        )
         self.projectDescriptionTextEdit.setPlainText(
             self.current_cloud_project.description
         )
-        self.projectIsPrivateCheckBox.setChecked(self.current_cloud_project.is_private)
+        self.projectDescriptionTextEdit.setReadOnly(
+            not can_update_project(self.current_cloud_project)
+        )
+
+        self.projectIsPublicCheckBox.setChecked(self.current_cloud_project.is_public)
+        self.projectIsPublicCheckBox.setEnabled(
+            can_update_project(self.current_cloud_project)
+        )
+
         self.projectOwnerLineEdit.setText(self.current_cloud_project.owner)
+
         self.localDirLineEdit.setText(self.current_cloud_project.local_dir or "")
         self.projectUrlLabelValue.setText(
             '<a href="{url}">{url}</a>'.format(
@@ -944,16 +957,13 @@ class CloudProjectsDialog(QDialog, CloudProjectsDialogUi):
         assert self.current_cloud_project
 
         should_update_online = False
-        if (
-            self.current_cloud_project.name != self.projectNameLineEdit.text()
-            or self.current_cloud_project.description
-            != self.projectDescriptionTextEdit.toPlainText()
-        ):
-            cloud_project_data = {
-                "name": self.projectNameLineEdit.text(),
-                "description": self.projectDescriptionTextEdit.toPlainText(),
-            }
+        cloud_project_data = {}
 
+        if (
+            not self.projectNameLineEdit.isReadOnly()
+            and self.current_cloud_project.name != self.projectNameLineEdit.text()
+        ):
+            cloud_project_data["name"] = self.projectNameLineEdit.text()
             if (
                 self.projectNameLineEdit.validator().validate(
                     cloud_project_data["name"], 0
@@ -964,19 +974,35 @@ class CloudProjectsDialog(QDialog, CloudProjectsDialogUi):
                     None,
                     self.tr("Invalid project name"),
                     self.tr(
-                        "You cannot create a new project without setting a valid name first."
+                        "Your project name is invalid, please ensure the name is unique and only contains accepted characters."
                     ),
                 )
                 return
 
+        if (
+            not self.projectDescriptionTextEdit.isReadOnly()
+            and self.current_cloud_project.description
+            != self.projectDescriptionTextEdit.toPlainText()
+        ):
+            cloud_project_data["description"] = (
+                self.projectDescriptionTextEdit.toPlainText()
+            )
+
+        if (
+            self.projectIsPublicCheckBox.isEnabled()
+            and self.current_cloud_project.is_public
+            != self.projectIsPublicCheckBox.isChecked()
+        ):
+            cloud_project_data["is_public"] = self.projectIsPublicCheckBox.isChecked()
+
+        if cloud_project_data:
             self.projectsFormPage.setEnabled(False)
 
             self.set_feedback(self.tr("Updating project…"))
 
             reply = self.network_manager.update_project(
                 self.current_cloud_project.id,
-                cloud_project_data["name"],
-                cloud_project_data["description"],
+                cloud_project_data,
             )
             reply.finished.connect(lambda: self.on_update_project_finished(reply))
 

--- a/qfieldsync/ui/cloud_projects_dialog.ui
+++ b/qfieldsync/ui/cloud_projects_dialog.ui
@@ -379,7 +379,7 @@
                 </property>
                </widget>
               </item>
-              <item row="3" column="0">
+              <item row="4" column="0">
                <widget class="QLabel" name="projectOwnerLabel">
                 <property name="text">
                  <string>Owner</string>
@@ -387,36 +387,29 @@
                </widget>
               </item>
               <item row="1" column="1">
-               <layout class="QHBoxLayout" name="projectFormButtonLayout">
-                <property name="leftMargin">
-                 <number>0</number>
+               <widget class="QLineEdit" name="projectNameLineEdit">
+                <property name="toolTip">
+                 <string>A valid project name consists of at least 3 characters, starting with a letter and containing nothing other than letters, digits, dashes and underscores</string>
                 </property>
-                <property name="topMargin">
-                 <number>0</number>
-                </property>
-                <item>
-                 <widget class="QLineEdit" name="projectNameLineEdit">
-                  <property name="toolTip">
-                   <string>A valid project name consists of at least 3 characters, starting with a letter and containing nothing other than letters, digits, dashes and underscores</string>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QCheckBox" name="projectIsPrivateCheckBox">
-                  <property name="enabled">
-                   <bool>false</bool>
-                  </property>
-                  <property name="text">
-                   <string>Private</string>
-                  </property>
-                 </widget>
-                </item>
-               </layout>
+               </widget>
               </item>
               <item row="2" column="1">
                <widget class="QPlainTextEdit" name="projectDescriptionTextEdit"/>
               </item>
               <item row="3" column="1">
+               <widget class="QCheckBox" name="projectIsPublicCheckBox">
+                <property name="enabled">
+                 <bool>false</bool>
+                </property>
+                <property name="text">
+                 <string>Is public</string>
+                </property>
+                <property name="toolTip">
+                 <string>Projects marked as public are visible to (but not editable by) anyone</string>
+                </property>
+               </widget>
+              </item>
+              <item row="4" column="1">
                <widget class="QLineEdit" name="projectOwnerLineEdit">
                 <property name="enabled">
                  <bool>false</bool>
@@ -498,6 +491,13 @@
               <number>0</number>
              </property>
              <item>
+              <widget class="QPushButton" name="editOnlineButton">
+               <property name="text">
+                <string>Edit on QFieldCloud</string>
+               </property>
+              </widget>
+             </item>
+             <item>
               <spacer name="projectFormButtonSpacer_2">
                <property name="orientation">
                 <enum>Qt::Horizontal</enum>
@@ -509,13 +509,6 @@
                 </size>
                </property>
               </spacer>
-             </item>
-             <item>
-              <widget class="QPushButton" name="editOnlineButton">
-               <property name="text">
-                <string>Edit on QFieldCloud</string>
-               </property>
-              </widget>
              </item>
              <item>
               <widget class="QPushButton" name="submitButton">

--- a/qfieldsync/utils/permissions.py
+++ b/qfieldsync/utils/permissions.py
@@ -7,3 +7,7 @@ def can_change_project_owner(project: CloudProject) -> bool:
 
 def can_delete_project(project: CloudProject) -> bool:
     return project.user_role == "admin"
+
+
+def can_update_project(project: CloudProject) -> bool:
+    return project.user_role in {"admin", "manager"}


### PR DESCRIPTION
For historical reasons, QFieldSync was showing a [x] private checkbox in the project properties dialog, while we ultimately adopted a [x] is public checkbox UI on app.qfield.cloud. This PR harmonizes the UI matching what users see on the web side of things.

In addition, the PR enables the checkbox when the project owner matches the currently logged in user, allowing for this setting to be modified within QFieldSync itself.

Before (left) vs. PR (right):

<img width="900" height="527" alt="ba" src="https://github.com/user-attachments/assets/925781c2-ec90-4fa9-9b3f-0d2b39f0d0f5" />

