### PR TITLE
Add the option to create/switch to `TEMPLATE` or `REGULAR` projects

### DIFF
--- a/qfieldsync/core/cloud_api.py
+++ b/qfieldsync/core/cloud_api.py
@@ -56,7 +56,7 @@ from qgis.PyQt.QtNetwork import (
     QNetworkRequest,
 )
 
-from qfieldsync.core.cloud_project import CloudProject
+from qfieldsync.core.cloud_project import CloudProject, ProjectType
 from qfieldsync.core.preferences import Preferences
 from qfieldsync.utils.qt_utils import strip_html
 
@@ -583,7 +583,12 @@ class CloudNetworkAccessManager(QObject):
         return response.json()
 
     def create_project(
-        self, name: str, owner: str, description: str, is_public: bool
+        self,
+        name: str,
+        owner: str,
+        description: str,
+        is_public: bool,
+        project_type: ProjectType = ProjectType.REGULAR,
     ) -> QNetworkReply:
         """Create a new QFieldCloud project"""
         return self.cloud_post(
@@ -593,6 +598,7 @@ class CloudNetworkAccessManager(QObject):
                 "owner": owner,
                 "description": description,
                 "is_public": is_public,
+                "project_type": project_type.value,
             },
         )
 

--- a/qfieldsync/core/cloud_project.py
+++ b/qfieldsync/core/cloud_project.py
@@ -21,7 +21,7 @@
 import sqlite3
 from collections.abc import Iterator
 from datetime import datetime, timezone
-from enum import IntFlag
+from enum import Enum, IntFlag
 from pathlib import Path
 from typing import Any, Optional
 
@@ -44,6 +44,12 @@ class ProjectFileCheckout(IntFlag):
     Local = 1
     Cloud = 2
     LocalAndCloud = 3
+
+
+class ProjectType(str, Enum):
+    REGULAR = "regular"
+    TEMPLATE = "template"
+    SHARED_DATASETS = "shared_datasets"
 
 
 class ProjectFile:
@@ -254,6 +260,17 @@ class CloudProject:
     @property
     def is_public(self) -> bool:
         return self._data["is_public"]
+
+    @property
+    def project_type(self) -> ProjectType:
+        # Servers APIs older than QFC v26.22 do not have the `project_type` property, fallback to support older QFC API versions
+        try:
+            return ProjectType(self._data.get("project_type"))
+        except ValueError:
+            if self._data.get("is_shared_datasets", False):
+                return ProjectType.SHARED_DATASETS
+
+        return ProjectType.REGULAR
 
     @property
     def created_at(self) -> str:

--- a/qfieldsync/gui/cloud_create_project_widget.py
+++ b/qfieldsync/gui/cloud_create_project_widget.py
@@ -43,7 +43,7 @@ from qgis.PyQt.uic import loadUiType
 
 from qfieldsync.core.cloud_api import CloudNetworkAccessManager, QfcError
 from qfieldsync.core.cloud_converter import CloudConverter
-from qfieldsync.core.cloud_project import CloudProject
+from qfieldsync.core.cloud_project import CloudProject, ProjectType
 from qfieldsync.core.cloud_transferrer import CloudTransferrer
 from qfieldsync.core.preferences import Preferences
 from qfieldsync.gui.cloud_login_dialog import CloudLoginDialog
@@ -132,8 +132,13 @@ class CloudCreateProjectWidget(QWidget, WidgetUi):
             lambda: self.on_project_owner_refresh_button_click()
         )
 
+        self.projectTypeComboBox.addItem(self.tr("Regular"), ProjectType.REGULAR.value)
+        self.projectTypeComboBox.addItem(
+            self.tr("Template"), ProjectType.TEMPLATE.value
+        )
+
         self.storage_widget = StorageWidget(self.network_manager, self)
-        self.projectDetailsLayout.addWidget(self.storage_widget, 5, 1)
+        self.projectDetailsLayout.addWidget(self.storage_widget, 6, 1)
 
     def restart(self):
         self.stackedWidget.setCurrentWidget(self.selectTypePage)
@@ -229,6 +234,7 @@ class CloudCreateProjectWidget(QWidget, WidgetUi):
             self.projectOwnerComboBox.currentText(),
             description,
             self.projectIsPublicCheckBox.isChecked(),
+            ProjectType(self.projectTypeComboBox.currentData()),
         )
         reply.finished.connect(lambda: self.on_create_project_finished(reply))
 

--- a/qfieldsync/gui/cloud_projects_dialog.py
+++ b/qfieldsync/gui/cloud_projects_dialog.py
@@ -62,7 +62,12 @@ from qgis.PyQt.uic import loadUiType
 from qgis.utils import iface
 
 from qfieldsync.core.cloud_api import CloudNetworkAccessManager, QfcError
-from qfieldsync.core.cloud_project import CloudProject, ProjectFile, ProjectFileCheckout
+from qfieldsync.core.cloud_project import (
+    CloudProject,
+    ProjectFile,
+    ProjectFileCheckout,
+    ProjectType,
+)
 from qfieldsync.core.cloud_transferrer import FileTransfer
 from qfieldsync.core.preferences import Preferences
 from qfieldsync.gui.cloud_create_project_widget import CloudCreateProjectWidget
@@ -841,6 +846,27 @@ class CloudProjectsDialog(QDialog, CloudProjectsDialogUi):
 
         self.projectOwnerLineEdit.setText(self.current_cloud_project.owner)
 
+        if self.current_cloud_project.project_type == ProjectType.SHARED_DATASETS:
+            self.projectTypeComboBox.clear()
+            self.projectTypeComboBox.addItem(
+                self.tr("Shared datasets"), ProjectType.SHARED_DATASETS
+            )
+            self.projectTypeComboBox.setEnabled(False)
+        else:
+            self.projectTypeComboBox.clear()
+            self.projectTypeComboBox.addItem(self.tr("Regular"), ProjectType.REGULAR)
+            self.projectTypeComboBox.addItem(self.tr("Template"), ProjectType.TEMPLATE)
+            current_index = self.projectTypeComboBox.findData(
+                self.current_cloud_project.project_type
+            )
+            if current_index == -1:
+                current_index = 0
+
+            self.projectTypeComboBox.setCurrentIndex(current_index)
+            self.projectTypeComboBox.setEnabled(
+                can_update_project(self.current_cloud_project)
+            )
+
         self.localDirLineEdit.setText(self.current_cloud_project.local_dir or "")
         self.projectUrlLabelValue.setText(
             '<a href="{url}">{url}</a>'.format(
@@ -922,6 +948,13 @@ class CloudProjectsDialog(QDialog, CloudProjectsDialogUi):
             != self.projectIsPublicCheckBox.isChecked()
         ):
             cloud_project_data["is_public"] = self.projectIsPublicCheckBox.isChecked()
+
+        if (
+            self.projectTypeComboBox.isEnabled()
+            and self.current_cloud_project.project_type
+            != self.projectTypeComboBox.currentData()
+        ):
+            cloud_project_data["project_type"] = self.projectTypeComboBox.currentData()
 
         if cloud_project_data:
             self.projectsFormPage.setEnabled(False)

--- a/qfieldsync/ui/cloud_create_project_widget.ui
+++ b/qfieldsync/ui/cloud_create_project_widget.ui
@@ -156,7 +156,7 @@
           <string>Project Details</string>
          </property>
          <layout class="QGridLayout" name="projectDetailsLayout">
-          <item row="3" column="1">
+          <item row="4" column="1">
            <layout class="QHBoxLayout" name="projectOwnerHLayout">
             <item>
              <widget class="QComboBox" name="projectOwnerComboBox"/>
@@ -181,7 +181,7 @@
             </property>
            </widget>
           </item>
-          <item row="3" column="0">
+          <item row="4" column="0">
            <widget class="QLabel" name="projectOwnerLabel">
             <property name="text">
              <string>Owner</string>
@@ -198,7 +198,17 @@
           <item row="1" column="1">
            <widget class="QTextEdit" name="projectDescriptionTextEdit"/>
           </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="projectTypeLabel">
+            <property name="text">
+             <string>Project Type</string>
+            </property>
+           </widget>
+          </item>
           <item row="2" column="1">
+           <widget class="QComboBox" name="projectTypeComboBox"/>
+          </item>
+          <item row="3" column="1">
            <widget class="QCheckBox" name="projectIsPublicCheckBox">
             <property name="text">
              <string>Is public</string>
@@ -221,7 +231,7 @@
             </property>
            </widget>
           </item>
-          <item row="4" column="1">
+          <item row="5" column="1">
            <widget class="QLabel" name="projectOwnerFeedbackLabel">
             <property name="visible">
              <bool>false</bool>

--- a/qfieldsync/ui/cloud_projects_dialog.ui
+++ b/qfieldsync/ui/cloud_projects_dialog.ui
@@ -412,6 +412,20 @@
                 </property>
                </widget>
               </item>
+              <item row="5" column="0">
+               <widget class="QLabel" name="projectTypeLabel">
+                <property name="text">
+                 <string>Project Type</string>
+                </property>
+               </widget>
+              </item>
+              <item row="5" column="1">
+               <widget class="QComboBox" name="projectTypeComboBox">
+                <property name="enabled">
+                 <bool>false</bool>
+                </property>
+               </widget>
+              </item>
              </layout>
             </widget>
            </item>


### PR DESCRIPTION
In the past we only had one type of projects in QFieldCloud - "REGULAR". With those projects we can do anything - sync from QField, QGIS, CLI etc.

However, https://github.com/opengisch/QFieldCloud/pull/1735  introduced a new `TEMPLATE` project type.

This PR introduces the ability to create a new project and mark it as `TEMPLATE`, or change the type of existing project between `TEMPLATE` and `REGULAR`.

- Add a `ProjectType` enum (`regular`/`template`/`shared_datasets`) and a `CloudProject.project_type` property, mirroring QFieldCloud's new `project_type` field
- Let users pick `Regular`/`Template` when creating a new project
- Let users switch between `Regular`/`Template` when editing an existing project
- Show a disabled dropdown reading "Shared datasets", for projects whose type is `shared_datasets`
- Fall back to "regular" when talking to older API servers that don't send the `project_type` field yet