### PR TITLE
Improve cloud project deletion by avoiding overly wide dialog and allowing text selection

### DIFF
--- a/qfieldsync/gui/cloud_projects_dialog.py
+++ b/qfieldsync/gui/cloud_projects_dialog.py
@@ -51,6 +51,7 @@ from qgis.PyQt.QtWidgets import (
     QHBoxLayout,
     QHeaderView,
     QInputDialog,
+    QLabel,
     QMenu,
     QMessageBox,
     QPushButton,
@@ -775,11 +776,28 @@ class CloudProjectsDialog(QDialog, CloudProjectsDialogUi):
             reassuring_remark = self.tr(
                 "The project will be permanently deleted from QFieldCloud, your local copy will remain unaffected"
             )
-            return QInputDialog().getText(
-                self,
-                delete_msg,
-                f"<p><b>{are_you_sure}</b></p>{maybe_warning}<p>{confirm_with} <em>{expected_input}</em>. {reassuring_remark}.</p>",
+
+            input_dialog = QInputDialog()
+            input_dialog.setInputMode(QInputDialog.InputMode.TextInput)
+            input_dialog.setWindowTitle(delete_msg)
+            input_dialog.setMinimumWidth(350)
+            input_dialog.setLabelText(
+                f"<p><b>{are_you_sure}</b></p>{maybe_warning}<p>{confirm_with} <em>{expected_input}</em>.</p>{reassuring_remark}."
             )
+
+            label_widget = input_dialog.findChild(QLabel)
+            if label_widget:
+                label_widget.setTextInteractionFlags(
+                    Qt.TextInteractionFlag.TextSelectableByMouse
+                    | Qt.TextInteractionFlag.TextSelectableByKeyboard
+                )
+                label_widget.setWordWrap(True)
+
+            ok = input_dialog.exec()
+            response = input_dialog.textValue()
+            input_dialog.deleteLater()
+
+            return response, ok
 
         text, ok = ask()
 


### PR DESCRIPTION
Deleting cloud projects in QFieldSync is _painful_ when compared with deletion on app.qfield.cloud.

The main reason is that for long user/project names, the (good) requirement to confirm via project name becomes a real PITA especially when you have to delete multiple projects in a row.

On the web interface, users can copy/paste the name from the HTML confirmation dialog. Let's allow that in QFieldSync too. It'll still require users to provide a confirmation, but they'll be able to fasten the process via copy/paste.

The confirmation dialog was also insanely wide for long user/project names, this PR fixes that too.

Result:

<img width="435" height="291" alt="Screenshot From 2026-08-29 11-20-27" src="https://github.com/user-attachments/assets/4108464b-32b0-49cb-ba2e-8085cc781193" />
