### PR TITLE
fix: enable login when there is at least one auth method available

### DIFF
--- a/qfieldsync/gui/cloud_login_dialog.py
+++ b/qfieldsync/gui/cloud_login_dialog.py
@@ -34,7 +34,6 @@ from qgis.PyQt.QtWidgets import (
     QApplication,
     QDialog,
     QDialogButtonBox,
-    QGroupBox,
     QMainWindow,
     QPushButton,
     QWidget,
@@ -132,7 +131,7 @@ class CloudLoginDialog(QDialog, CloudLoginDialogUi):
         )
 
         self.loginFormGroup.setVisible(False)
-        self.set_login_groupbox_visibility(self.signInUsernameGroupBox, False)
+        self.signInUsernameGroupBox.setEnabled(False)
 
         for server_url in self.network_manager.server_urls():
             self.serverUrlCmb.addItem(server_url)
@@ -196,16 +195,18 @@ class CloudLoginDialog(QDialog, CloudLoginDialogUi):
         self.loginFormGroup.setVisible(not self.loginFormGroup.isVisible())
 
     def clear_login_widgets(self) -> None:
-        self.set_login_groupbox_visibility(self.signInUsernameGroupBox, False)
+        # disable credentials inputs
+        self.usernameLineEdit.setEnabled(False)
+        self.passwordLineEdit.setEnabled(False)
+        self.signInUsernameButton.setEnabled(False)
+
+        self.signInUsernameGroupBox.setEnabled(False)
         self.authenticationDivider.setVisible(False)
 
         for push_button in self._sso_login_buttons:
             push_button.deleteLater()
 
         self._sso_login_buttons = []
-
-    def set_login_groupbox_visibility(self, group_box: QGroupBox, visible: bool):
-        group_box.setEnabled(visible)
 
     def fetch_server_auth_capabilities(self) -> None:
         """Fetches the provided server authentication method capabilities."""
@@ -218,7 +219,7 @@ class CloudLoginDialog(QDialog, CloudLoginDialogUi):
         try:
             auth_methods = self.network_manager.json_array(self.auth_methods_reply)
         except QfcError:
-            self.set_login_groupbox_visibility(self.signInUsernameGroupBox, True)
+            self.signInUsernameGroupBox.setEnabled(True)
             return
 
         self.signInUsernameGroupBox.setEnabled(True)
@@ -247,9 +248,14 @@ class CloudLoginDialog(QDialog, CloudLoginDialogUi):
 
         has_credentials = False
 
+        if len(auth_methods) > 0:
+            self.signInUsernameGroupBox.setEnabled(True)
+
         for auth_method in auth_methods:
             if auth_method["id"] == "credentials":
-                self.set_login_groupbox_visibility(self.signInUsernameGroupBox, True)
+                self.usernameLineEdit.setEnabled(True)
+                self.passwordLineEdit.setEnabled(True)
+                self.signInUsernameButton.setEnabled(True)
                 has_credentials = True
                 continue
 

--- a/qfieldsync/tests/test_cloud_login_dialog.py
+++ b/qfieldsync/tests/test_cloud_login_dialog.py
@@ -1,0 +1,100 @@
+"""
+/***************************************************************************
+ QFieldSync
+                              -------------------
+        begin                : 2026
+        copyright            : (C) 2026 by OPENGIS.ch
+        email                : info@opengis.ch
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+"""
+
+from typing import Any
+
+from qgis.core import Qgis, QgsAuthMethodConfig
+from qgis.PyQt.QtCore import (
+    QObject,
+)
+from qgis.PyQt.QtNetwork import (
+    QNetworkReply,
+)
+from qgis.PyQt.QtWidgets import QPushButton
+from qgis.testing import start_app, unittest
+
+from qfieldsync.gui.cloud_login_dialog import (
+    QGIS_MIN_VERSION_FOR_OAUTH2_EXTRA_TOKENS,
+    CloudLoginDialog,
+)
+
+start_app()
+
+
+class DummySignal:
+    def connect(self, _callback):
+        pass
+
+
+class DummyReply(QNetworkReply):
+    finished = DummySignal()
+
+
+class DummyNetworkManager(QObject):
+    url = "https://dummy.qfield.cloud/"
+    login_finished = DummySignal()
+
+    def __init__(self):
+        super().__init__()
+        self.reply = DummyReply()
+
+    def auth(self) -> QgsAuthMethodConfig:
+        return QgsAuthMethodConfig()
+
+    def get_auth_capabilities(self) -> QNetworkReply:
+        return self.reply
+
+    def get_remote_resource(self, _resource_url: str) -> QNetworkReply:
+        return DummyReply()
+
+    def json_array(self, _reply: QNetworkReply) -> list[Any]:
+        return [
+            {
+                "type": "oauth2",
+                "id": "sso",
+                "name": "SSO",
+                "styles": {"light": {}, "dark": {}},
+            }
+        ]
+
+    def server_urls(self) -> list[Any]:
+        return [self.url]
+
+    def set_url(self, server_url: str) -> None:
+        self.url = server_url
+
+
+@unittest.skipIf(
+    Qgis.versionInt() < QGIS_MIN_VERSION_FOR_OAUTH2_EXTRA_TOKENS,
+    "OAuth2 SSO requires QGIS 3.44+",
+)
+class CloudLoginDialogTest(unittest.TestCase):
+    def test_sso_only_provider_button_is_enabled(self):
+        dialog = CloudLoginDialog(DummyNetworkManager())
+
+        dialog.on_fetch_auth_methods_finished()
+
+        sso_button = None
+        for buttons in dialog.findChildren(QPushButton):
+            if buttons.text() == "SSO":
+                sso_button = buttons
+                break
+
+        self.assertIsNotNone(sso_button)
+        self.assertTrue(sso_button.isEnabledTo(dialog))


### PR DESCRIPTION
This PR intends to make QFieldSync cloud login dialog follow the targetted QFieldCloud instance configuration, e.g. login enabled or not the credentials login inputs depending on if the password login is enabled or not on the QFC instance.

If a QFieldCloud instance is configured with no password login, currently the login groupbox stays disabled, so it prevents the user from clicking on a 3rd party IDP login button.

Now, with this PR :

| Login **enabled** in QFieldCloud | Login **disabled** in QFieldCloud |
| --- | --- |
| <img width="386" height="667" alt="image" src="https://github.com/user-attachments/assets/8063d566-8b57-42c4-a714-8ca10a476a96" /> | <img width="386" height="644" alt="image" src="https://github.com/user-attachments/assets/b36a65ec-7a9b-4ee8-b239-fbbed7cc255e" /> |
| Username & password line edits + `Sign In` button are **enabled**. | Username & password line edits + `Sign In` button are **disabled**. |

Also, getting rid of this `set_login_groupbox_visibility` method which was uncorrectly named and was only setting a groupbox enabled or not.

Fixes #807 