### PR TITLE
Add a new `Config` class that sets project level configurations to the qgs file

### DIFF
--- a/qfieldsync/gui/map_overlay_configuration_widget.py
+++ b/qfieldsync/gui/map_overlay_configuration_widget.py
@@ -1,6 +1,6 @@
 import os
 
-from libqfieldsync.project import ProjectProperties
+from libqfieldsync.project import QFieldItemSize
 from qgis.gui import QgsPanelWidget
 from qgis.PyQt.QtGui import QColor
 from qgis.PyQt.uic import loadUiType
@@ -21,10 +21,10 @@ class MapOverlayConfigurationWidget(WidgetUi, QgsPanelWidget):
         self.setPanelTitle(self.tr("Map Overlay Elements"))
 
         size_options = [
-            (self.tr("Tiny"), ProjectProperties.QFieldItemSize.TINY),
-            (self.tr("Normal"), ProjectProperties.QFieldItemSize.NORMAL),
-            (self.tr("Big"), ProjectProperties.QFieldItemSize.BIG),
-            (self.tr("Biggest"), ProjectProperties.QFieldItemSize.BIGGEST),
+            (self.tr("Tiny"), QFieldItemSize.TINY),
+            (self.tr("Normal"), QFieldItemSize.NORMAL),
+            (self.tr("Big"), QFieldItemSize.BIG),
+            (self.tr("Biggest"), QFieldItemSize.BIGGEST),
         ]
 
         for label, value in size_options:
@@ -87,9 +87,7 @@ class MapOverlayConfigurationWidget(WidgetUi, QgsPanelWidget):
     def set_location_arrow_size(self, size):
         index = self.locationArrowSizeComboBox.findData(size)
         if index == -1:
-            index = self.locationArrowSizeComboBox.findData(
-                ProjectProperties.QFieldItemSize.NORMAL
-            )
+            index = self.locationArrowSizeComboBox.findData(QFieldItemSize.NORMAL)
 
         self.locationArrowSizeComboBox.setCurrentIndex(index)
 
@@ -127,8 +125,6 @@ class MapOverlayConfigurationWidget(WidgetUi, QgsPanelWidget):
     def set_coordinate_cursor_size(self, size):
         index = self.coordinateCursorSizeComboBox.findData(size)
         if index == -1:
-            index = self.coordinateCursorSizeComboBox.findData(
-                ProjectProperties.QFieldItemSize.NORMAL
-            )
+            index = self.coordinateCursorSizeComboBox.findData(QFieldItemSize.NORMAL)
 
         self.coordinateCursorSizeComboBox.setCurrentIndex(index)

--- a/qfieldsync/gui/package_dialog.py
+++ b/qfieldsync/gui/package_dialog.py
@@ -46,7 +46,7 @@ except ModuleNotFoundError:
         ),
     )
 
-from libqfieldsync.project import ProjectConfiguration
+from libqfieldsync.project import ProjectConfig
 from libqfieldsync.project_checker import ProjectChecker
 from libqfieldsync.utils.file_utils import fileparts
 from libqfieldsync.utils.qgis import get_project_title
@@ -79,8 +79,8 @@ class PackageDialog(QDialog, DialogUi):
         self.offliner = QgisCoreOffliner(offline_editing=offline_editing)
         self.project = project
         self.qfield_preferences = Preferences()
+        self.config = ProjectConfig(self.project)
         self.dirsToCopyWidget = DirsToCopyWidget()
-        self.__project_configuration = ProjectConfiguration(self.project)
         self.button_box.button(QDialogButtonBox.StandardButton.Save).setText(
             self.tr("Create")
         )
@@ -228,13 +228,13 @@ class PackageDialog(QDialog, DialogUi):
 
         self.button_box.button(QDialogButtonBox.StandardButton.Save).setEnabled(True)
 
-        if self.__project_configuration.area_of_interest:
-            area_of_interest = self.__project_configuration.area_of_interest
+        if self.config.area_of_interest:
+            area_of_interest = self.config.area_of_interest
         else:
             area_of_interest = self.iface.mapCanvas().extent().asWktPolygon()
 
-        if self.__project_configuration.area_of_interest_crs:
-            area_of_interest_crs = self.__project_configuration.area_of_interest_crs
+        if self.config.area_of_interest_crs:
+            area_of_interest_crs = self.config.area_of_interest_crs
         else:
             area_of_interest_crs = QgsProject.instance().crs().authid()
 

--- a/qfieldsync/gui/project_configuration_widget.py
+++ b/qfieldsync/gui/project_configuration_widget.py
@@ -21,7 +21,12 @@ import contextlib
 import os
 
 from libqfieldsync.layer import LayerSource
-from libqfieldsync.project import ProjectConfiguration, ProjectProperties
+from libqfieldsync.project import (
+    BaseMapType,
+    GeofencingBehavior,
+    InitialMapMode,
+    ProjectConfig,
+)
 from qgis.core import (
     Qgis,
     QgsCoordinateReferenceSystem,
@@ -91,7 +96,7 @@ class ProjectConfigurationWidget(WidgetUi, QgsPanelWidget):
 
         self.project = QgsProject.instance()
         self.preferences = Preferences()
-        self.__project_configuration = ProjectConfiguration(self.project)
+        self.__project_configuration = ProjectConfig(self.project)
 
         self.stamping_font_style = self.__project_configuration.stamping_font_style
         self.stamping_horizontal_alignment = (
@@ -182,15 +187,15 @@ class ProjectConfigurationWidget(WidgetUi, QgsPanelWidget):
 
         self.geofencingBehaviorComboBox.addItem(
             self.tr("Alert users when inside an area"),
-            ProjectProperties.GeofencingBehavior.ALERT_INSIDE_AREAS,
+            GeofencingBehavior.ALERT_INSIDE_AREAS,
         )
         self.geofencingBehaviorComboBox.addItem(
             self.tr("Alert users when outside all areas"),
-            ProjectProperties.GeofencingBehavior.ALERT_OUTSIDE_AREAS,
+            GeofencingBehavior.ALERT_OUTSIDE_AREAS,
         )
         self.geofencingBehaviorComboBox.addItem(
             self.tr("Inform users when entering and leaving an area"),
-            ProjectProperties.GeofencingBehavior.INFORM_ENTER_LEAVE_AREAS,
+            GeofencingBehavior.INFORM_ENTER_LEAVE_AREAS,
         )
 
         self.initialMapModeComboBox.addItem(
@@ -198,7 +203,7 @@ class ProjectConfigurationWidget(WidgetUi, QgsPanelWidget):
                 os.path.join(os.path.dirname(__file__), "../resources/state_browse.svg")
             ),
             self.tr("Browse"),
-            ProjectProperties.InitialMapMode.BROWSE,
+            InitialMapMode.BROWSE,
         )
         self.initialMapModeComboBox.addItem(
             QIcon(
@@ -207,7 +212,7 @@ class ProjectConfigurationWidget(WidgetUi, QgsPanelWidget):
                 )
             ),
             self.tr("Digitize"),
-            ProjectProperties.InitialMapMode.DIGITIZE,
+            InitialMapMode.DIGITIZE,
         )
 
         self._reload_project()
@@ -256,7 +261,7 @@ class ProjectConfigurationWidget(WidgetUi, QgsPanelWidget):
             self.digitizingLogsLayerComboBox.setProject(self.project)
             self.initialActiveLayerComboBox.setProject(self.project)
 
-        self.__project_configuration = ProjectConfiguration(self.project)
+        self.__project_configuration = ProjectConfig(self.project)
 
         self.mapThemesConfigWidget = MapThemesConfigWidget(
             self.project, self.__project_configuration.map_themes_active_layer
@@ -268,10 +273,7 @@ class ProjectConfigurationWidget(WidgetUi, QgsPanelWidget):
             self.__project_configuration.create_base_map
         )
 
-        if (
-            self.__project_configuration.base_map_type
-            == ProjectProperties.BaseMapType.SINGLE_LAYER
-        ):
+        if self.__project_configuration.base_map_type == BaseMapType.SINGLE_LAYER:
             self.singleLayerRadioButton.setChecked(True)
         else:
             self.mapThemeRadioButton.setChecked(True)
@@ -397,13 +399,9 @@ class ProjectConfigurationWidget(WidgetUi, QgsPanelWidget):
         )
 
         if self.singleLayerRadioButton.isChecked():
-            self.__project_configuration.base_map_type = (
-                ProjectProperties.BaseMapType.SINGLE_LAYER
-            )
+            self.__project_configuration.base_map_type = BaseMapType.SINGLE_LAYER
         else:
-            self.__project_configuration.base_map_type = (
-                ProjectProperties.BaseMapType.MAP_THEME
-            )
+            self.__project_configuration.base_map_type = BaseMapType.MAP_THEME
 
         self.__project_configuration.base_map_theme = (
             self.mapThemeComboBox.currentText()

--- a/qfieldsync/gui/synchronize_dialog.py
+++ b/qfieldsync/gui/synchronize_dialog.py
@@ -24,7 +24,7 @@ import os
 from pathlib import Path
 from typing import Optional
 
-from libqfieldsync.project import ProjectConfiguration
+from libqfieldsync.project import ProjectConfig
 from libqfieldsync.utils.exceptions import NoProjectFoundError
 from libqfieldsync.utils.file_utils import (
     copy_attachments,
@@ -121,7 +121,7 @@ class SynchronizeDialog(QDialog, DialogUi):
             except Exception:
                 self.offline_editing.synchronize()
 
-            project_config = ProjectConfiguration(QgsProject.instance())
+            project_config = ProjectConfig(QgsProject.instance())
             original_path = Path(project_config.original_project_path or "")
 
             if not original_path.exists():
@@ -181,7 +181,7 @@ class SynchronizeDialog(QDialog, DialogUi):
 
                 # save the data_file_checksum to the project and save it
                 imported_files_checksums.append(import_file_checksum(str(qfield_path)))
-                ProjectConfiguration(
+                ProjectConfig(
                     QgsProject.instance()
                 ).imported_files_checksums = imported_files_checksums
                 QgsProject.instance().write()

--- a/qfieldsync/utils/qgis_utils.py
+++ b/qfieldsync/utils/qgis_utils.py
@@ -17,7 +17,7 @@
  ***************************************************************************/
 """
 
-from libqfieldsync.project import ProjectConfiguration
+from libqfieldsync.project import ProjectConfig
 from libqfieldsync.utils.file_utils import get_project_in_folder
 from libqfieldsync.utils.qgis import open_project
 from qgis.core import QgsProject
@@ -27,6 +27,6 @@ def import_checksums_of_project(dirname: str) -> list[str]:
     project = QgsProject.instance()
     qgs_file = get_project_in_folder(dirname)
     open_project(qgs_file)
-    original_project_path = ProjectConfiguration(project).original_project_path
+    original_project_path = ProjectConfig(project).original_project_path
     open_project(original_project_path)
-    return ProjectConfiguration(project).imported_files_checksums
+    return ProjectConfig(project).imported_files_checksums

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 # NOTE `libqfielsync` version should be defined in the `*.tar.gz` format, not `git+https://` to make `wheel` happy
-libqfieldsync @ https://github.com/opengisch/libqfieldsync/archive/b3541aa99630f39354e479c75f0f1bcb2f7020ba.tar.gz
+libqfieldsync @ https://github.com/opengisch/libqfieldsync/archive/b83bfa46646d218a95202b62e8431354ead3de48.tar.gz


### PR DESCRIPTION
Previously one was required to use `ProjectProperties` and to explicitly define a getter and setter for a given property. This was tiresome, repetitive
 and error prone.

Check libqfieldsync for full understanding of the change.

This is very similar to what `settings_manager` does and it will eventually replace it.

See https://github.com/opengisch/libqfieldsync/pull/156