### PR TITLE
We store the timestamp value in a track's M dimension as _seconds_ since epoch

### DIFF
--- a/qfieldsync/gui/map_layer_config_widget.py
+++ b/qfieldsync/gui/map_layer_config_widget.py
@@ -91,9 +91,7 @@ class MapLayerConfigWidget(QgsMapLayerConfigWidget, WidgetUi):
         self.measurementTypeComboBox.addItem(
             "Elapsed time (seconds since start of tracking)"
         )
-        self.measurementTypeComboBox.addItem(
-            self.tr("Timestamp (milliseconds since epoch)")
-        )
+        self.measurementTypeComboBox.addItem(self.tr("Timestamp (seconds since epoch)"))
         self.measurementTypeComboBox.addItem(self.tr("Ground speed"))
         self.measurementTypeComboBox.addItem(self.tr("Bearing"))
         self.measurementTypeComboBox.addItem(self.tr("Horizontal accuracy"))


### PR DESCRIPTION
Counterpart to this: https://github.com/opengisch/QField/pull/7472