### PR TITLE
Add macOS and Apple Silicon setup notes to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,6 @@ pip install -e libqfieldsync
 > /Applications/QGIS.app/Contents/MacOS/python -m pip install -e ./libqfieldsync
 > ```
 >
-> The Python version (`python3.12`) may differ depending on your QGIS release. To find the correct binary, navigate to the Application folder right-click on `QGIS` icon and select **Show Package Contents** and look in `Contents/MacOS/`.
 
 ### Opening a PR
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,15 @@ pip install -e libqfieldsync
 > On more recent Linux distributions you might get an error `error: externally-managed-environment` and you have to pass additional `--break-system-packages`.
 > Despite the name, we promise this is not going to break system packages.
 
+> [!NOTE]
+> On **macOS**, QGIS bundles its own Python interpreter. Use it instead of the system `pip`:
+>
+> ```shell
+> PYTHONHOME=/Applications/QGIS.app/Contents/Frameworks /Applications/QGIS.app/Contents/MacOS/python3.12 -m pip install -e ./libqfieldsync
+> ```
+>
+> The Python version (`python3.12`) may differ depending on your QGIS release. To find the correct binary, navigate to the Application folder right-click on `QGIS` icon and select **Show Package Contents** and look in `Contents/MacOS/`.
+
 ### Opening a PR
 
 Make sure each new feature or bug fix are in a separate PR.
@@ -86,3 +95,10 @@ If you want to test with a specific QGIS version, or you don't have QGIS install
 ```shell
 docker run --rm $(docker build --build-arg QGIS_TEST_VERSION=ltr -q -f .docker/Dockerfile .) .docker/xvfb-pytest
 ```
+
+> [!NOTE]
+> On Apple Silicon add `--platform linux/amd64`. `qgis/qgis` image is only published for `linux/amd64`.
+>
+> ```shell
+> docker run --rm $(docker build --platform linux/amd64 --build-arg QGIS_TEST_VERSION=ltr -q -f .docker/Dockerfile .) .docker/xvfb-pytest
+> ```

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ pip install -e libqfieldsync
 > On **macOS**, QGIS bundles its own Python interpreter. Use it instead of the system `pip`:
 >
 > ```shell
-> PYTHONHOME=/Applications/QGIS.app/Contents/Frameworks /Applications/QGIS.app/Contents/MacOS/python3.12 -m pip install -e ./libqfieldsync
+> /Applications/QGIS.app/Contents/MacOS/python -m pip install -e ./libqfieldsync
 > ```
 >
 > The Python version (`python3.12`) may differ depending on your QGIS release. To find the correct binary, navigate to the Application folder right-click on `QGIS` icon and select **Show Package Contents** and look in `Contents/MacOS/`.


### PR DESCRIPTION
Prevent two setup failures that macOS and Apple Silicon contributors can run into but currently have no guidance for.