### PR TITLE
Present project properties' files details using friendly file sizes

### DIFF
--- a/qfieldsync/gui/cloud_projects_dialog.py
+++ b/qfieldsync/gui/cloud_projects_dialog.py
@@ -74,6 +74,7 @@ from qfieldsync.utils.cloud_utils import (
     closure,
     local_dir_feedback,
 )
+from qfieldsync.utils.file_utils import filesizeformat10
 from qfieldsync.utils.permissions import can_delete_project, can_update_project
 from qfieldsync.utils.qt_utils import rounded_pixmap
 
@@ -418,7 +419,7 @@ class CloudProjectsDialog(QDialog, CloudProjectsDialogUi):
                     item.setToolTip(0, project_file.name)
                     item.setData(0, Qt.ItemDataRole.UserRole, project_file)
 
-                    item.setText(1, str(project_file.size))
+                    item.setText(1, filesizeformat10(project_file.size))
                     item.setTextAlignment(1, Qt.AlignmentFlag.AlignRight)
                     item.setText(2, project_file.created_at)
 
@@ -432,7 +433,7 @@ class CloudProjectsDialog(QDialog, CloudProjectsDialogUi):
                             "display", versions_count - version_idx
                         )
                         version_item.setText(0, "Version {}".format(version_display))
-                        version_item.setText(1, str(version_obj["size"]))
+                        version_item.setText(1, filesizeformat10(version_obj["size"]))
                         version_item.setTextAlignment(1, Qt.AlignmentFlag.AlignRight)
                         version_item.setText(2, version_obj["last_modified"])
 

--- a/qfieldsync/ui/cloud_projects_dialog.ui
+++ b/qfieldsync/ui/cloud_projects_dialog.ui
@@ -638,7 +638,7 @@
              </column>
              <column>
               <property name="text">
-               <string>Size (bytes)</string>
+               <string>Size</string>
               </property>
              </column>
              <column>


### PR DESCRIPTION
Before (left) vs PR (right):

<img width="1281" height="489" alt="rect1" src="https://github.com/user-attachments/assets/31bf07d4-d967-451c-b760-159c0fe419dd" />

Tiny paper cut I stumbled upon when doing the storage meter last week. I can't unsee so better fix it :)