### PR TITLE
Restore cloud projects sorting order following upgrade to model

### DIFF
--- a/qfieldsync/gui/cloud_projects_dialog.py
+++ b/qfieldsync/gui/cloud_projects_dialog.py
@@ -325,6 +325,7 @@ class CloudProjectsDialog(QDialog, CloudProjectsDialogUi):
     def on_cloud_projects_model_refreshed(self) -> None:
         self.projectsTable.setColumnWidth(0, int(self.projectsTable.width() * 0.75))
         self.projectsTable.setColumnWidth(1, int(self.projectsTable.width() * 0.25))
+        self.projectsTable.sortByColumn(0, Qt.SortOrder.AscendingOrder)
 
     def on_projects_cached_projects_started(self) -> None:
         self.projectsStack.setEnabled(False)

--- a/qfieldsync/gui/cloud_projects_model.py
+++ b/qfieldsync/gui/cloud_projects_model.py
@@ -63,6 +63,7 @@ class CloudProjectsModel(QSortFilterProxyModel):
         self.filter_string = ""
 
         self.setDynamicSortFilter(True)
+        self.setSortCaseSensitivity(Qt.CaseSensitivity.CaseInsensitive)
 
     def set_include_public(self, include_public: bool) -> None:
         if self.include_public == include_public:


### PR DESCRIPTION
I had not seen that until now as I was developing the model upgrade using a custom sorting (that'll be for a different PR :) ). This just restore the previous sorting behavior.