### PR TITLE
Adding a warning that projects that are not save as `.qgs`/`.qgz` are not supported

### DIFF
--- a/qfieldsync/gui/cloud_create_project_widget.py
+++ b/qfieldsync/gui/cloud_create_project_widget.py
@@ -395,6 +395,21 @@ class CloudCreateProjectWidget(QWidget, WidgetUi):
         self.canceled.emit()
 
     def on_next_button_clicked(self) -> None:
+
+        file_name = self.project.fileName().lower()
+
+        if not (file_name.endswith(".qgs") or file_name.endswith(".qgz")):
+            if "postgresql:" in file_name or "geopackage:" in file_name:
+                QMessageBox.warning(
+                    None,
+                    self.tr("Warning"),
+                    self.tr(
+                        "The project can not be inside a database (e.g., PostGIS or GeoPackage) instead use a standard .qgs/.qgz file."
+                    ),
+                )
+
+        return
+
         project_name = self.get_unique_project_name(self.project)
 
         self.stackedWidget.setCurrentWidget(self.projectDetailsPage)

--- a/qfieldsync/gui/cloud_create_project_widget.py
+++ b/qfieldsync/gui/cloud_create_project_widget.py
@@ -403,7 +403,7 @@ class CloudCreateProjectWidget(QWidget, WidgetUi):
                 None,
                 self.tr("Warning"),
                 self.tr(
-                    "The QGIS project file must be stored as a `.qgs`/`.qgz` file!. "
+                    "The QGIS project file must be stored as a `.qgs`/`.qgz` file! "
                     f'Storing within a database "{project_storage_type.type()}" is not supported.'
                 ),
             )

--- a/qfieldsync/gui/cloud_create_project_widget.py
+++ b/qfieldsync/gui/cloud_create_project_widget.py
@@ -396,13 +396,15 @@ class CloudCreateProjectWidget(QWidget, WidgetUi):
 
     def on_next_button_clicked(self) -> None:
 
-        if self.project.projectStorage() is not None:
+        project_storage_type = self.project.projectStorage()
+
+        if project_storage_type is not None:
             QMessageBox.warning(
                 None,
                 self.tr("Warning"),
                 self.tr(
-                    "The project cannot be inside a database (e.g., PostGIS or GeoPackage, etc.). "
-                    "Please save it as a standard .qgs/.qgz file first."
+                    "The QGIS project file must be stored as a `.qgs`/`.qgz` file!. "
+                    f'Storing within a database "{project_storage_type.type()}" is not supported.'
                 ),
             )
 

--- a/qfieldsync/gui/cloud_create_project_widget.py
+++ b/qfieldsync/gui/cloud_create_project_widget.py
@@ -396,19 +396,17 @@ class CloudCreateProjectWidget(QWidget, WidgetUi):
 
     def on_next_button_clicked(self) -> None:
 
-        file_name = self.project.fileName().lower()
+        if self.project.projectStorage() is not None:
+            QMessageBox.warning(
+                None,
+                self.tr("Warning"),
+                self.tr(
+                    "The project cannot be inside a database (e.g., PostGIS or GeoPackage, etc.). "
+                    "Please save it as a standard .qgs/.qgz file first."
+                ),
+            )
 
-        if not (file_name.endswith(".qgs") or file_name.endswith(".qgz")):
-            if "postgresql:" in file_name or "geopackage:" in file_name:
-                QMessageBox.warning(
-                    None,
-                    self.tr("Warning"),
-                    self.tr(
-                        "The project can not be inside a database (e.g., PostGIS or GeoPackage) instead use a standard .qgs/.qgz file."
-                    ),
-                )
-
-        return
+            return
 
         project_name = self.get_unique_project_name(self.project)
 


### PR DESCRIPTION
As title indicate. I added a warning that before proceed to create the project a warning indicate ```The QGIS project file must be stored as a \`.qgs`/`.qgz` file!. Storing within a database "geopackage" is not supported.```

<img width="652" height="760" alt="image" src="https://github.com/user-attachments/assets/a04fd97c-0065-41e0-ae11-7532f44e45d1" />
