### PR TITLE
fix: file storage widget fails to load due to Python error trying to call `tr()` statically on `QObject`

### DIFF
--- a/qfieldsync/utils/file_utils.py
+++ b/qfieldsync/utils/file_utils.py
@@ -306,10 +306,11 @@ def filesizeformat10(bytes_: int) -> str:
     Format the value like a 'human-readable' file size (i.e. 13 KB, 4.1 MB,
     102 bytes, etc.).
     """
+    tmp_obj = QObject()
     try:
         bytes_ = int(bytes_)
     except (TypeError, ValueError, UnicodeDecodeError):
-        return QObject.tr("%n byte(s)", "", 0)
+        return tmp_obj.tr("%n byte(s)", "", 0)
 
     KB = 10**3  # noqa: N806
     MB = 10**6  # noqa: N806
@@ -322,17 +323,17 @@ def filesizeformat10(bytes_: int) -> str:
         bytes_ = -bytes_  # Allow formatting of negative numbers.
 
     if bytes_ < KB:
-        value = QObject.tr("%n byte(s)", "", bytes_)
+        value = tmp_obj.tr("%n byte(s)", "", bytes_)
     elif bytes_ < MB:
-        value = QObject.tr("{} KB").format(round(bytes_ / KB, 1))
+        value = tmp_obj.tr("{} KB").format(round(bytes_ / KB, 1))
     elif bytes_ < GB:
-        value = QObject.tr("{} MB").format(round(bytes_ / MB, 1))
+        value = tmp_obj.tr("{} MB").format(round(bytes_ / MB, 1))
     elif bytes_ < TB:
-        value = QObject.tr("{} GB").format(round(bytes_ / GB, 1))
+        value = tmp_obj.tr("{} GB").format(round(bytes_ / GB, 1))
     elif bytes_ < PB:
-        value = QObject.tr("{} TB").format(round(bytes_ / TB, 1))
+        value = tmp_obj.tr("{} TB").format(round(bytes_ / TB, 1))
     else:
-        value = QObject.tr("{} PB").format(round(bytes_ / PB, 1))
+        value = tmp_obj.tr("{} PB").format(round(bytes_ / PB, 1))
 
     if negative:
         value = "-{}".format(value)


### PR DESCRIPTION
Just make a tmp `QObject`, used in several other places too.

Error:
```
TypeError: tr(self, sourceText: str, disambiguation: str = None, n: int = -1): first argument of unbound method must have type 'QObject'
```