### PR TITLE
Fix duplicate cloud project item names in the browser panel

### DIFF
--- a/qfieldsync/gui/cloud_browser_tree.py
+++ b/qfieldsync/gui/cloud_browser_tree.py
@@ -189,7 +189,7 @@ class QFieldCloudProjectItem(QgsDataItem):
         super().__init__(
             QgsDataItem.Type.Collection,
             parent,
-            project.name,
+            f"{project.owner}/{project.name}",
             "/QFieldCloud/project/" + project.id,
         )
         self.project_id = project.id


### PR DESCRIPTION
Before:

<img width="671" height="546" alt="image" src="https://github.com/user-attachments/assets/2c5ff834-d251-43f0-9bd1-78a78ac99b5b" />

PR:

<img width="635" height="1027" alt="image" src="https://github.com/user-attachments/assets/1c92b8c3-26ca-442c-92cf-e456332cdcac" />

There's room here to do a lot more (e.g. regrouping projects under a parent owner item in the tree), but let's defer that for later.