### PR TITLE
Support embedding the photo stamp logo in the project

### DIFF
--- a/qfieldsync/gui/image_stamping_configuration_widget.py
+++ b/qfieldsync/gui/image_stamping_configuration_widget.py
@@ -30,7 +30,11 @@ from qgis.core import (
     QgsReadWriteContext,
     QgsTextFormat,
 )
-from qgis.gui import QgsExpressionBuilderDialog, QgsPanelWidget
+from qgis.gui import (
+    QgsExpressionBuilderDialog,
+    QgsPanelWidget,
+    QgsPictureSourceLineEditBase,
+)
 from qgis.PyQt.QtCore import QDateTime
 from qgis.PyQt.QtXml import QDomDocument
 from qgis.PyQt.uic import loadUiType
@@ -55,6 +59,10 @@ Speed [% if(@gnss_ground_speed != 'nan', format_number(@gnss_ground_speed, 3) ||
         self.setupUi(self)
 
         self.setPanelTitle(self.tr("Image Stamping"))
+
+        self.customImageDecorationFile.setMode(
+            QgsPictureSourceLineEditBase.Format.Image
+        )
 
         self.customFontStyleButton.setShowNullFormat(True)
         self.customFontStyleButton.setShowNullFormat(True)
@@ -274,10 +282,10 @@ Speed [% if(@gnss_ground_speed != 'nan', format_number(@gnss_ground_speed, 3) ||
         self.customAlignmentComboBox.setCurrentIndex(horizontal_alignment)
 
     def image_decoration(self):
-        return self.customImageDecorationFile.filePath()
+        return self.customImageDecorationFile.source()
 
-    def set_image_decoration(self, file_path):
-        self.customImageDecorationFile.setFilePath(file_path)
+    def set_image_decoration(self, source):
+        self.customImageDecorationFile.setSource(source)
 
     def details_template(self):
         details = self.customDetailsTextEdit.toPlainText().strip()

--- a/qfieldsync/gui/project_configuration_widget.py
+++ b/qfieldsync/gui/project_configuration_widget.py
@@ -102,17 +102,12 @@ class ProjectConfigurationWidget(WidgetUi, QgsPanelWidget):
         self.stamping_horizontal_alignment = (
             self.__project_configuration.stamping_horizontal_alignment
         )
-        self.stamping_image_decoration = (
-            self.__project_configuration.stamping_image_decoration
-        )
-        if self.__project_configuration.stamping_image_decoration:
-            self.stamping_image_decoration = (
-                QgsProject.instance()
-                .pathResolver()
-                .readPath(self.__project_configuration.stamping_image_decoration)
-            )
-        else:
-            self.stamping_image_decoration = ""
+
+        source = self.__project_configuration.stamping_image_decoration
+        if source and not source.startswith("base64:"):
+            source = QgsProject.instance().pathResolver().readPath(source)
+
+        self.stamping_image_decoration = source or ""
 
         self.stamping_details_template = (
             self.__project_configuration.stamping_details_template
@@ -510,14 +505,11 @@ class ProjectConfigurationWidget(WidgetUi, QgsPanelWidget):
         self.__project_configuration.stamping_horizontal_alignment = (
             self.stamping_horizontal_alignment
         )
-        if self.stamping_image_decoration:
-            self.__project_configuration.stamping_image_decoration = (
-                QgsProject.instance()
-                .pathResolver()
-                .writePath(self.stamping_image_decoration)
-            )
-        else:
-            self.__project_configuration.stamping_image_decoration = ""
+        source = self.stamping_image_decoration
+        if source and not source.startswith("base64:"):
+            source = QgsProject.instance().pathResolver().writePath(source)
+
+        self.__project_configuration.stamping_image_decoration = source or ""
 
         self.__project_configuration.stamping_details_template = (
             self.stamping_details_template

--- a/qfieldsync/ui/image_stamping_configuration_widget.ui
+++ b/qfieldsync/ui/image_stamping_configuration_widget.ui
@@ -58,7 +58,7 @@
        </widget>
       </item>
       <item row="2" column="1">
-       <widget class="QgsFileWidget" name="customImageDecorationFile" native="true"/>
+       <widget class="QgsImageSourceLineEdit" name="customImageDecorationFile"/>
       </item>
       <item row="3" column="0" colspan="2">
        <widget class="QCheckBox" name="forceStampingCheckBox">
@@ -170,9 +170,9 @@
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsFileWidget</class>
+   <class>QgsImageSourceLineEdit</class>
    <extends>QWidget</extends>
-   <header>qgsfilewidget.h</header>
+   <header>qgis.gui</header>
   </customwidget>
   <customwidget>
    <class>QgsFontButton</class>


### PR DESCRIPTION
Right now the stamp decoration image has to be a file sitting next to the project, which is awkward to keep track of when sharing or packaging. This swaps the plain file picker for QgsImageSourceLineEdit, so you can embed the image straight into the project instead, no separate file to carry around, planned by @nirvn

<img width="1496" height="921" alt="Screenshot 2026-07-19 at 11 11 58 PM" src="https://github.com/user-attachments/assets/0f902c6c-c402-431d-ac9b-d71a37a5bb53" />
