### PR TITLE
Save the last used server URLs in the list of QFieldCloud server URL

### DIFF
--- a/qfieldsync/core/cloud_api.py
+++ b/qfieldsync/core/cloud_api.py
@@ -329,8 +329,6 @@ class CloudNetworkAccessManager(QObject):
     def server_urls() -> list[str]:
         return [
             "https://app.qfield.cloud/",
-            "https://dev.qfield.cloud/",
-            "https://localhost:8002/",
         ]
 
     def get_username(self) -> Optional[str]:

--- a/qfieldsync/core/preferences.py
+++ b/qfieldsync/core/preferences.py
@@ -36,6 +36,7 @@ class Preferences(SettingManager):
         self.add_setting(Dictionary("qfieldCloudProjectLocalDirs", Scope.Global, {}))
         self.add_setting(Dictionary("qfieldCloudLastProjectFiles", Scope.Global, {}))
         self.add_setting(String("qfieldCloudServerUrl", Scope.Global, ""))
+        self.add_setting(Stringlist("qfieldCloudServersHistory", Scope.Global, []))
         self.add_setting(String("qfieldCloudAuthcfg", Scope.Global, ""))
         self.add_setting(Integer("qfieldCloudAuthMethod", Scope.Global, 0))
         self.add_setting(Bool("qfieldCloudRememberMe", Scope.Global, False))

--- a/qfieldsync/core/preferences.py
+++ b/qfieldsync/core/preferences.py
@@ -36,7 +36,7 @@ class Preferences(SettingManager):
         self.add_setting(Dictionary("qfieldCloudProjectLocalDirs", Scope.Global, {}))
         self.add_setting(Dictionary("qfieldCloudLastProjectFiles", Scope.Global, {}))
         self.add_setting(String("qfieldCloudServerUrl", Scope.Global, ""))
-        self.add_setting(Stringlist("qfieldCloudServersHistory", Scope.Global, []))
+        self.add_setting(Stringlist("qfieldCloudServerUrlsHistory", Scope.Global, []))
         self.add_setting(String("qfieldCloudAuthcfg", Scope.Global, ""))
         self.add_setting(Integer("qfieldCloudAuthMethod", Scope.Global, 0))
         self.add_setting(Bool("qfieldCloudRememberMe", Scope.Global, False))

--- a/qfieldsync/gui/cloud_login_dialog.py
+++ b/qfieldsync/gui/cloud_login_dialog.py
@@ -134,7 +134,7 @@ class CloudLoginDialog(QDialog, CloudLoginDialogUi):
         self.signInUsernameGroupBox.setEnabled(False)
 
         default_urls = list(self.network_manager.server_urls())
-        history_urls = self.preferences.value("qfieldCloudServersHistory") or []
+        history_urls = self.preferences.value("qfieldCloudServerUrlsHistory") or []
 
         combined_urls = set(default_urls + history_urls)
 
@@ -412,10 +412,10 @@ class CloudLoginDialog(QDialog, CloudLoginDialogUi):
 
         current_url = self.serverUrlCmb.currentText().strip()
         if current_url:
-            history = self.preferences.value("qfieldCloudServersHistory") or []
+            history = self.preferences.value("qfieldCloudServerUrlsHistory") or []
             if current_url not in history:
                 history.append(current_url)
-                self.preferences.set_value("qfieldCloudServersHistory", history)
+                self.preferences.set_value("qfieldCloudServerUrlsHistory", history)
 
         self.usernameLineEdit.setEnabled(False)
         self.passwordLineEdit.setEnabled(False)

--- a/qfieldsync/gui/cloud_login_dialog.py
+++ b/qfieldsync/gui/cloud_login_dialog.py
@@ -133,8 +133,13 @@ class CloudLoginDialog(QDialog, CloudLoginDialogUi):
         self.loginFormGroup.setVisible(False)
         self.signInUsernameGroupBox.setEnabled(False)
 
-        for server_url in self.network_manager.server_urls():
-            self.serverUrlCmb.addItem(server_url)
+        default_urls = list(self.network_manager.server_urls())
+        history_urls = self.preferences.value("qfieldCloudServersHistory") or []
+
+        combined_urls = set(default_urls + history_urls)
+
+        for url in combined_urls:
+            self.serverUrlCmb.addItem(url)
 
         cfg = self.network_manager.auth()
         self.serverUrlCmb.setCurrentText(cfg.uri() or self.network_manager.url)
@@ -404,6 +409,13 @@ class CloudLoginDialog(QDialog, CloudLoginDialogUi):
             self.rememberMeCheckBox.setEnabled(True)
             self.buttonBox.button(QDialogButtonBox.StandardButton.Ok).setEnabled(True)
             return
+
+        current_url = self.serverUrlCmb.currentText().strip()
+        if current_url:
+            history = self.preferences.value("qfieldCloudServersHistory") or []
+            if current_url not in history:
+                history.append(current_url)
+                self.preferences.set_value("qfieldCloudServersHistory", history)
 
         self.usernameLineEdit.setEnabled(False)
         self.passwordLineEdit.setEnabled(False)

--- a/qfieldsync/gui/cloud_servers_history.py
+++ b/qfieldsync/gui/cloud_servers_history.py
@@ -1,0 +1,96 @@
+"""
+/***************************************************************************
+                             -------------------
+        begin                : 2026-07-09
+        git sha              : $Format:%H$
+        copyright            : (C) 2024 by OPENGIS.ch
+        email                : info@opengis.ch
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+"""
+
+import os
+
+from qgis.core import QgsApplication
+from qgis.PyQt.QtCore import Qt
+from qgis.PyQt.QtWidgets import QListWidgetItem, QWidget
+from qgis.PyQt.uic import loadUiType
+
+from qfieldsync.core.preferences import Preferences
+
+WidgetUi, _ = loadUiType(
+    os.path.join(os.path.dirname(__file__), "../ui/cloud_servers_history.ui")
+)
+
+
+class CloudServerHistoryListWidget(QWidget, WidgetUi):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setupUi(self)
+        self.preferences = Preferences()
+
+        self.addButton.setIcon(QgsApplication.getThemeIcon("/symbologyAdd.svg"))
+        self.addButton.clicked.connect(self._on_add_button_clicked)
+
+        self.removeButton.setIcon(QgsApplication.getThemeIcon("/symbologyRemove.svg"))
+        self.removeButton.setEnabled(False)
+        self.removeButton.clicked.connect(self._on_remove_button_clicked)
+
+        self.serverHistoryList.itemClicked.connect(
+            lambda: self.removeButton.setEnabled(
+                len(self.serverHistoryList.selectedItems()) > 0
+            )
+        )
+
+        self.serverHistoryList.itemChanged.connect(self.save_server_history)
+
+        self.load_server_history()
+
+    def load_server_history(self) -> None:
+        self.serverHistoryList.blockSignals(True)
+        self.serverHistoryList.clear()
+
+        history = self.preferences.value("qfieldCloudServersHistory") or []
+        for url in history:
+            item = QListWidgetItem(url)
+            item.setFlags(item.flags() | Qt.ItemFlag.ItemIsEditable)
+            self.serverHistoryList.addItem(item)
+
+        self.serverHistoryList.blockSignals(False)
+
+    def _on_add_button_clicked(self) -> None:
+        item = QListWidgetItem("")
+        item.setFlags(item.flags() | Qt.ItemFlag.ItemIsEditable)
+
+        self.serverHistoryList.addItem(item)
+
+        self.serverHistoryList.setCurrentItem(item)
+        self.serverHistoryList.editItem(item)
+
+    def _on_remove_button_clicked(self) -> None:
+        current_item = self.serverHistoryList.currentItem()
+        if not current_item:
+            return
+
+        row = self.serverHistoryList.row(current_item)
+        self.serverHistoryList.takeItem(row)
+
+        self.save_server_history()
+
+    def save_server_history(self) -> None:
+        urls = []
+        for i in range(self.serverHistoryList.count()):
+            url = self.serverHistoryList.item(i).text().strip()
+            if url:
+                urls.append(url)
+
+        unique_urls = list(dict.fromkeys(urls))
+        self.preferences.set_value("qfieldCloudServersHistory", unique_urls)

--- a/qfieldsync/gui/cloud_servers_history.py
+++ b/qfieldsync/gui/cloud_servers_history.py
@@ -3,7 +3,7 @@
                              -------------------
         begin                : 2026-07-09
         git sha              : $Format:%H$
-        copyright            : (C) 2024 by OPENGIS.ch
+        copyright            : (C) 2026 by OPENGIS.ch
         email                : info@opengis.ch
  ***************************************************************************/
 
@@ -58,7 +58,7 @@ class CloudServerHistoryListWidget(QWidget, WidgetUi):
         self.serverHistoryList.blockSignals(True)
         self.serverHistoryList.clear()
 
-        history = self.preferences.value("qfieldCloudServersHistory") or []
+        history = self.preferences.value("qfieldCloudServerUrlsHistory") or []
         for url in history:
             item = QListWidgetItem(url)
             item.setFlags(item.flags() | Qt.ItemFlag.ItemIsEditable)
@@ -93,4 +93,4 @@ class CloudServerHistoryListWidget(QWidget, WidgetUi):
                 urls.append(url)
 
         unique_urls = list(dict.fromkeys(urls))
-        self.preferences.set_value("qfieldCloudServersHistory", unique_urls)
+        self.preferences.set_value("qfieldCloudServerUrlsHistory", unique_urls)

--- a/qfieldsync/gui/preferences_widget.py
+++ b/qfieldsync/gui/preferences_widget.py
@@ -26,6 +26,7 @@ from qgis.gui import QgsFileWidget, QgsOptionsPageWidget
 from qgis.PyQt.uic import loadUiType
 
 from qfieldsync.core.preferences import Preferences
+from qfieldsync.gui.cloud_servers_history import CloudServerHistoryListWidget
 from qfieldsync.setting_manager import SettingDialog
 
 WidgetUi, _ = loadUiType(
@@ -52,6 +53,11 @@ class PreferencesWidget(WidgetUi, QgsOptionsPageWidget, SettingDialog):
             QgsFileWidget.StorageMode.GetDirectory
         )
 
+        self.server_history_widget = CloudServerHistoryListWidget(self)
+        self.cloudGridLayout.addWidget(self.server_history_widget, 3, 0, 1, 2)
+
     def apply(self):
+        self.server_history_widget.save_server_history()
+
         self.set_values_from_widgets()
         self.qfieldSync.update_button_visibility()

--- a/qfieldsync/ui/cloud_servers_history.ui
+++ b/qfieldsync/ui/cloud_servers_history.ui
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>serverHistoryList</class>
+ <widget class="QWidget" name="serverHistoryList">
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="windowTitle">
+   <string/>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_0">
+   <item>
+    <widget class="QLabel" name="label">
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Sunken</enum>
+     </property>
+     <property name="text">
+      <string>List of used URLs server</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_1">
+     <item>
+      <widget class="QListWidget" name="serverHistoryList"/>
+     </item>
+     <item>
+      <layout class="QVBoxLayout" name="verticalLayout_1">
+       <item>
+        <widget class="QToolButton" name="addButton">
+         <property name="toolTip">
+          <string>Add server URL</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QToolButton" name="removeButton">
+         <property name="toolTip">
+          <string>Remove server URL</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="buttonsSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>13</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
This PR introduces a global server URL history, and a UI management system for QFieldSync. Now is possible to view, add, edit, and remove custom QFieldCloud server instances within the QFieldSync Preferences tab. These custom URLs are automatically populated into the QFieldCloud Login Dialog dropdown.

When login the URL used is saved in the URL history

<img width="1247" height="946" alt="image" src="https://github.com/user-attachments/assets/bdcb92c7-1250-49ee-96c2-30281f2decdf" />
