### PR TITLE
Only throw an out of storage block when we are trying to upload content

### DIFF
--- a/qfieldsync/gui/cloud_transfer_dialog.py
+++ b/qfieldsync/gui/cloud_transfer_dialog.py
@@ -756,6 +756,7 @@ class CloudTransferDialog(QDialog, CloudTransferDialogUi):
 
             if (
                 self.storage_widget.active_storage_total_bytes() > 0
+                and total_upload_size > 0
                 and total_upload_size
                 > self.storage_widget.active_storage_total_bytes()
                 - self.storage_widget.storage_used_bytes()


### PR DESCRIPTION
Improve logic to insure we only throw an out of storage block when we are trying to upload content.