### PR TITLE
Suggest saving the project before uploading packaging

### DIFF
--- a/qfieldsync/gui/checker_feedback_table.py
+++ b/qfieldsync/gui/checker_feedback_table.py
@@ -23,7 +23,15 @@
 from libqfieldsync.project_checker import Feedback, ProjectCheckerFeedback
 from qgis.core import QgsApplication
 from qgis.PyQt.QtCore import Qt
-from qgis.PyQt.QtWidgets import QLabel, QSizePolicy, QTableWidget, QTableWidgetItem
+from qgis.PyQt.QtWidgets import (
+    QCheckBox,
+    QLabel,
+    QSizePolicy,
+    QTableWidget,
+    QTableWidgetItem,
+    QVBoxLayout,
+    QWidget,
+)
 
 from qfieldsync.utils.qt_utils import make_icon
 
@@ -44,7 +52,6 @@ class CheckerFeedbackTable(QTableWidget):
         for layer_id in checker_feedback.feedbacks:
             for feedback in checker_feedback.feedbacks[layer_id]:
                 row = self.rowCount()
-
                 self.insertRow(row)
 
                 # first column
@@ -66,24 +73,42 @@ class CheckerFeedbackTable(QTableWidget):
                 else:
                     source = self.tr("Project")
 
-                item = QTableWidgetItem()
-                item.setFlags(Qt.ItemFlag.ItemIsEnabled)
-                item.setToolTip(level_text)
-                self.setItem(row, 1, item)
+                # cell container widget for interactive actions
+                cell_widget = QWidget()
+                cell_layout = QVBoxLayout(cell_widget)
+                cell_layout.setContentsMargins(2, 2, 2, 2)
+                cell_layout.setSpacing(6)
 
                 # we do not escape the values on purpose to support Markdown/HTML
                 label = QLabel("**{}**\n\n{}".format(source, feedback.message))
                 label.setWordWrap(True)
-                label.setMargin(5)
                 label.setTextFormat(Qt.TextFormat.MarkdownText)
                 label.setTextInteractionFlags(
                     Qt.TextInteractionFlag.TextSelectableByMouse
-                    | Qt.TextInteractionFlag.TextSelectableByKeyboard
                     | Qt.TextInteractionFlag.LinksAccessibleByMouse
-                    | Qt.TextInteractionFlag.LinksAccessibleByKeyboard
                 )
                 label.setOpenExternalLinks(True)
-                self.setCellWidget(row, 1, label)
+
+                cell_layout.addWidget(label)
+
+                # checkbox for interactive actions
+                if feedback.action_text and feedback.action_callback:
+                    checkbox = QCheckBox(feedback.action_text)
+
+                    def on_toggled(
+                        checked: bool, callback=feedback.action_callback, box=checkbox
+                    ):
+                        if checked:
+                            callback()
+                            box.setEnabled(False)
+
+                    checkbox.toggled.connect(on_toggled)
+                    cell_layout.addWidget(checkbox)
+
+                    checkbox.toggled.connect(on_toggled)
+                    cell_layout.addWidget(checkbox)
+
+                self.setCellWidget(row, 1, cell_widget)
 
         self.verticalHeader().hide()
         self.resizeColumnsToContents()

--- a/qfieldsync/gui/checker_feedback_table.py
+++ b/qfieldsync/gui/checker_feedback_table.py
@@ -20,31 +20,63 @@
  ***************************************************************************/
 """
 
-from libqfieldsync.project_checker import Feedback, ProjectCheckerFeedback
-from qgis.core import QgsApplication
-from qgis.PyQt.QtCore import Qt
-from qgis.PyQt.QtWidgets import QLabel, QSizePolicy, QTableWidget, QTableWidgetItem
+from libqfieldsync.project_checker import (
+    Feedback,
+    FeedbackTypeId,
+    ProjectCheckerFeedback,
+)
+from qgis.core import QgsApplication, QgsProject
+from qgis.PyQt.QtCore import Qt, pyqtSignal
+from qgis.PyQt.QtWidgets import (
+    QHBoxLayout,
+    QHeaderView,
+    QLabel,
+    QPushButton,
+    QSizePolicy,
+    QTableWidget,
+    QTableWidgetItem,
+    QWidget,
+)
 
 from qfieldsync.utils.qt_utils import make_icon
 
 
 class CheckerFeedbackTable(QTableWidget):
+    feedback_fixed = pyqtSignal()
+
     def __init__(self, checker_feedback: ProjectCheckerFeedback, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
+        # dictionary mapping FeedbackTypeId to fix action callbacks
+        self._fix_handlers = {
+            FeedbackTypeId.PROJECT_IS_DIRTY: self._fix_project_is_dirty,
+        }
+
         self.setColumnCount(2)
         self.setHorizontalHeaderLabels(["", self.tr("Message")])
-        self.horizontalHeader().setStretchLastSection(True)
+        self.horizontalHeader().setSectionResizeMode(
+            0, QHeaderView.ResizeMode.ResizeToContents
+        )
+        self.horizontalHeader().setSectionResizeMode(1, QHeaderView.ResizeMode.Stretch)
+
         self.setRowCount(0)
         self.setMinimumHeight(100)
         self.setSizePolicy(
             QSizePolicy.Policy.MinimumExpanding, QSizePolicy.Policy.MinimumExpanding
         )
 
+        self.verticalHeader().hide()
+        self.horizontalHeader().sectionResized.connect(self.resizeRowsToContents)
+        self.setWordWrap(True)
+
+        self.set_feedback(checker_feedback)
+
+    def set_feedback(self, checker_feedback: ProjectCheckerFeedback) -> None:
+        self.setRowCount(0)
+
         for layer_id in checker_feedback.feedbacks:
             for feedback in checker_feedback.feedbacks[layer_id]:
                 row = self.rowCount()
-
                 self.insertRow(row)
 
                 # first column
@@ -72,6 +104,10 @@ class CheckerFeedbackTable(QTableWidget):
                 self.setItem(row, 1, item)
 
                 # we do not escape the values on purpose to support Markdown/HTML
+                cell_widget = QWidget()
+                cell_layout = QHBoxLayout(cell_widget)
+                cell_layout.setContentsMargins(0, 0, 8, 0)
+
                 label = QLabel("**{}**\n\n{}".format(source, feedback.message))
                 label.setWordWrap(True)
                 label.setMargin(5)
@@ -83,10 +119,34 @@ class CheckerFeedbackTable(QTableWidget):
                     | Qt.TextInteractionFlag.LinksAccessibleByKeyboard
                 )
                 label.setOpenExternalLinks(True)
-                self.setCellWidget(row, 1, label)
+                cell_layout.addWidget(label, stretch=1)
 
-        self.verticalHeader().hide()
-        self.resizeColumnsToContents()
+                fix_action = self._fix_handlers.get(feedback.type_id)
+                if fix_action:
+                    fix_button = QPushButton(self.tr("Fix!"))
+
+                    def on_fix_clicked(
+                        _checked: bool,
+                        action=fix_action,
+                        target_feedback=feedback,
+                    ) -> None:
+                        action(target_feedback)
+                        self._refresh_project_checker()
+
+                    fix_button.clicked.connect(on_fix_clicked)
+                    cell_layout.addWidget(
+                        fix_button,
+                        alignment=Qt.AlignmentFlag.AlignRight
+                        | Qt.AlignmentFlag.AlignVCenter,
+                    )
+
+                self.setCellWidget(row, 1, cell_widget)
+
         self.resizeRowsToContents()
-        self.horizontalHeader().sectionResized.connect(self.resizeRowsToContents)
-        self.setWordWrap(True)
+
+    def _refresh_project_checker(self) -> None:
+
+        self.feedback_fixed.emit()
+
+    def _fix_project_is_dirty(self, _feedbackfeedback: Feedback) -> None:
+        QgsProject.instance().write()

--- a/qfieldsync/gui/checker_feedback_table.py
+++ b/qfieldsync/gui/checker_feedback_table.py
@@ -131,7 +131,8 @@ class CheckerFeedbackTable(QTableWidget):
                         target_feedback=feedback,
                     ) -> None:
                         action(target_feedback)
-                        self._refresh_project_checker()
+
+                        self.feedback_fixed.emit()
 
                     fix_button.clicked.connect(on_fix_clicked)
                     cell_layout.addWidget(
@@ -143,10 +144,6 @@ class CheckerFeedbackTable(QTableWidget):
                 self.setCellWidget(row, 1, cell_widget)
 
         self.resizeRowsToContents()
-
-    def _refresh_project_checker(self) -> None:
-
-        self.feedback_fixed.emit()
 
     def _fix_project_is_dirty(self, _feedbackfeedback: Feedback) -> None:
         QgsProject.instance().write()

--- a/qfieldsync/gui/cloud_transfer_dialog.py
+++ b/qfieldsync/gui/cloud_transfer_dialog.py
@@ -292,16 +292,18 @@ class CloudTransferDialog(QDialog, CloudTransferDialogUi):
             self.is_project_compatible_page_prepared = True
 
     def refresh_project_compatibility_page(self):
-        if self.cloud_project and self.cloud_project.is_current_qgis_project:
-            feedback = self.project_checker.check(ExportType.Cloud)
-            if feedback.count == 0:
-                self.show_project_files_fetching_page()
-            else:
-                self.feedback_table.set_feedback(feedback)
-                has_errors = len(feedback.error_feedbacks) > 0
-                self.buttonBox.button(QDialogButtonBox.StandardButton.Apply).setEnabled(
-                    not has_errors
-                )
+        if not self.cloud_project or not self.cloud_project.is_current_qgis_project:
+            return
+
+        feedback = self.project_checker.check(ExportType.Cloud)
+        if feedback.count == 0:
+            self.show_project_files_fetching_page()
+        else:
+            self.feedback_table.set_feedback(feedback)
+            has_errors = len(feedback.error_feedbacks) > 0
+            self.buttonBox.button(QDialogButtonBox.StandardButton.Apply).setEnabled(
+                not has_errors
+            )
 
     def show_project_files_fetching_page(self):
         self.stackedWidget.setCurrentWidget(self.getProjectFilesPage)

--- a/qfieldsync/gui/cloud_transfer_dialog.py
+++ b/qfieldsync/gui/cloud_transfer_dialog.py
@@ -265,14 +265,17 @@ class CloudTransferDialog(QDialog, CloudTransferDialogUi):
         if not self.is_project_compatible_page_prepared:
             feedback = None
             if self.cloud_project and self.cloud_project.is_current_qgis_project:
-                checker = ProjectChecker(QgsProject.instance())
-                feedback = checker.check(ExportType.Cloud)
+                self.project_checker = ProjectChecker(QgsProject.instance())
+                feedback = self.project_checker.check(ExportType.Cloud)
 
             if feedback and feedback.count > 0:
                 # check whether the widget has already been added the guard from adding twice due to repeated showEvent signal
                 has_errors = len(feedback.error_feedbacks) > 0
-                feedback_table = CheckerFeedbackTable(feedback)
-                self.feedbackTableWrapperLayout.addWidget(feedback_table)
+                self.feedback_table = CheckerFeedbackTable(feedback)
+                self.feedback_table.feedback_fixed.connect(
+                    self.refresh_project_compatibility_page
+                )
+                self.feedbackTableWrapperLayout.addWidget(self.feedback_table)
                 self.stackedWidget.setCurrentWidget(self.projectCompatibilityPage)
                 self.buttonBox.button(QDialogButtonBox.StandardButton.Apply).setVisible(
                     True
@@ -287,6 +290,18 @@ class CloudTransferDialog(QDialog, CloudTransferDialogUi):
                 self.show_project_files_fetching_page()
 
             self.is_project_compatible_page_prepared = True
+
+    def refresh_project_compatibility_page(self):
+        if self.cloud_project and self.cloud_project.is_current_qgis_project:
+            feedback = self.project_checker.check(ExportType.Cloud)
+            if feedback.count == 0:
+                self.show_project_files_fetching_page()
+            else:
+                self.feedback_table.set_feedback(feedback)
+                has_errors = len(feedback.error_feedbacks) > 0
+                self.buttonBox.button(QDialogButtonBox.StandardButton.Apply).setEnabled(
+                    not has_errors
+                )
 
     def show_project_files_fetching_page(self):
         self.stackedWidget.setCurrentWidget(self.getProjectFilesPage)

--- a/qfieldsync/gui/package_dialog.py
+++ b/qfieldsync/gui/package_dialog.py
@@ -152,13 +152,27 @@ class PackageDialog(QDialog, DialogUi):
         if feedback and feedback.count > 0:
             has_errors = len(feedback.error_feedbacks) > 0
 
-            feedback_table = CheckerFeedbackTable(feedback)
-            self.feedbackTableWrapperLayout.addWidget(feedback_table)
+            self.feedback_table = CheckerFeedbackTable(feedback)
+            self.feedback_table.feedback_fixed.connect(
+                self.refresh_project_compatibility_page
+            )
+            self.feedbackTableWrapperLayout.addWidget(self.feedback_table)
             self.stackedWidget.setCurrentWidget(self.projectCompatibilityPage)
             self.nextButton.setVisible(True)
             self.nextButton.setEnabled(not has_errors)
         else:
             self.show_package_page()
+
+    def refresh_project_compatibility_page(self):
+        if os.path.exists(self.project.fileName()):
+            feedback = self.project_checker.check(ExportType.Cable)
+            if feedback.count == 0:
+                # All issues resolved -> advance directly to package page
+                self.show_package_page()
+            else:
+                self.feedback_table.set_feedback(feedback)
+                has_errors = len(feedback.error_feedbacks) > 0
+                self.nextButton.setEnabled(not has_errors)
 
     def get_export_filename_suggestion(self) -> str:
         """Get the suggested export filename"""

--- a/qfieldsync/gui/package_dialog.py
+++ b/qfieldsync/gui/package_dialog.py
@@ -146,7 +146,7 @@ class PackageDialog(QDialog, DialogUi):
         self.dirsToCopyWidget.refresh_tree()
 
         feedback = None
-        if os.path.exists(self.project.fileName()):
+        if Path(self.project.fileName()).exists():
             feedback = self.project_checker.check(ExportType.Cable)
 
         if feedback and feedback.count > 0:
@@ -164,7 +164,7 @@ class PackageDialog(QDialog, DialogUi):
             self.show_package_page()
 
     def refresh_project_compatibility_page(self):
-        if os.path.exists(self.project.fileName()):
+        if Path(self.project.fileName()).exists():
             feedback = self.project_checker.check(ExportType.Cable)
             if feedback.count == 0:
                 # All issues resolved -> advance directly to package page


### PR DESCRIPTION
This PR informs the users if the QGIS project has unsaved changes before packaging (Cable) or uploading (Cloud), and provides an interactive "Save project changes now" checkbox directly inside the project checker feedback table to save the project on the spot.

[fix_action_callable_qfieldsync.webm](https://github.com/user-attachments/assets/3edb734e-55cc-4631-9224-745a70bc607e)

it requires this [PR from libqfield](https://github.com/opengisch/libqfieldsync/pull/164)