### PR TITLE
Better table selection handling to fix assert error when reopening the cloud projects dialog

### DIFF
--- a/qfieldsync/gui/cloud_projects_dialog.py
+++ b/qfieldsync/gui/cloud_projects_dialog.py
@@ -154,6 +154,9 @@ class CloudProjectsDialog(QDialog, CloudProjectsDialogUi):
         )
         self.projectsTable.setModel(self.cloud_projects_model)
 
+        # Adjust projects table column width and sorting
+        self.on_cloud_projects_model_refreshed()
+
         self.synchronizeButton.clicked.connect(
             lambda: self.on_project_sync_button_clicked()
         )
@@ -1022,7 +1025,7 @@ class CloudProjectsDialog(QDialog, CloudProjectsDialogUi):
                     QAbstractItemView.ScrollHint.EnsureVisible,
                 )
 
-            self.update_project_buttons()
+        self.update_project_buttons()
 
     def on_update_project_finished(self, reply: QNetworkReply) -> None:
         self.projectsFormPage.setEnabled(True)
@@ -1039,9 +1042,9 @@ class CloudProjectsDialog(QDialog, CloudProjectsDialogUi):
         self.network_manager.projects_cache.refresh()
 
     def on_projects_table_selection_changed(self) -> None:
-        if self.projectsTable.selectionModel().hasSelection():
+        if self.projectsTable.selectedIndexes():
             idx = self.projectsTable.model().index(
-                self.projectsTable.selectionModel().currentIndex().row(), 0
+                self.projectsTable.selectedIndexes()[0].row(), 0
             )
             self.current_cloud_project = self.projectsTable.model().data(
                 idx, Qt.ItemDataRole.UserRole
@@ -1053,10 +1056,10 @@ class CloudProjectsDialog(QDialog, CloudProjectsDialogUi):
         has_selection = False
         is_currently_open_project = False
         can_delete_selected_project = False
-        if self.projectsTable.selectionModel().hasSelection():
+        if self.projectsTable.selectedIndexes():
             has_selection = True
             idx = self.projectsTable.model().index(
-                self.projectsTable.selectionModel().currentIndex().row(), 0
+                self.projectsTable.selectedIndexes()[0].row(), 0
             )
             self.current_cloud_project = self.projectsTable.model().data(
                 idx, Qt.ItemDataRole.UserRole

--- a/qfieldsync/gui/cloud_projects_model.py
+++ b/qfieldsync/gui/cloud_projects_model.py
@@ -117,6 +117,8 @@ class CloudProjectsModelBase(QStandardItemModel):
         )
         self.network_manager.logout_success.connect(lambda: self._refresh())
 
+        self._refresh()
+
     def _get_name_item(self, cloud_project: CloudProject) -> QStandardItem:
         item = QStandardItem()
         item.setData(cloud_project, Qt.ItemDataRole.UserRole)


### PR DESCRIPTION
Fixes https://github.com/opengisch/qfieldsync/issues/796 

The commit also fixes a blank projects list when reopening the cloud projects dialog by trigger a refresh from cache when creating the model.