### PR TITLE
Add ability to make a cloud project public during the creation process

### DIFF
--- a/qfieldsync/core/cloud_api.py
+++ b/qfieldsync/core/cloud_api.py
@@ -551,7 +551,7 @@ class CloudNetworkAccessManager(QObject):
         return response.json()
 
     def create_project(
-        self, name: str, owner: str, description: str, private: bool
+        self, name: str, owner: str, description: str, is_public: bool
     ) -> QNetworkReply:
         """Create a new QFieldCloud project"""
         return self.cloud_post(
@@ -560,7 +560,7 @@ class CloudNetworkAccessManager(QObject):
                 "name": name,
                 "owner": owner,
                 "description": description,
-                "private": private,
+                "is_public": is_public,
             },
         )
 

--- a/qfieldsync/gui/cloud_create_project_widget.py
+++ b/qfieldsync/gui/cloud_create_project_widget.py
@@ -133,7 +133,7 @@ class CloudCreateProjectWidget(QWidget, WidgetUi):
         )
 
         self.storage_widget = StorageWidget(self.network_manager, self)
-        self.projectDetailsLayout.addWidget(self.storage_widget, 3, 1)
+        self.projectDetailsLayout.addWidget(self.storage_widget, 5, 1)
 
     def restart(self):
         self.stackedWidget.setCurrentWidget(self.selectTypePage)
@@ -228,7 +228,7 @@ class CloudCreateProjectWidget(QWidget, WidgetUi):
             self.get_cloud_project_name(),
             self.projectOwnerComboBox.currentText(),
             description,
-            True,
+            self.projectIsPublicCheckBox.isChecked(),
         )
         reply.finished.connect(lambda: self.on_create_project_finished(reply))
 

--- a/qfieldsync/ui/cloud_create_project_widget.ui
+++ b/qfieldsync/ui/cloud_create_project_widget.ui
@@ -156,7 +156,7 @@
           <string>Project Details</string>
          </property>
          <layout class="QGridLayout" name="projectDetailsLayout">
-          <item row="2" column="1">
+          <item row="3" column="1">
            <layout class="QHBoxLayout" name="projectOwnerHLayout">
             <item>
              <widget class="QComboBox" name="projectOwnerComboBox"/>
@@ -181,7 +181,7 @@
             </property>
            </widget>
           </item>
-          <item row="2" column="0">
+          <item row="3" column="0">
            <widget class="QLabel" name="projectOwnerLabel">
             <property name="text">
              <string>Owner</string>
@@ -198,6 +198,16 @@
           <item row="1" column="1">
            <widget class="QTextEdit" name="projectDescriptionTextEdit"/>
           </item>
+          <item row="2" column="1">
+           <widget class="QCheckBox" name="projectIsPublicCheckBox">
+            <property name="text">
+             <string>Is public</string>
+            </property>
+            <property name="toolTip">
+             <string>Projects marked as public are visible to (but not editable by) anyone</string>
+            </property>
+           </widget>
+          </item>
           <item row="0" column="1">
            <widget class="QLineEdit" name="projectNameLineEdit">
             <property name="sizePolicy">
@@ -211,7 +221,7 @@
             </property>
            </widget>
           </item>
-          <item row="3" column="1">
+          <item row="4" column="1">
            <widget class="QLabel" name="projectOwnerFeedbackLabel">
             <property name="visible">
              <bool>false</bool>


### PR DESCRIPTION
Title says it all. Screenshot:

<img width="693" height="671" alt="image" src="https://github.com/user-attachments/assets/7471c9cf-177a-4251-84eb-deac31234628" />

Since we can control whether a cloud project is public or not during creation through app.qfield.cloud, and we now have a clear UI when editing project properties in QFS, it feels like we'd benefit from matching that UI and behavior for projection creation in QFS.